### PR TITLE
Improve String.prototype.repeat

### DIFF
--- a/src/runtime/GlobalObjectBuiltinString.cpp
+++ b/src/runtime/GlobalObjectBuiltinString.cpp
@@ -290,13 +290,16 @@ static Value builtinStringRepeat(ExecutionState& state, Value thisValue, size_t 
     Value argument = argv[0];
     int32_t repeatCount;
     double count = argument.toInteger(state);
-    if (count < 0 || count == std::numeric_limits<double>::infinity()) {
+    double newStringLength = str->length() * count;
+    if (count < 0 || count == std::numeric_limits<double>::infinity() || newStringLength > STRING_MAXIMUM_LENGTH) {
         ErrorObject::throwBuiltinError(state, ErrorObject::RangeError, "invalid count number of String repeat method");
     }
-    repeatCount = static_cast<int32_t>(count);
-    if (count == 0) {
+
+    if (newStringLength == 0) {
         return String::emptyString;
     }
+
+    repeatCount = static_cast<int32_t>(count);
 
     StringBuilder builder;
     for (int i = 0; i < repeatCount; i++) {

--- a/tools/test/v8/v8.mjsunit.status
+++ b/tools/test/v8/v8.mjsunit.status
@@ -851,7 +851,6 @@
   'es6/string-html' : [SKIP],
   'es6/string-includes' : [SKIP],
   'es6/string-match' : [SKIP],
-  'es6/string-repeat' : [SKIP],
   'es6/string-replace' : [SKIP],
   'es6/string-search' : [SKIP],
   'es6/string-startswith' : [SKIP],


### PR DESCRIPTION
 - Limit the size of the concatenated string
 - Skip the concatenation of empty strings

This patch allows to enable mjsunit/es6/string-repeat.js

Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu