### PR TITLE
Make lambda return types implicit

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -1653,7 +1653,7 @@ NEVER_INLINE EnumerateObjectData* ByteCodeInterpreter::executeEnumerateObject(Ex
     size_t ownKeyCount = 0;
     bool shouldSearchProto = false;
 
-    target.asObject()->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    target.asObject()->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data) {
         if (desc.isEnumerable()) {
             size_t* ownKeyCount = (size_t*)data;
             (*ownKeyCount)++;
@@ -1671,7 +1671,7 @@ NEVER_INLINE EnumerateObjectData* ByteCodeInterpreter::executeEnumerateObject(Ex
     target = target.asObject()->getPrototype(state);
     while (target.isObject()) {
         if (!shouldSearchProto) {
-            target.asObject()->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+            target.asObject()->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) {
                 if (desc.isEnumerable()) {
                     bool* shouldSearchProto = (bool*)data;
                     *shouldSearchProto = true;
@@ -1700,7 +1700,7 @@ NEVER_INLINE EnumerateObjectData* ByteCodeInterpreter::executeEnumerateObject(Ex
 
     if (shouldSearchProto) {
         while (target.isObject()) {
-            target.asObject()->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+            target.asObject()->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) {
                 EData* eData = (EData*)data;
                 if (desc.isEnumerable()) {
                     String* key = name.toPlainValue(state).toString(state);
@@ -1725,7 +1725,7 @@ NEVER_INLINE EnumerateObjectData* ByteCodeInterpreter::executeEnumerateObject(Ex
         size_t idx = 0;
         eData.idx = &idx;
         data->m_keys.resizeWithUninitializedValues(ownKeyCount);
-        target.asObject()->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+        target.asObject()->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) {
             if (desc.isEnumerable()) {
                 EData* eData = (EData*)data;
                 eData->data->m_keys[(*eData->idx)++] = name.toPlainValue(state);

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -89,7 +89,7 @@ Script::ScriptSandboxExecuteResult Script::sandboxExecute(ExecutionState& state)
     SandBox sb(state.context());
     ExecutionState stateForInit(state.context(), &state, nullptr);
 
-    auto sandBoxResult = sb.run([&]() -> Value {
+    auto sandBoxResult = sb.run([&]() {
         return execute(stateForInit, false, false, true);
     });
     result.result = sandBoxResult.result;

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -211,7 +211,7 @@ void ArrayObject::sort(ExecutionState& state, const std::function<bool(const Val
                 TightVector<Value, GCUtil::gc_malloc_ignore_off_page_allocator<Value>> tempSpace;
                 tempSpace.resizeWithUninitializedValues(orgLength);
 
-                mergeSort(tempBuffer, orgLength, tempSpace.data(), [&](const Value& a, const Value& b, bool* lessOrEqualp) -> bool {
+                mergeSort(tempBuffer, orgLength, tempSpace.data(), [&](const Value& a, const Value& b, bool* lessOrEqualp) {
                     *lessOrEqualp = comp(a, b);
                     return true;
                 });

--- a/src/runtime/GlobalObjectBuiltinArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinArray.cpp
@@ -347,7 +347,7 @@ static Value builtinArraySort(ExecutionState& state, Value thisValue, size_t arg
     }
     bool defaultSort = (argc == 0) || cmpfn.isUndefined();
 
-    thisObject->sort(state, [defaultSort, &cmpfn, &state](const Value& a, const Value& b) -> bool {
+    thisObject->sort(state, [defaultSort, &cmpfn, &state](const Value& a, const Value& b) {
         if (a.isEmpty() && b.isUndefined())
             return false;
         if (a.isUndefined() && b.isEmpty())
@@ -1558,8 +1558,8 @@ static Value builtinArrayIteratorNext(ExecutionState& state, Value thisValue, si
 
 void GlobalObject::installArray(ExecutionState& state)
 {
-    m_array = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Array, builtinArrayConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                     return new ArrayObject(state);
+    m_array = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Array, builtinArrayConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                     return (new ArrayObject(state))->asObject();
                                  }),
                                  FunctionObject::__ForBuiltin__);
     m_array->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinBoolean.cpp
+++ b/src/runtime/GlobalObjectBuiltinBoolean.cpp
@@ -61,8 +61,8 @@ static Value builtinBooleanToString(ExecutionState& state, Value thisValue, size
 void GlobalObject::installBoolean(ExecutionState& state)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
-    m_boolean = new FunctionObject(state, NativeFunctionInfo(strings->Boolean, builtinBooleanConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                       return new BooleanObject(state);
+    m_boolean = new FunctionObject(state, NativeFunctionInfo(strings->Boolean, builtinBooleanConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                       return (new BooleanObject(state))->asObject();
                                    }),
                                    FunctionObject::__ForBuiltin__);
     m_boolean->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinDataView.cpp
+++ b/src/runtime/GlobalObjectBuiltinDataView.cpp
@@ -152,7 +152,7 @@ static Value builtinDataViewByteOffsetGetter(ExecutionState& state, Value thisVa
 void GlobalObject::installDataView(ExecutionState& state)
 {
     m_dataView = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().DataView, builtinDataViewConstructor, 3, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                        return new DataViewObject(state);
+                                        return (new DataViewObject(state))->asObject();
                                     }),
                                     FunctionObject::__ForBuiltin__);
     m_dataView->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinDate.cpp
+++ b/src/runtime/GlobalObjectBuiltinDate.cpp
@@ -505,8 +505,8 @@ static Value builtinDateToPrimitive(ExecutionState& state, Value thisValue, size
 
 void GlobalObject::installDate(ExecutionState& state)
 {
-    m_date = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Date, builtinDateConstructor, 7, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                    return new DateObject(state);
+    m_date = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Date, builtinDateConstructor, 7, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                    return (new DateObject(state))->asObject();
                                 }),
                                 FunctionObject::__ForBuiltin__);
     m_date->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinError.cpp
+++ b/src/runtime/GlobalObjectBuiltinError.cpp
@@ -125,8 +125,8 @@ static Value builtinErrorToString(ExecutionState& state, Value thisValue, size_t
 
 void GlobalObject::installError(ExecutionState& state)
 {
-    m_error = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Error, builtinErrorConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                     return new ErrorObject(state, String::emptyString);
+    m_error = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Error, builtinErrorConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                     return (new ErrorObject(state, String::emptyString))->asObject();
                                  }),
                                  FunctionObject::__ForBuiltin__);
     m_error->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -243,10 +243,10 @@ void GlobalObject::installFunction(ExecutionState& state)
     m_functionPrototype->setPrototype(state, m_objectPrototype);
     m_functionPrototype->markThisObjectDontNeedStructureTransitionTable(state);
 
-    m_function = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Function, builtinFunctionConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
+    m_function = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Function, builtinFunctionConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
                                         // create dummy object.
                                         // this object is replaced in function ctor
-                                        return new FunctionObject(state, NativeFunctionInfo(AtomicString(), builtinFunctionConstructor, 0, nullptr, 0));
+                                        return (new FunctionObject(state, NativeFunctionInfo(AtomicString(), builtinFunctionConstructor, 0, nullptr, 0)))->asObject();
                                     }),
                                     FunctionObject::__ForBuiltin__);
     m_function->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinIntl.cpp
+++ b/src/runtime/GlobalObjectBuiltinIntl.cpp
@@ -422,7 +422,7 @@ static std::string canonicalLangTag(const std::vector<std::string>& parts)
     std::sort(
         extensions.begin(),
         extensions.end(),
-        [](const std::string& a, const std::string& b) -> bool {
+        [](const std::string& a, const std::string& b) {
             return a[0] < b[0];
         });
     size_t numExtenstions = extensions.size();
@@ -2552,7 +2552,7 @@ void GlobalObject::installIntl(ExecutionState& state)
     defineOwnProperty(state, ObjectPropertyName(strings->Intl),
                       ObjectPropertyDescriptor(m_intl, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
-    m_intlCollator = new FunctionObject(state, NativeFunctionInfo(strings->Collator, builtinIntlCollatorConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
+    m_intlCollator = new FunctionObject(state, NativeFunctionInfo(strings->Collator, builtinIntlCollatorConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
                                             return new Object(state);
                                         }),
                                         FunctionObject::__ForBuiltin__);
@@ -2567,7 +2567,7 @@ void GlobalObject::installIntl(ExecutionState& state)
     m_intlCollator->defineOwnProperty(state, state.context()->staticStrings().supportedLocalesOf,
                                       ObjectPropertyDescriptor(new FunctionObject(state, NativeFunctionInfo(strings->supportedLocalesOf, builtinIntlCollatorSupportedLocalesOf, 1, nullptr, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent | ObjectPropertyDescriptor::WritablePresent)));
 
-    m_intlDateTimeFormat = new FunctionObject(state, NativeFunctionInfo(strings->DateTimeFormat, builtinIntlDateTimeFormatConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
+    m_intlDateTimeFormat = new FunctionObject(state, NativeFunctionInfo(strings->DateTimeFormat, builtinIntlDateTimeFormatConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
                                                   return new Object(state);
                                               }),
                                               FunctionObject::__ForBuiltin__);
@@ -2582,7 +2582,7 @@ void GlobalObject::installIntl(ExecutionState& state)
     m_intlDateTimeFormat->defineOwnProperty(state, state.context()->staticStrings().supportedLocalesOf,
                                             ObjectPropertyDescriptor(new FunctionObject(state, NativeFunctionInfo(strings->supportedLocalesOf, builtinIntlDateTimeFormatSupportedLocalesOf, 1, nullptr, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent | ObjectPropertyDescriptor::WritablePresent)));
 
-    m_intlNumberFormat = new FunctionObject(state, NativeFunctionInfo(strings->NumberFormat, builtinIntlNumberFormatConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
+    m_intlNumberFormat = new FunctionObject(state, NativeFunctionInfo(strings->NumberFormat, builtinIntlNumberFormatConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
                                                 return new Object(state);
                                             }),
                                             FunctionObject::__ForBuiltin__);

--- a/src/runtime/GlobalObjectBuiltinJSON.cpp
+++ b/src/runtime/GlobalObjectBuiltinJSON.cpp
@@ -216,7 +216,7 @@ static Value builtinJSONParse(ExecutionState& state, Value thisValue, size_t arg
             Object* root = new Object(state);
             root->defineOwnProperty(state, ObjectPropertyName(state, String::emptyString), ObjectPropertyDescriptor(unfiltered, ObjectPropertyDescriptor::AllPresent));
             std::function<Value(Value, const ObjectPropertyName&)> Walk;
-            Walk = [&](Value holder, const ObjectPropertyName& name) -> Value {
+            Walk = [&](Value holder, const ObjectPropertyName& name) {
                 Value val = holder.asPointerValue()->asObject()->get(state, name).value(state, holder);
                 if (val.isObject()) {
                     if (val.asObject()->isArrayObject()) {
@@ -248,7 +248,7 @@ static Value builtinJSONParse(ExecutionState& state, Value thisValue, size_t arg
                     } else {
                         Object* object = val.asObject();
                         std::vector<ObjectPropertyName, GCUtil::gc_malloc_ignore_off_page_allocator<ObjectPropertyName>> keys;
-                        object->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+                        object->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) {
                             if (desc.isEnumerable()) {
                                 std::vector<ObjectPropertyName, GCUtil::gc_malloc_ignore_off_page_allocator<ObjectPropertyName>>* keys = (std::vector<ObjectPropertyName, GCUtil::gc_malloc_ignore_off_page_allocator<ObjectPropertyName>>*)data;
                                 keys->push_back(P);
@@ -302,7 +302,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
             ArrayObject* arrObject = replacer.asObject()->asArrayObject();
 
             std::vector<Value::ValueIndex> indexes;
-            arrObject->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool { //Value key, HiddenClassPropertyInfo* propertyInfo) {
+            arrObject->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) { //Value key, HiddenClassPropertyInfo* propertyInfo) {
                 Value::ValueIndex idx = P.toPlainValue(state).toIndex(state);
                 if (idx != Value::InvalidIndexValue) {
                     std::vector<Value::ValueIndex>* indexes = (std::vector<Value::ValueIndex>*)data;
@@ -429,7 +429,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
         return Value();
     };
 
-    Quote = [&](ObjectPropertyName value) -> String* {
+    Quote = [&](ObjectPropertyName value) {
         String* str = value.toPropertyName(state).plainString();
 
         StringBuilder product;
@@ -467,7 +467,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
         return product.finalize(&state);
     };
 
-    JA = [&](ArrayObject* arrayObj) -> String* {
+    JA = [&](ArrayObject* arrayObj) {
         // 1
         for (size_t i = 0; i < stack.size(); i++) {
             Value& v = stack[i];
@@ -538,7 +538,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
         return final.finalize(&state);
     };
 
-    JO = [&](Object* value) -> String* {
+    JO = [&](Object* value) {
         // 1
         for (size_t i = 0; i < stack.size(); i++) {
             if (stack[i] == value) {
@@ -559,7 +559,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
         if (propertyListTouched) {
             k = propertyList;
         } else {
-            value->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+            value->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) {
                 std::vector<ObjectPropertyName, GCUtil::gc_malloc_ignore_off_page_allocator<ObjectPropertyName>>* k = (std::vector<ObjectPropertyName, GCUtil::gc_malloc_ignore_off_page_allocator<ObjectPropertyName>>*)data;
                 if (desc.isEnumerable()) {
                     k->push_back(P);

--- a/src/runtime/GlobalObjectBuiltinMap.cpp
+++ b/src/runtime/GlobalObjectBuiltinMap.cpp
@@ -203,8 +203,8 @@ static Value builtinMapIteratorNext(ExecutionState& state, Value thisValue, size
 
 void GlobalObject::installMap(ExecutionState& state)
 {
-    m_map = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Map, builtinMapConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                   return new MapObject(state);
+    m_map = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Map, builtinMapConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                   return (new MapObject(state))->asObject();
                                }),
                                FunctionObject::__ForBuiltin__);
     m_map->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinNumber.cpp
+++ b/src/runtime/GlobalObjectBuiltinNumber.cpp
@@ -362,8 +362,8 @@ static Value builtinNumberIsSafeInteger(ExecutionState& state, Value thisValue, 
 void GlobalObject::installNumber(ExecutionState& state)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
-    m_number = new FunctionObject(state, NativeFunctionInfo(strings->Number, builtinNumberConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                      return new NumberObject(state);
+    m_number = new FunctionObject(state, NativeFunctionInfo(strings->Number, builtinNumberConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                      return (new NumberObject(state))->asObject();
                                   }),
                                   FunctionObject::__ForBuiltin__);
     m_number->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -104,7 +104,7 @@ static Value objectDefineProperties(ExecutionState& state, Value object, Value p
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, strings->Object.string(), false, strings->defineProperty.string(), errorMessage_GlobalObject_FirstArgumentNotObject);
     Object* props = properties.toObject(state);
     std::vector<std::pair<ObjectPropertyName, ObjectPropertyDescriptor>, gc_allocator_ignore_off_page<std::pair<ObjectPropertyName, ObjectPropertyDescriptor>>> descriptors;
-    props->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    props->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) {
         auto propDesc = self->getOwnProperty(state, name);
         std::vector<std::pair<ObjectPropertyName, ObjectPropertyDescriptor>, gc_allocator_ignore_off_page<std::pair<ObjectPropertyName, ObjectPropertyDescriptor>>>* descriptors = (std::vector<std::pair<ObjectPropertyName, ObjectPropertyDescriptor>, gc_allocator_ignore_off_page<std::pair<ObjectPropertyName, ObjectPropertyDescriptor>>>*)data;
         if (propDesc.hasValue() && desc.isEnumerable()) {
@@ -278,7 +278,7 @@ static Value builtinObjectFreeze(ExecutionState& state, Value thisValue, size_t 
 
     // For each named own property name P of O,
     std::vector<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>> descriptors;
-    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) {
         std::vector<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>>* descriptors = (std::vector<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>>*)data;
         descriptors->push_back(std::make_pair(P, desc));
         return true;
@@ -357,7 +357,7 @@ static Value builtinObjectGetOwnPropertyNames(ExecutionState& state, Value thisV
     data.array = array;
     data.n = &n;
     // For each named own property P of O
-    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) {
         Data* a = (Data*)data;
         // Let name be the String value that is the name of P.
         Value name = P.toPlainValue(state).toString(state);
@@ -389,7 +389,7 @@ static Value builtinObjectGetOwnPropertySymbols(ExecutionState& state, Value thi
     data.array = array;
     data.n = &n;
     // For each named own property P of O
-    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) {
         Data* a = (Data*)data;
         // Let name be the String value that is the name of P.
         Value name = P.toPlainValue(state);
@@ -427,7 +427,7 @@ static Value builtinObjectIsFrozen(ExecutionState& state, Value thisValue, size_
 
     bool hasNonFrozenProperty = false;
     // For each named own property name P of O,
-    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) {
         if ((desc.isDataProperty() && desc.isWritable()) || desc.isConfigurable()) {
             bool* hasNonFrozenProperty = (bool*)data;
             *hasNonFrozenProperty = true;
@@ -457,7 +457,7 @@ static Value builtinObjectIsSealed(ExecutionState& state, Value thisValue, size_
 
     bool hasNonSealedProperty = false;
     // For each named own property name P of O,
-    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) {
         // Let desc be the result of calling the [[GetOwnProperty]] internal method of O with P.
         // If desc.[[Configurable]] is true, then return false.
         if (desc.isConfigurable()) {
@@ -501,7 +501,7 @@ static Value builtinObjectKeys(ExecutionState& state, Value thisValue, size_t ar
     data.index = &index;
 
     // For each own enumerable property of O whose name String is P
-    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) {
         if (desc.isEnumerable()) {
             Data* aData = (Data*)data;
             // Call the [[DefineOwnProperty]] internal method of array with arguments ToString(index), the PropertyDescriptor {[[Value]]: P, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true}, and false.
@@ -527,7 +527,7 @@ static Value builtinObjectSeal(ExecutionState& state, Value thisValue, size_t ar
 
     // For each named own property name P of O,
     std::vector<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>, GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>>> descriptors;
-    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) {
         std::vector<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>, GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>>>* descriptors = (std::vector<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>, GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>>>*)data;
         descriptors->push_back(std::make_pair(P, desc));
         return true;
@@ -672,7 +672,7 @@ static ValueVector enumerableOwnProperties(ExecutionState& state, Object* O, Enu
         }
     }
 
-    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& keyName, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    O->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& keyName, const ObjectStructurePropertyDescriptor& desc, void* data) {
         Data* d = (Data*)data;
         Value vv = keyName.toPlainValue(state);
         if (vv.toArrayIndex(state) != Value::InvalidArrayIndexValue) {
@@ -737,7 +737,7 @@ void GlobalObject::installObject(ExecutionState& state)
     const StaticStrings& strings = state.context()->staticStrings();
 
     FunctionObject* emptyFunction = m_functionPrototype;
-    m_object = new FunctionObject(state, NativeFunctionInfo(strings.Object, builtinObjectConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
+    m_object = new FunctionObject(state, NativeFunctionInfo(strings.Object, builtinObjectConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
                                       return new Object(state);
                                   }),
                                   FunctionObject::__ForBuiltin__);

--- a/src/runtime/GlobalObjectBuiltinPromise.cpp
+++ b/src/runtime/GlobalObjectBuiltinPromise.cpp
@@ -33,7 +33,7 @@ namespace Escargot {
 static SandBox::SandBoxResult tryCallMethodAndCatchError(ExecutionState& state, ObjectPropertyName name, Value receiver, Value arguments[], const size_t& argumentCount, bool isNewExpression)
 {
     SandBox sb(state.context());
-    return sb.run([&]() -> Value {
+    return sb.run([&]() {
         Value callee = receiver.toObject(state)->get(state, name).value(state, receiver);
         return FunctionObject::call(state, callee, receiver, argumentCount, arguments);
     });
@@ -58,7 +58,7 @@ static Value builtinPromiseConstructor(ExecutionState& state, Value thisValue, s
     PromiseReaction::Capability capability = promise->createResolvingFunctions(state);
 
     SandBox sb(state.context());
-    auto res = sb.run([&]() -> Value {
+    auto res = sb.run([&]() {
         Value arguments[] = { capability.m_resolveFunction, capability.m_rejectFunction };
         FunctionObject::call(state, executor, Value(), 2, arguments);
         return Value();
@@ -170,7 +170,7 @@ static Value builtinPromiseAll(ExecutionState& state, Value thisValue, size_t ar
             remainingElementsCount->setThrowsException(state, strings->value, Value(remainingElements - 1), remainingElementsCount);
             if (remainingElements == 1) {
                 SandBox sb(state.context());
-                auto res = sb.run([&]() -> Value {
+                auto res = sb.run([&]() {
                     Value arguments[] = { values };
                     FunctionObject::call(state, capability.m_resolveFunction, Value(), 1, arguments);
                     return Value();
@@ -383,7 +383,7 @@ Value promiseResolveFunction(ExecutionState& state, Value thisValue, size_t argc
     Object* resolution = resolutionValue.asObject();
 
     SandBox sb(state.context());
-    auto res = sb.run([&]() -> Value {
+    auto res = sb.run([&]() {
         return resolution->get(state, strings->then).value(state, resolution);
     });
     if (!res.error.isEmpty()) {
@@ -454,8 +454,8 @@ static Value builtinPromiseToString(ExecutionState& state, Value thisValue, size
 void GlobalObject::installPromise(ExecutionState& state)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
-    m_promise = new FunctionObject(state, NativeFunctionInfo(strings->Promise, builtinPromiseConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                       return new PromiseObject(state);
+    m_promise = new FunctionObject(state, NativeFunctionInfo(strings->Promise, builtinPromiseConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                       return (new PromiseObject(state))->asObject();
                                    }),
                                    FunctionObject::__ForBuiltin__);
     m_promise->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinRegExp.cpp
+++ b/src/runtime/GlobalObjectBuiltinRegExp.cpp
@@ -141,8 +141,8 @@ static Value builtinRegExpCompile(ExecutionState& state, Value thisValue, size_t
 }
 
 GlobalRegExpFunctionObject::GlobalRegExpFunctionObject(ExecutionState& state)
-    : FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().RegExp, builtinRegExpConstructor, 2, [](ExecutionState& state, CodeBlock * codeBlock, size_t argc, Value * argv) -> Object* {
-                         return new RegExpObject(state, String::emptyString, String::emptyString);
+    : FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().RegExp, builtinRegExpConstructor, 2, [](ExecutionState& state, CodeBlock * codeBlock, size_t argc, Value * argv) {
+                         return (new RegExpObject(state, String::emptyString, String::emptyString))->asObject();
                      }),
                      FunctionObject::__ForBuiltin__)
 {

--- a/src/runtime/GlobalObjectBuiltinSet.cpp
+++ b/src/runtime/GlobalObjectBuiltinSet.cpp
@@ -181,8 +181,8 @@ static Value builtinSetIteratorNext(ExecutionState& state, Value thisValue, size
 
 void GlobalObject::installSet(ExecutionState& state)
 {
-    m_set = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Set, builtinSetConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                   return new SetObject(state);
+    m_set = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Set, builtinSetConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                   return (new SetObject(state))->asObject();
                                }),
                                FunctionObject::__ForBuiltin__);
     m_set->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinString.cpp
+++ b/src/runtime/GlobalObjectBuiltinString.cpp
@@ -536,7 +536,7 @@ static Value builtinStringSplit(ExecutionState& state, Value thisValue, size_t a
     }
 
     std::function<Value(String*, int, String*)> splitMatchUsingStr;
-    splitMatchUsingStr = [](String* S, int q, String* R) -> Value {
+    splitMatchUsingStr = [](String* S, int q, String* R) {
         int s = S->length();
         int r = R->length();
         if (q + r > s)
@@ -1054,8 +1054,8 @@ static Value builtinStringIterator(ExecutionState& state, Value thisValue, size_
 void GlobalObject::installString(ExecutionState& state)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
-    m_string = new FunctionObject(state, NativeFunctionInfo(strings->String, builtinStringConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                      return new StringObject(state);
+    m_string = new FunctionObject(state, NativeFunctionInfo(strings->String, builtinStringConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                      return (new StringObject(state))->asObject();
                                   }),
                                   FunctionObject::__ForBuiltin__);
     m_string->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinSymbol.cpp
+++ b/src/runtime/GlobalObjectBuiltinSymbol.cpp
@@ -120,7 +120,7 @@ Value builtinSymbolKeyFor(ExecutionState& state, Value thisValue, size_t argc, V
 
 void GlobalObject::installSymbol(ExecutionState& state)
 {
-    m_symbol = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Symbol, builtinSymbolConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
+    m_symbol = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Symbol, builtinSymbolConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
                                       return new Object(state);
                                   }),
                                   FunctionObject::__ForBuiltin__);

--- a/src/runtime/GlobalObjectBuiltinTypedArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinTypedArray.cpp
@@ -631,8 +631,8 @@ template <typename TA, int elementSize>
 FunctionObject* GlobalObject::installTypedArray(ExecutionState& state, AtomicString taName, Object** proto, FunctionObject* typedArrayFunction)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
-    FunctionObject* taConstructor = new FunctionObject(state, NativeFunctionInfo(taName, builtinTypedArrayConstructor<TA, elementSize>, 3, [](ExecutionState& state, CodeBlock* cb, size_t argc, Value* argv) -> Object* {
-                                                           return new TA(state);
+    FunctionObject* taConstructor = new FunctionObject(state, NativeFunctionInfo(taName, builtinTypedArrayConstructor<TA, elementSize>, 3, [](ExecutionState& state, CodeBlock* cb, size_t argc, Value* argv) {
+                                                           return (new TA(state))->asObject();
                                                        }),
                                                        FunctionObject::__ForBuiltin__);
     taConstructor->markThisObjectDontNeedStructureTransitionTable(state);
@@ -692,8 +692,8 @@ static Value builtinTypedArrayGetToStringTag(ExecutionState& state, Value thisVa
 
 void GlobalObject::installTypedArray(ExecutionState& state)
 {
-    m_arrayBuffer = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().ArrayBuffer, builtinArrayBufferConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                           return new ArrayBufferObject(state);
+    m_arrayBuffer = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().ArrayBuffer, builtinArrayBufferConstructor, 1, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                           return (new ArrayBufferObject(state))->asObject();
                                        }),
                                        FunctionObject::__ForBuiltin__);
     m_arrayBuffer->markThisObjectDontNeedStructureTransitionTable(state);
@@ -726,7 +726,7 @@ void GlobalObject::installTypedArray(ExecutionState& state)
                       ObjectPropertyDescriptor(m_arrayBuffer, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     // %TypedArray%
-    FunctionObject* typedArrayFunction = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().TypedArray, builtinTypedArrayConstructor, 0, [](ExecutionState& state, CodeBlock* cb, size_t argc, Value* argv) -> Object* {
+    FunctionObject* typedArrayFunction = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().TypedArray, builtinTypedArrayConstructor, 0, [](ExecutionState& state, CodeBlock* cb, size_t argc, Value* argv) {
                                                                 return new Object(state);
                                                             },
                                                                                       (NativeFunctionInfo::Flags)(NativeFunctionInfo::Strict | NativeFunctionInfo::Constructor)),

--- a/src/runtime/GlobalObjectBuiltinWeakMap.cpp
+++ b/src/runtime/GlobalObjectBuiltinWeakMap.cpp
@@ -148,8 +148,8 @@ static Value builtinWeakMapSet(ExecutionState& state, Value thisValue, size_t ar
 
 void GlobalObject::installWeakMap(ExecutionState& state)
 {
-    m_weakMap = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().WeakMap, builtinWeakMapConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                       return new WeakMapObject(state);
+    m_weakMap = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().WeakMap, builtinWeakMapConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                       return (new WeakMapObject(state))->asObject();
                                    }),
                                    FunctionObject::__ForBuiltin__);
     m_weakMap->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/GlobalObjectBuiltinWeakSet.cpp
+++ b/src/runtime/GlobalObjectBuiltinWeakSet.cpp
@@ -126,8 +126,8 @@ static Value builtinWeakSetHas(ExecutionState& state, Value thisValue, size_t ar
 
 void GlobalObject::installWeakSet(ExecutionState& state)
 {
-    m_weakSet = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().WeakSet, builtinWeakSetConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
-                                       return new WeakSetObject(state);
+    m_weakSet = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().WeakSet, builtinWeakSetConstructor, 0, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) {
+                                       return (new WeakSetObject(state))->asObject();
                                    }),
                                    FunctionObject::__ForBuiltin__);
     m_weakSet->markThisObjectDontNeedStructureTransitionTable(state);

--- a/src/runtime/Job.cpp
+++ b/src/runtime/Job.cpp
@@ -31,7 +31,7 @@ SandBox::SandBoxResult PromiseReactionJob::run()
 {
     SandBox sandbox(relatedContext());
     ExecutionState state(relatedContext());
-    return sandbox.run([&]() -> Value {
+    return sandbox.run([&]() {
         /* 25.4.2.1.4 Handler is "Identity" case */
         if (m_reaction.m_handler == (FunctionObject*)1) {
             Value value[] = { m_argument };
@@ -45,7 +45,7 @@ SandBox::SandBoxResult PromiseReactionJob::run()
         }
 
         SandBox sb(state.context());
-        auto res = sb.run([&]() -> Value {
+        auto res = sb.run([&]() {
             Value arguments[] = { m_argument };
             Value res = FunctionObject::call(state, m_reaction.m_handler, Value(), 1, arguments);
             Value value[] = { res };
@@ -63,12 +63,12 @@ SandBox::SandBoxResult PromiseResolveThenableJob::run()
 {
     SandBox sandbox(relatedContext());
     ExecutionState state(relatedContext());
-    return sandbox.run([&]() -> Value {
+    return sandbox.run([&]() {
         auto strings = &state.context()->staticStrings();
         PromiseReaction::Capability capability = m_promise->createResolvingFunctions(state);
 
         SandBox sb(state.context());
-        auto res = sb.run([&]() -> Value {
+        auto res = sb.run([&]() {
             Value arguments[] = { capability.m_resolveFunction, capability.m_rejectFunction };
             Value thenCallResult = FunctionObject::call(state, m_then, m_thenable, 2, arguments);
             Value value[] = { thenCallResult };

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -717,7 +717,7 @@ void Object::enumeration(ExecutionState& state, bool (*callback)(ExecutionState&
 ValueVector Object::getOwnPropertyKeys(ExecutionState& state)
 {
     ValueVector result;
-    enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
+    enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) {
         ValueVector* result = (ValueVector*)data;
         result->pushBack(name.toPlainValue(state));
         return true;
@@ -987,7 +987,7 @@ void Object::sort(ExecutionState& state, const std::function<bool(const Value& a
         TightVector<Value, GCUtil::gc_malloc_ignore_off_page_allocator<Value>> tempSpace;
         tempSpace.resizeWithUninitializedValues(selected.size());
 
-        mergeSort(selected.data(), selected.size(), tempSpace.data(), [&](const Value& a, const Value& b, bool* lessOrEqualp) -> bool {
+        mergeSort(selected.data(), selected.size(), tempSpace.data(), [&](const Value& a, const Value& b, bool* lessOrEqualp) {
             *lessOrEqualp = comp(a, b);
             return true;
         });

--- a/src/runtime/SandBox.cpp
+++ b/src/runtime/SandBox.cpp
@@ -113,7 +113,7 @@ void ErrorObject::StackTraceData::buildStackTrace(Context* context, StringBuilde
     if (exception.isObject()) {
         ExecutionState state(context);
         SandBox sb(context);
-        sb.run([&]() -> Value {
+        sb.run([&]() {
             auto getResult = exception.asObject()->get(state, state.context()->staticStrings().name);
             if (getResult.hasValue()) {
                 builder.appendString(getResult.value(state, exception.asObject()).toString(state));

--- a/src/runtime/Value.cpp
+++ b/src/runtime/Value.cpp
@@ -464,7 +464,7 @@ double Value::toNumberSlowCase(ExecutionState& state) const // $7.1.3 ToNumber
                                                              "Infinity", "NaN");
         val = converter.StringToDouble(buf, len, &end);
         if (static_cast<size_t>(end) != len) {
-            auto isSpace = [](char16_t c) -> bool {
+            auto isSpace = [](char16_t c) {
                 switch (c) {
                 case 0x0009:
                 case 0x000A:


### PR DESCRIPTION
It is a best practice to make lambda return types implicit. First and foremost, doing so avoids implicit conversions which could result in data or precision loss. Second, omitting the return type helps future-proof the code. The issue was found by SonarCloud.