### PR TITLE
Create a structure for the block scope information.

### DIFF
--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -72,35 +72,37 @@ void* InterpretedCodeBlock::operator new(size_t size)
 
 CodeBlock::CodeBlock(Context* ctx, const NativeFunctionInfo& info)
     : m_context(ctx)
-    , m_isConstructor(info.m_isConstructor)
-    , m_isStrict(info.m_isStrict)
-    , m_hasCallNativeFunctionCode(true)
-    , m_isFunctionNameSaveOnHeap(false)
-    , m_isFunctionNameExplicitlyDeclared(false)
-    , m_canUseIndexedVariableStorage(true)
-    , m_canAllocateEnvironmentOnStack(true)
-    , m_needsComplexParameterCopy(false)
-    , m_hasEval(false)
-    , m_hasWith(false)
-    , m_hasCatch(false)
-    , m_hasYield(false)
-    , m_inCatch(false)
-    , m_inWith(false)
-    , m_usesArgumentsObject(false)
-    , m_isFunctionExpression(false)
-    , m_isFunctionDeclaration(false)
-    , m_isFunctionDeclarationWithSpecialBinding(false)
-    , m_isArrowFunctionExpression(false)
-    , m_isClassConstructor(false)
-    , m_isGenerator(false)
-    , m_isInWithScope(false)
-    , m_isEvalCodeInFunction(false)
-    , m_needsVirtualIDOperation(false)
-    , m_needToLoadThisValue(false)
-    , m_hasRestElement(false)
     , m_parameterCount(info.m_argumentCount)
     , m_functionName(info.m_name)
 {
+    m_scopeInfo.isConstructor = info.m_isConstructor;
+    m_scopeInfo.isStrict = info.m_isStrict;
+    m_scopeInfo.hasCallNativeFunctionCode = true;
+    m_scopeInfo.isFunctionNameSaveOnHeap = false;
+    m_scopeInfo.isFunctionNameExplicitlyDeclared = false;
+    m_scopeInfo.canUseIndexedVariableStorage = true;
+    m_scopeInfo.canAllocateEnvironmentOnStack = true;
+    m_scopeInfo.needsComplexParameterCopy = false;
+    m_scopeInfo.hasEval = false;
+    m_scopeInfo.hasWith = false;
+    m_scopeInfo.hasSuper = false;
+    m_scopeInfo.hasCatch = false;
+    m_scopeInfo.hasYield = false;
+    m_scopeInfo.inCatch = false;
+    m_scopeInfo.inWith = false;
+    m_scopeInfo.usesArgumentsObject = false;
+    m_scopeInfo.isFunctionExpression = false;
+    m_scopeInfo.isFunctionDeclaration = false;
+    m_scopeInfo.isFunctionDeclarationWithSpecialBinding = false;
+    m_scopeInfo.isArrowFunctionExpression = false;
+    m_scopeInfo.isClassConstructor = false;
+    m_scopeInfo.isGenerator = false;
+    m_scopeInfo.isInWithScope = false;
+    m_scopeInfo.isEvalCodeInFunction = false;
+    m_scopeInfo.needsVirtualIDOperation = false;
+    m_scopeInfo.needToLoadThisValue = false;
+    m_scopeInfo.hasRestElement = false;
+
     auto data = new (PointerFreeGC) CallNativeFunctionData();
     m_nativeFunctionData = (CallNativeFunctionData*)data;
 
@@ -110,36 +112,37 @@ CodeBlock::CodeBlock(Context* ctx, const NativeFunctionInfo& info)
 
 CodeBlock::CodeBlock(Context* ctx, AtomicString name, size_t argc, bool isStrict, bool isCtor, CallNativeFunctionData* info)
     : m_context(ctx)
-    , m_isConstructor(isCtor)
-    , m_isStrict(isStrict)
-    , m_hasCallNativeFunctionCode(true)
-    , m_isFunctionNameSaveOnHeap(false)
-    , m_isFunctionNameExplicitlyDeclared(false)
-    , m_canUseIndexedVariableStorage(true)
-    , m_canAllocateEnvironmentOnStack(true)
-    , m_needsComplexParameterCopy(false)
-    , m_hasEval(false)
-    , m_hasWith(false)
-    , m_hasCatch(false)
-    , m_hasYield(false)
-    , m_inCatch(false)
-    , m_inWith(false)
-    , m_usesArgumentsObject(false)
-    , m_isFunctionExpression(false)
-    , m_isFunctionDeclaration(false)
-    , m_isFunctionDeclarationWithSpecialBinding(false)
-    , m_isArrowFunctionExpression(false)
-    , m_isClassConstructor(false)
-    , m_isGenerator(false)
-    , m_isInWithScope(false)
-    , m_isEvalCodeInFunction(false)
-    , m_needsVirtualIDOperation(false)
-    , m_needToLoadThisValue(false)
-    , m_hasRestElement(false)
     , m_parameterCount(argc)
     , m_functionName(name)
     , m_nativeFunctionData(info)
 {
+    m_scopeInfo.isConstructor = isCtor;
+    m_scopeInfo.isStrict = isStrict;
+    m_scopeInfo.hasCallNativeFunctionCode = true;
+    m_scopeInfo.isFunctionNameSaveOnHeap = false;
+    m_scopeInfo.isFunctionNameExplicitlyDeclared = false;
+    m_scopeInfo.canUseIndexedVariableStorage = true;
+    m_scopeInfo.canAllocateEnvironmentOnStack = true;
+    m_scopeInfo.needsComplexParameterCopy = false;
+    m_scopeInfo.hasEval = false;
+    m_scopeInfo.hasWith = false;
+    m_scopeInfo.hasSuper = false;
+    m_scopeInfo.hasCatch = false;
+    m_scopeInfo.hasYield = false;
+    m_scopeInfo.inCatch = false;
+    m_scopeInfo.inWith = false;
+    m_scopeInfo.usesArgumentsObject = false;
+    m_scopeInfo.isFunctionExpression = false;
+    m_scopeInfo.isFunctionDeclaration = false;
+    m_scopeInfo.isFunctionDeclarationWithSpecialBinding = false;
+    m_scopeInfo.isArrowFunctionExpression = false;
+    m_scopeInfo.isClassConstructor = false;
+    m_scopeInfo.isGenerator = false;
+    m_scopeInfo.isInWithScope = false;
+    m_scopeInfo.isEvalCodeInFunction = false;
+    m_scopeInfo.needsVirtualIDOperation = false;
+    m_scopeInfo.needToLoadThisValue = false;
+    m_scopeInfo.hasRestElement = false;
 }
 
 InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTScopeContext* scopeCtx, ExtendedNodeLOC sourceElementStart)
@@ -158,36 +161,35 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
 {
     m_context = ctx;
     m_byteCodeBlock = nullptr;
-
     m_parameterCount = 0;
-    m_isConstructor = false;
-    m_hasCallNativeFunctionCode = false;
-    m_isFunctionDeclaration = false;
-    m_isFunctionDeclarationWithSpecialBinding = false;
-    m_isFunctionExpression = false;
-    m_isArrowFunctionExpression = false;
-    m_isStrict = scopeCtx->m_isStrict;
-    m_isClassConstructor = scopeCtx->m_isClassConstructor;
-    m_isGenerator = scopeCtx->m_isGenerator;
 
-    m_hasEval = scopeCtx->m_hasEval;
-    m_hasWith = scopeCtx->m_hasWith;
-    m_hasCatch = scopeCtx->m_hasCatch;
-    m_hasYield = scopeCtx->m_hasYield;
-    m_inCatch = false;
-    m_inWith = false;
-
-    m_usesArgumentsObject = false;
-    m_canUseIndexedVariableStorage = false;
-    m_canAllocateEnvironmentOnStack = false;
-    m_needsComplexParameterCopy = false;
-    m_isInWithScope = false;
-    m_isEvalCodeInFunction = false;
-    m_needsVirtualIDOperation = false;
-    m_needToLoadThisValue = false;
-    m_hasRestElement = scopeCtx->m_hasRestElement;
-    m_isFunctionNameExplicitlyDeclared = false;
-    m_isFunctionNameSaveOnHeap = false;
+    m_scopeInfo.isConstructor = false;
+    m_scopeInfo.isStrict = scopeCtx->m_isStrict;
+    m_scopeInfo.hasCallNativeFunctionCode = false;
+    m_scopeInfo.isFunctionNameSaveOnHeap = false;
+    m_scopeInfo.isFunctionNameExplicitlyDeclared = false;
+    m_scopeInfo.canUseIndexedVariableStorage = false;
+    m_scopeInfo.canAllocateEnvironmentOnStack = false;
+    m_scopeInfo.needsComplexParameterCopy = false;
+    m_scopeInfo.hasEval = scopeCtx->m_hasEval;
+    m_scopeInfo.hasWith = scopeCtx->m_hasWith;
+    m_scopeInfo.hasSuper = false;
+    m_scopeInfo.hasCatch = scopeCtx->m_hasCatch;
+    m_scopeInfo.hasYield = scopeCtx->m_hasYield;
+    m_scopeInfo.inCatch = false;
+    m_scopeInfo.inWith = false;
+    m_scopeInfo.usesArgumentsObject = false;
+    m_scopeInfo.isFunctionExpression = false;
+    m_scopeInfo.isFunctionDeclaration = false;
+    m_scopeInfo.isFunctionDeclarationWithSpecialBinding = false;
+    m_scopeInfo.isArrowFunctionExpression = false;
+    m_scopeInfo.isClassConstructor = scopeCtx->m_isClassConstructor;
+    m_scopeInfo.isGenerator = scopeCtx->m_isGenerator;
+    m_scopeInfo.isInWithScope = false;
+    m_scopeInfo.isEvalCodeInFunction = false;
+    m_scopeInfo.needsVirtualIDOperation = false;
+    m_scopeInfo.needToLoadThisValue = false;
+    m_scopeInfo.hasRestElement = scopeCtx->m_hasRestElement;
 
     const ASTScopeContextNameInfoVector& innerIdentifiers = scopeCtx->m_names;
 
@@ -228,32 +230,35 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     m_byteCodeBlock = nullptr;
     m_functionName = scopeCtx->m_functionName;
     m_parameterCount = scopeCtx->m_hasRestElement ? parameterNames.size() - 1 : parameterNames.size();
-    m_isConstructor = true;
-    m_hasCallNativeFunctionCode = false;
-    m_isStrict = scopeCtx->m_isStrict;
-    m_hasEval = scopeCtx->m_hasEval;
-    m_hasWith = scopeCtx->m_hasWith;
-    m_hasCatch = scopeCtx->m_hasCatch;
-    m_hasYield = scopeCtx->m_hasYield;
-    m_inCatch = scopeCtx->m_inCatch;
-    m_inWith = scopeCtx->m_inWith;
-    m_usesArgumentsObject = false;
-    m_isFunctionDeclaration = isFD;
-    m_isFunctionDeclarationWithSpecialBinding = scopeCtx->m_needsSpecialInitialize;
-    m_isFunctionExpression = isFE;
-    m_isArrowFunctionExpression = scopeCtx->m_isArrowFunctionExpression;
-    m_isConstructor = !scopeCtx->m_isArrowFunctionExpression;
-    m_isClassConstructor = scopeCtx->m_isClassConstructor;
-    m_isGenerator = scopeCtx->m_isGenerator;
-    m_isFunctionNameExplicitlyDeclared = false;
-    m_isFunctionNameSaveOnHeap = false;
-    m_needsComplexParameterCopy = false;
-    m_isInWithScope = false;
-    m_isEvalCodeInFunction = false;
-    m_needsVirtualIDOperation = false;
-    m_needToLoadThisValue = false;
-    m_hasRestElement = scopeCtx->m_hasRestElement;
     m_shouldReparseArguments = scopeCtx->m_hasNonIdentArgument;
+
+    m_scopeInfo.isStrict = scopeCtx->m_isStrict;
+    m_scopeInfo.hasCallNativeFunctionCode = false;
+    m_scopeInfo.isFunctionNameSaveOnHeap = false;
+    m_scopeInfo.isFunctionNameExplicitlyDeclared = false;
+    m_scopeInfo.canUseIndexedVariableStorage = false;
+    m_scopeInfo.canAllocateEnvironmentOnStack = false;
+    m_scopeInfo.needsComplexParameterCopy = false;
+    m_scopeInfo.hasEval = scopeCtx->m_hasEval;
+    m_scopeInfo.hasWith = scopeCtx->m_hasWith;
+    m_scopeInfo.hasSuper = false;
+    m_scopeInfo.hasCatch = scopeCtx->m_hasCatch;
+    m_scopeInfo.hasYield = scopeCtx->m_hasYield;
+    m_scopeInfo.inCatch = scopeCtx->m_inCatch;
+    m_scopeInfo.inWith = scopeCtx->m_inWith;
+    m_scopeInfo.usesArgumentsObject = false;
+    m_scopeInfo.isFunctionExpression = isFE;
+    m_scopeInfo.isFunctionDeclaration = isFD;
+    m_scopeInfo.isFunctionDeclarationWithSpecialBinding = scopeCtx->m_needsSpecialInitialize;
+    m_scopeInfo.isArrowFunctionExpression = scopeCtx->m_isArrowFunctionExpression;
+    m_scopeInfo.isConstructor = !scopeCtx->m_isArrowFunctionExpression;
+    m_scopeInfo.isClassConstructor = scopeCtx->m_isClassConstructor;
+    m_scopeInfo.isGenerator = scopeCtx->m_isGenerator;
+    m_scopeInfo.isInWithScope = false;
+    m_scopeInfo.isEvalCodeInFunction = false;
+    m_scopeInfo.needsVirtualIDOperation = false;
+    m_scopeInfo.needToLoadThisValue = false;
+    m_scopeInfo.hasRestElement = scopeCtx->m_hasRestElement;
 
     m_parametersInfomation.resizeWithUninitializedValues(parameterNames.size());
     for (size_t i = 0; i < parameterNames.size(); i++) {
@@ -261,14 +266,14 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
         m_parametersInfomation[i].m_isDuplicated = false;
     }
 
-    m_canUseIndexedVariableStorage = !hasEvalWithYield() && !m_inCatch && !m_inWith && !scopeCtx->m_hasArrowSuper && !m_shouldReparseArguments && !m_isGenerator;
-    m_canAllocateEnvironmentOnStack = m_canUseIndexedVariableStorage;
+    m_scopeInfo.canUseIndexedVariableStorage = !hasEvalWithYield() && !m_scopeInfo.inCatch && !m_scopeInfo.inWith && !scopeCtx->m_hasArrowSuper && !m_shouldReparseArguments && !m_scopeInfo.isGenerator;
+    m_scopeInfo.canAllocateEnvironmentOnStack = m_scopeInfo.canUseIndexedVariableStorage;
 
     const ASTScopeContextNameInfoVector& innerIdentifiers = scopeCtx->m_names;
     for (size_t i = 0; i < innerIdentifiers.size(); i++) {
         IdentifierInfo info;
         info.m_name = innerIdentifiers[i].name();
-        info.m_needToAllocateOnStack = m_canUseIndexedVariableStorage;
+        info.m_needToAllocateOnStack = m_scopeInfo.canUseIndexedVariableStorage;
         info.m_isMutable = true;
         info.m_isExplicitlyDeclaredOrParameterName = innerIdentifiers[i].isExplicitlyDeclaredOrParameterName();
         info.m_indexForIndexedStorage = SIZE_MAX;
@@ -289,7 +294,7 @@ void InterpretedCodeBlock::captureThis()
         return;
     }
 
-    m_canAllocateEnvironmentOnStack = false;
+    m_scopeInfo.canAllocateEnvironmentOnStack = false;
 
     IdentifierInfo info;
     info.m_name = m_context->staticStrings().stringThis;
@@ -306,11 +311,11 @@ void InterpretedCodeBlock::captureArguments()
     ASSERT(!hasParameter(arguments));
     ASSERT(!isGlobalScopeCodeBlock() && !isArrowFunctionExpression());
 
-    if (m_usesArgumentsObject) {
+    if (m_scopeInfo.usesArgumentsObject) {
         return;
     }
 
-    m_usesArgumentsObject = true;
+    m_scopeInfo.usesArgumentsObject = true;
     if (!hasName(arguments)) {
         IdentifierInfo info;
         info.m_indexForIndexedStorage = SIZE_MAX;
@@ -320,7 +325,7 @@ void InterpretedCodeBlock::captureArguments()
         m_identifierInfos.pushBack(info);
     }
     if (m_parameterCount) {
-        m_canAllocateEnvironmentOnStack = false;
+        m_scopeInfo.canAllocateEnvironmentOnStack = false;
         for (size_t j = 0; j < m_parametersInfomation.size(); j++) {
             for (size_t k = 0; k < m_identifierInfos.size(); k++) {
                 if (m_identifierInfos[k].m_name == m_parametersInfomation[j].m_name) {
@@ -336,7 +341,7 @@ bool InterpretedCodeBlock::tryCaptureIdentifiersFromChildCodeBlock(AtomicString 
 {
     for (size_t i = 0; i < m_identifierInfos.size(); i++) {
         if (m_identifierInfos[i].m_name == name) {
-            m_canAllocateEnvironmentOnStack = false;
+            m_scopeInfo.canAllocateEnvironmentOnStack = false;
             m_identifierInfos[i].m_needToAllocateOnStack = false;
             return true;
         }
@@ -346,8 +351,8 @@ bool InterpretedCodeBlock::tryCaptureIdentifiersFromChildCodeBlock(AtomicString 
 
 void InterpretedCodeBlock::notifySelfOrChildHasEvalWithYield()
 {
-    m_canAllocateEnvironmentOnStack = false;
-    m_canUseIndexedVariableStorage = false;
+    m_scopeInfo.canAllocateEnvironmentOnStack = false;
+    m_scopeInfo.canUseIndexedVariableStorage = false;
 
     for (size_t i = 0; i < m_identifierInfos.size(); i++) {
         m_identifierInfos[i].m_indexForIndexedStorage = SIZE_MAX;
@@ -362,29 +367,29 @@ void InterpretedCodeBlock::notifySelfOrChildHasEvalWithYield()
 
 void InterpretedCodeBlock::computeVariables()
 {
-    if (m_usesArgumentsObject) {
-        m_canAllocateEnvironmentOnStack = false;
+    if (m_scopeInfo.usesArgumentsObject) {
+        m_scopeInfo.canAllocateEnvironmentOnStack = false;
     }
 
     if (inEvalWithYieldScope() || inNotIndexedCodeBlockScope() || hasCatch()) {
-        m_canAllocateEnvironmentOnStack = false;
+        m_scopeInfo.canAllocateEnvironmentOnStack = false;
     }
 
-    if (!m_canAllocateEnvironmentOnStack) {
+    if (!m_scopeInfo.canAllocateEnvironmentOnStack) {
         CodeBlock* cb = parentCodeBlock();
         while (cb && cb->isInterpretedCodeBlock()) {
-            cb->m_canAllocateEnvironmentOnStack = false;
+            cb->m_scopeInfo.canAllocateEnvironmentOnStack = false;
             cb = cb->asInterpretedCodeBlock()->parentCodeBlock();
         }
     }
 
     if (m_functionName.string()->length()) {
-        if (m_isFunctionExpression) {
+        if (m_scopeInfo.isFunctionExpression) {
             // name of function expression is immuable
             for (size_t i = 0; i < m_identifierInfos.size(); i++) {
                 if (m_identifierInfos[i].m_name == m_functionName && !m_identifierInfos[i].m_isExplicitlyDeclaredOrParameterName) {
                     m_identifierInfos[i].m_isMutable = false;
-                    m_needsComplexParameterCopy = true;
+                    m_scopeInfo.needsComplexParameterCopy = true;
                     break;
                 }
             }
@@ -393,7 +398,7 @@ void InterpretedCodeBlock::computeVariables()
         for (size_t i = 0; i < m_parametersInfomation.size(); i++) {
             AtomicString name = m_parametersInfomation[i].m_name;
             if (name == m_functionName) {
-                m_needsComplexParameterCopy = true;
+                m_scopeInfo.needsComplexParameterCopy = true;
                 break;
             }
         }
@@ -405,17 +410,17 @@ void InterpretedCodeBlock::computeVariables()
 
         for (size_t i = 0; i < m_identifierInfos.size(); i++) {
             if (m_identifierInfos[i].m_name == m_functionName) {
-                m_needsComplexParameterCopy = true;
+                m_scopeInfo.needsComplexParameterCopy = true;
                 if (m_identifierInfos[i].m_isExplicitlyDeclaredOrParameterName) {
-                    m_isFunctionNameExplicitlyDeclared = true;
+                    m_scopeInfo.isFunctionNameExplicitlyDeclared = true;
                 }
 
                 if (!m_identifierInfos[i].m_needToAllocateOnStack) {
-                    m_isFunctionNameSaveOnHeap = true;
+                    m_scopeInfo.isFunctionNameSaveOnHeap = true;
                     m_identifierInfos[i].m_indexForIndexedStorage = h;
                     h++;
                 } else {
-                    if (m_isFunctionNameExplicitlyDeclared) {
+                    if (m_scopeInfo.isFunctionNameExplicitlyDeclared) {
                         s++;
                     }
                     m_identifierInfos[i].m_indexForIndexedStorage = 1;
@@ -465,7 +470,7 @@ void InterpretedCodeBlock::computeVariables()
             for (size_t j = 0; j < computedNameIndex.size(); j++) {
                 if (computedNameIndex[j].first == name) {
                     // found dup parameter name!
-                    m_needsComplexParameterCopy = true;
+                    m_scopeInfo.needsComplexParameterCopy = true;
                     computed = true;
                     computedIndex = computedNameIndex[j].second;
 
@@ -483,7 +488,7 @@ void InterpretedCodeBlock::computeVariables()
             if (!computed) {
                 if (isHeap) {
                     m_parametersInfomation[i].m_index = indexInIdInfo;
-                    m_needsComplexParameterCopy = true;
+                    m_scopeInfo.needsComplexParameterCopy = true;
                     computedNameIndex.push_back(std::make_pair(name, indexInIdInfo));
                 } else {
                     m_parametersInfomation[i].m_index = indexInIdInfo;
@@ -494,9 +499,9 @@ void InterpretedCodeBlock::computeVariables()
             }
         }
     } else {
-        m_needsComplexParameterCopy = true;
+        m_scopeInfo.needsComplexParameterCopy = true;
 
-        if (m_isEvalCodeInFunction) {
+        if (m_scopeInfo.isEvalCodeInFunction) {
             AtomicString arguments = m_context->staticStrings().arguments;
             for (size_t i = 0; i < m_identifierInfos.size(); i++) {
                 if (m_identifierInfos[i].m_name == arguments) {
@@ -513,9 +518,9 @@ void InterpretedCodeBlock::computeVariables()
 
             if (m_identifierInfos[i].m_name == m_functionName) {
                 if (m_identifierInfos[i].m_isExplicitlyDeclaredOrParameterName) {
-                    m_isFunctionNameExplicitlyDeclared = true;
+                    m_scopeInfo.isFunctionNameExplicitlyDeclared = true;
                 }
-                m_isFunctionNameSaveOnHeap = true;
+                m_scopeInfo.isFunctionNameSaveOnHeap = true;
                 m_identifierInfos[i].m_indexForIndexedStorage = h;
                 h++;
                 continue;

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -69,6 +69,36 @@ struct NativeFunctionInfo {
     }
 };
 
+typedef struct ScopeInfo {
+    bool isConstructor : 1;
+    bool isStrict : 1;
+    bool hasCallNativeFunctionCode : 1;
+    bool isFunctionNameSaveOnHeap : 1;
+    bool isFunctionNameExplicitlyDeclared : 1;
+    bool canUseIndexedVariableStorage : 1;
+    bool canAllocateEnvironmentOnStack : 1;
+    bool needsComplexParameterCopy : 1;
+    bool hasEval : 1;
+    bool hasWith : 1;
+    bool hasSuper : 1;
+    bool hasCatch : 1;
+    bool hasYield : 1;
+    bool inCatch : 1;
+    bool inWith : 1;
+    bool usesArgumentsObject : 1;
+    bool isFunctionExpression : 1;
+    bool isFunctionDeclaration : 1;
+    bool isFunctionDeclarationWithSpecialBinding : 1;
+    bool isArrowFunctionExpression : 1;
+    bool isClassConstructor : 1;
+    bool isGenerator : 1;
+    bool isInWithScope : 1;
+    bool isEvalCodeInFunction : 1;
+    bool needsVirtualIDOperation : 1;
+    bool needToLoadThisValue : 1;
+    bool hasRestElement : 1;
+} ScopeInfo;
+
 class CallNativeFunctionData : public gc {
 public:
     NativeFunctionPointer m_fn;
@@ -110,104 +140,109 @@ public:
         return m_context;
     }
 
+    ScopeInfo descriptor()
+    {
+        return m_scopeInfo;
+    }
+
     bool isConstructor() const
     {
-        return m_isConstructor;
+        return m_scopeInfo.isConstructor;
     }
 
     bool inCatchWith()
     {
-        return m_inCatch || m_inWith;
+        return m_scopeInfo.inCatch || m_scopeInfo.inWith;
     }
 
     bool hasEval() const
     {
-        return m_hasEval;
+        return m_scopeInfo.hasEval;
     }
 
     bool hasWith() const
     {
-        return m_hasWith;
+        return m_scopeInfo.hasWith;
     }
 
     bool hasCatch() const
     {
-        return m_hasCatch;
+        return m_scopeInfo.hasCatch;
     }
 
     bool hasYield() const
     {
-        return m_hasYield;
+        return m_scopeInfo.hasYield;
     }
 
     bool hasEvalWithYield() const
     {
-        return m_hasEval || m_hasWith || m_hasYield;
+        return m_scopeInfo.hasEval || m_scopeInfo.hasWith || m_scopeInfo.hasYield;
     }
 
     bool isStrict() const
     {
-        return m_isStrict;
+        return m_scopeInfo.isStrict;
     }
 
     bool canUseIndexedVariableStorage() const
     {
-        return m_canUseIndexedVariableStorage;
+        return m_scopeInfo.canUseIndexedVariableStorage;
     }
 
     bool canAllocateEnvironmentOnStack() const
     {
-        return m_canAllocateEnvironmentOnStack;
+        return m_scopeInfo.canAllocateEnvironmentOnStack;
     }
 
     bool isFunctionDeclaration() const
     {
-        return m_isFunctionDeclaration;
+        return m_scopeInfo.isFunctionDeclaration;
     }
 
     bool isFunctionDeclarationWithSpecialBinding() const
     {
-        return m_isFunctionDeclarationWithSpecialBinding;
+        return m_scopeInfo.isFunctionDeclarationWithSpecialBinding;
     }
 
     bool isFunctionExpression() const
     {
-        return m_isFunctionExpression;
+        return m_scopeInfo.isFunctionExpression;
     }
 
     bool isArrowFunctionExpression() const
     {
-        return m_isArrowFunctionExpression;
+        return m_scopeInfo.isArrowFunctionExpression;
     }
 
     bool isClassConstructor() const
     {
-        return m_isClassConstructor;
+        return m_scopeInfo.isClassConstructor;
     }
 
     bool isGenerator() const
     {
-        return m_isGenerator;
+        return m_scopeInfo.isGenerator;
     }
 
     bool needToLoadThisValue() const
     {
-        return m_needToLoadThisValue;
+        return m_scopeInfo.needToLoadThisValue;
     }
 
     void setNeedToLoadThisValue()
     {
-        m_needToLoadThisValue = true;
+        m_scopeInfo.needToLoadThisValue = true;
     }
 
     bool hasCallNativeFunctionCode() const
     {
-        return m_hasCallNativeFunctionCode;
+        return m_scopeInfo.hasCallNativeFunctionCode;
     }
 
     bool usesArgumentsObject() const
     {
-        return m_usesArgumentsObject;
+        return m_scopeInfo.usesArgumentsObject;
     }
 
     AtomicString functionName() const
@@ -217,44 +252,44 @@ public:
 
     bool needsComplexParameterCopy() const
     {
-        return m_needsComplexParameterCopy;
+        return m_scopeInfo.needsComplexParameterCopy;
     }
 
     void setInWithScope()
     {
-        m_isInWithScope = true;
+        m_scopeInfo.isInWithScope = true;
     }
 
     void clearInWithScope()
     {
-        m_isInWithScope = false;
+        m_scopeInfo.isInWithScope = false;
     }
 
     bool isInWithScope() const
     {
-        return m_isInWithScope;
+        return m_scopeInfo.isInWithScope;
     }
 
     void setHasEval()
     {
-        m_hasEval = true;
-        m_canUseIndexedVariableStorage = false;
+        m_scopeInfo.hasEval = true;
+        m_scopeInfo.canUseIndexedVariableStorage = false;
     }
 
     void setAsClassConstructor()
     {
-        m_isClassConstructor = true;
+        m_scopeInfo.isClassConstructor = true;
     }
 
     void setNeedsVirtualIDOperation()
     {
         ASSERT(isInterpretedCodeBlock());
-        m_needsVirtualIDOperation = true;
+        m_scopeInfo.needsVirtualIDOperation = true;
     }
 
     bool needsVirtualIDOperation()
     {
-        return m_needsVirtualIDOperation;
+        return m_scopeInfo.needsVirtualIDOperation;
     }
 
     uint16_t parameterCount()
@@ -264,12 +299,12 @@ public:
 
     bool isInterpretedCodeBlock()
     {
-        return !m_hasCallNativeFunctionCode;
+        return !m_scopeInfo.hasCallNativeFunctionCode;
     }
 
     InterpretedCodeBlock* asInterpretedCodeBlock()
     {
-        ASSERT(!m_hasCallNativeFunctionCode);
+        ASSERT(!m_scopeInfo.hasCallNativeFunctionCode);
         return (InterpretedCodeBlock*)this;
     }
 
@@ -282,35 +317,8 @@ protected:
     CodeBlock() {}
     Context* m_context;
 
-    bool m_isConstructor : 1;
-    bool m_isStrict : 1;
-    bool m_hasCallNativeFunctionCode : 1;
-    bool m_isFunctionNameSaveOnHeap : 1;
-    bool m_isFunctionNameExplicitlyDeclared : 1;
-    bool m_canUseIndexedVariableStorage : 1;
-    bool m_canAllocateEnvironmentOnStack : 1;
-    bool m_needsComplexParameterCopy : 1;
-    bool m_hasEval : 1;
-    bool m_hasWith : 1;
-    bool m_hasSuper : 1;
-    bool m_hasCatch : 1;
-    bool m_hasYield : 1;
-    bool m_inCatch : 1;
-    bool m_inWith : 1;
-    bool m_usesArgumentsObject : 1;
-    bool m_isFunctionExpression : 1;
-    bool m_isFunctionDeclaration : 1;
-    bool m_isFunctionDeclarationWithSpecialBinding : 1;
-    bool m_isArrowFunctionExpression : 1;
-    bool m_isClassConstructor : 1;
-    bool m_isGenerator : 1;
-    bool m_isInWithScope : 1;
-    bool m_isEvalCodeInFunction : 1;
-    bool m_needsVirtualIDOperation : 1;
-    bool m_needToLoadThisValue : 1;
-    bool m_hasRestElement : 1;
+    ScopeInfo m_scopeInfo;
     uint16_t m_parameterCount;
-
     AtomicString m_functionName;
 
     union {

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -54,7 +54,7 @@ InterpretedCodeBlock* ScriptParser::generateCodeBlockTreeFromASTWalker(Context* 
         if (scopeCtx->m_hasEvaluateBindingId) {
             InterpretedCodeBlock* c = codeBlock;
             while (c) {
-                c->m_canAllocateEnvironmentOnStack = false;
+                c->m_scopeInfo.canAllocateEnvironmentOnStack = false;
                 c = c->parentCodeBlock();
             }
         }
@@ -116,8 +116,8 @@ InterpretedCodeBlock* ScriptParser::generateCodeBlockTreeFromASTWalker(Context* 
 
         if (hasCapturedIdentifier) {
             InterpretedCodeBlock* c = codeBlock->parentCodeBlock();
-            while (c && c->m_canAllocateEnvironmentOnStack) {
-                c->m_canAllocateEnvironmentOnStack = false;
+            while (c && c->m_scopeInfo.canAllocateEnvironmentOnStack) {
+                c->m_scopeInfo.canAllocateEnvironmentOnStack = false;
                 c = c->parentCodeBlock();
             }
         }
@@ -182,12 +182,12 @@ void ScriptParser::generateProgramCodeBlock(ExecutionState& state, StringView sc
             programNode->scopeContext()->m_hasYield = parentCodeBlock->hasYield();
             programNode->scopeContext()->m_isClassConstructor = parentCodeBlock->isClassConstructor();
             topCodeBlock = generateCodeBlockTreeFromASTWalker(m_context, scriptSource, script, programNode->scopeContext(), parentCodeBlock);
-            topCodeBlock->m_isEvalCodeInFunction = true;
-            topCodeBlock->m_isInWithScope = parentCodeBlock->m_isInWithScope;
+            topCodeBlock->m_scopeInfo.isEvalCodeInFunction = true;
+            topCodeBlock->m_scopeInfo.isInWithScope = parentCodeBlock->m_scopeInfo.isInWithScope;
         } else {
             topCodeBlock = generateCodeBlockTreeFromAST(m_context, scriptSource, script, programNode.get());
         }
-        topCodeBlock->m_isEvalCodeInFunction = isEvalCodeInFunction;
+        topCodeBlock->m_scopeInfo.isEvalCodeInFunction = isEvalCodeInFunction;
 
         generateCodeBlockTreeFromASTWalkerPostProcess(topCodeBlock);
 
@@ -243,14 +243,14 @@ void ScriptParser::dumpCodeBlockTree(InterpretedCodeBlock* topCodeBlock)
 
         PRINT_TAB()
         printf("CodeBlock %s %s (%d:%d -> %d:%d)(%s, %s) (E:%d, W:%d, C:%d, Y:%d, A:%d)\n", cb->m_functionName.string()->toUTF8StringData().data(),
-               cb->m_isStrict ? "Strict" : "",
+               cb->m_scopeInfo.isStrict ? "Strict" : "",
                (int)cb->m_locStart.line,
                (int)cb->m_locStart.column,
                (int)cb->m_locEnd.line,
                (int)cb->m_locEnd.column,
-               cb->m_canAllocateEnvironmentOnStack ? "Stack" : "Heap",
-               cb->m_canUseIndexedVariableStorage ? "Indexed" : "Named",
-               (int)cb->m_hasEval, (int)cb->m_hasWith, (int)cb->m_hasCatch, (int)cb->m_hasYield, (int)cb->m_usesArgumentsObject);
+               cb->m_scopeInfo.canAllocateEnvironmentOnStack ? "Stack" : "Heap",
+               cb->m_scopeInfo.canUseIndexedVariableStorage ? "Indexed" : "Named",
+               (int)cb->m_scopeInfo.hasEval, (int)cb->m_scopeInfo.hasWith, (int)cb->m_scopeInfo.hasCatch, (int)cb->m_scopeInfo.hasYield, (int)cb->m_scopeInfo.usesArgumentsObject);
 
         PRINT_TAB()
         printf("Names: ");

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -410,7 +410,7 @@ Value FunctionObject::processCall(ExecutionState& state, const Value& receiverSr
 
     // binding function name
     stackStorage[1] = this;
-    if (UNLIKELY(m_codeBlock->m_isFunctionNameSaveOnHeap)) {
+    if (UNLIKELY(m_codeBlock->m_scopeInfo.isFunctionNameSaveOnHeap)) {
         if (m_codeBlock->canUseIndexedVariableStorage()) {
             ASSERT(record->isFunctionEnvironmentRecordOnHeap());
             ((FunctionEnvironmentRecordOnHeap*)record)->m_heapStorage[0] = this;
@@ -419,9 +419,9 @@ Value FunctionObject::processCall(ExecutionState& state, const Value& receiverSr
         }
     }
 
-    if (UNLIKELY(m_codeBlock->m_isFunctionNameExplicitlyDeclared)) {
+    if (UNLIKELY(m_codeBlock->m_scopeInfo.isFunctionNameExplicitlyDeclared)) {
         if (m_codeBlock->canUseIndexedVariableStorage()) {
-            if (UNLIKELY(m_codeBlock->m_isFunctionNameSaveOnHeap)) {
+            if (UNLIKELY(m_codeBlock->m_scopeInfo.isFunctionNameSaveOnHeap)) {
                 ASSERT(record->isFunctionEnvironmentRecordOnHeap());
                 ((FunctionEnvironmentRecordOnHeap*)record)->m_heapStorage[0] = Value();
             } else {
@@ -447,7 +447,7 @@ Value FunctionObject::processCall(ExecutionState& state, const Value& receiverSr
             }
 
             // Handle rest param
-            if (m_codeBlock->m_hasRestElement) {
+            if (m_codeBlock->m_scopeInfo.hasRestElement) {
                 size_t argListLen = (size_t)m_codeBlock->parameterCount();
                 size_t arrayLen = argc - parameterCopySize;
                 ArrayObject* newArray = new ArrayObject(state, (double)arrayLen);
@@ -477,7 +477,7 @@ Value FunctionObject::processCall(ExecutionState& state, const Value& receiverSr
             }
 
             // Handle rest param
-            if (m_codeBlock->m_hasRestElement) {
+            if (m_codeBlock->m_scopeInfo.hasRestElement) {
                 size_t argListLen = (size_t)m_codeBlock->parameterCount();
                 size_t arrayLen = argc - parameterCopySize;
                 ArrayObject* newArray = new ArrayObject(state, (double)arrayLen);
@@ -504,7 +504,7 @@ Value FunctionObject::processCall(ExecutionState& state, const Value& receiverSr
         }
 
         // Handle rest param
-        if (m_codeBlock->m_hasRestElement) {
+        if (m_codeBlock->m_scopeInfo.hasRestElement) {
             size_t argListLen = (size_t)m_codeBlock->parameterCount();
             size_t arrayLen = argc - parameterCopySize;
             ArrayObject* newArray = new ArrayObject(state, (double)arrayLen);


### PR DESCRIPTION
There are a lot of (boolean typed) scope information in the `CodeBlock class` that should be dumped into a binary file in case of the **snapshot** feature. It would be nice if these data could be wrapped into a structure and that memory are could be dumped directly into the file. (Please note that this is also helpful when reading data from the binary file.)

This patch helps to do that, all the scope information is wrapped into a `ScopeInfo` named structure.
