### PR TITLE
Update LexicalEnvironment instead of creating new ExecutionState objects

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -86,7 +86,7 @@ public:
     static void evalOperation(ExecutionState& state, CallEvalFunction* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void classOperation(ExecutionState& state, CreateClass* code, Value* registerFile);
     static void superOperation(ExecutionState& state, SuperReference* code, Value* registerFile);
-    static Value withOperation(ExecutionState& state, WithOperation* code, Object* obj, LexicalEnvironment* env, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile, Value* stackStorage);
+    static Value withOperation(ExecutionState& state, WithOperation* code, Object* obj, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
     static Value blockOperation(ExecutionState& state, BlockOperation* code, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile, Value* stackStorage);
     static bool binaryInOperation(ExecutionState& state, const Value& left, const Value& right);
     static Value callFunctionInWithScope(ExecutionState& state, CallFunctionInWithScope* code, LexicalEnvironment* env, Value* argv);

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -45,9 +45,9 @@ Value Script::execute(ExecutionState& state, bool isEvalMode, bool needNewEnv)
         newState.setParent(new ExecutionState(&state, globalEnvironment, m_topCodeBlock->isStrict()));
 
         EnvironmentRecord* record = new DeclarativeEnvironmentRecordNotIndexed(state, m_topCodeBlock->identifierInfos());
-        newState.setLexicalEnvironment(new LexicalEnvironment(record, globalEnvironment), m_topCodeBlock->isStrict());
+        newState.initLexicalEnvironment(new LexicalEnvironment(record, globalEnvironment), m_topCodeBlock->isStrict());
     } else {
-        newState.setLexicalEnvironment(globalEnvironment, m_topCodeBlock->isStrict());
+        newState.initLexicalEnvironment(globalEnvironment, m_topCodeBlock->isStrict());
     }
 
     Value thisValue(state.context()->globalObject());

--- a/src/runtime/ExecutionState.h
+++ b/src/runtime/ExecutionState.h
@@ -97,13 +97,18 @@ public:
         return m_lexicalEnvironment;
     }
 
-    void setLexicalEnvironment(LexicalEnvironment* lexicalEnvironment, bool inStrictMode)
+    void initLexicalEnvironment(LexicalEnvironment* lexicalEnvironment, bool inStrictMode)
     {
         ASSERT(m_lexicalEnvironment == nullptr && !m_inStrictMode);
         ASSERT(lexicalEnvironment != nullptr);
 
         m_lexicalEnvironment = lexicalEnvironment;
         m_inStrictMode = inStrictMode;
+    }
+
+    void setLexicalEnvironment(LexicalEnvironment* lexicalEnvironment)
+    {
+        m_lexicalEnvironment = lexicalEnvironment;
     }
 
     size_t stackBase()


### PR DESCRIPTION
The motivation of this patch is that the state is a c++ reference, and cannot be reassigned in the interpreter. However, recursively calling interpret for each let/const block would cost too much. This patch is the first path of reworking with statements to work without recursive calls. The same technique could be used by let/const blocks later.
