### PR TITLE
Remove unused template string member of TemplateOperation opcode.

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -1089,14 +1089,12 @@ class TemplateOperation : public ByteCode {
 public:
     TemplateOperation(const ByteCodeLOC& loc, const size_t src0Index, const size_t src1Index, const size_t dstIndex)
         : ByteCode(Opcode::TemplateOperationOpcode, loc)
-        , m_quasi(NULL)
         , m_src0Index(src0Index)
         , m_src1Index(src1Index)
         , m_dstIndex(dstIndex)
     {
     }
 
-    String* m_quasi;
     ByteCodeRegisterIndex m_src0Index;
     ByteCodeRegisterIndex m_src1Index;
     ByteCodeRegisterIndex m_dstIndex;


### PR DESCRIPTION
There is no need to keep the template literal of TemplateOperation since it always set to NULL. Currently, a LoadLiteral opcode is created for the template literals ([TemplateLiteralNode.h#L72](https://github.com/Samsung/escargot/blob/master/src/parser/ast/TemplateLiteralNode.h#L72)).