### PR TITLE
Optimize/simplify static string initialization

### DIFF
--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -407,7 +407,7 @@ AtomicString keywordToString(::Escargot::Context* ctx, KeywordKind keyword)
     case ExtendsKeyword:
         return ctx->staticStrings().stringExtends;
     case FunctionKeyword:
-        return ctx->staticStrings().stringFunction;
+        return ctx->staticStrings().function;
     case ContinueKeyword:
         return ctx->staticStrings().stringContinue;
     case DebuggerKeyword:
@@ -415,11 +415,11 @@ AtomicString keywordToString(::Escargot::Context* ctx, KeywordKind keyword)
     case InstanceofKeyword:
         return ctx->staticStrings().stringInstanceof;
     case ImplementsKeyword:
-        return ctx->staticStrings().stringImplements;
+        return ctx->staticStrings().implements;
     case InterfaceKeyword:
-        return ctx->staticStrings().stringInterface;
+        return ctx->staticStrings().interface;
     case PackageKeyword:
-        return ctx->staticStrings().stringPackage;
+        return ctx->staticStrings().package;
     case PrivateKeyword:
         return ctx->staticStrings().stringPrivate;
     case ProtectedKeyword:
@@ -429,9 +429,9 @@ AtomicString keywordToString(::Escargot::Context* ctx, KeywordKind keyword)
     case StaticKeyword:
         return ctx->staticStrings().stringStatic;
     case YieldKeyword:
-        return ctx->staticStrings().stringYield;
+        return ctx->staticStrings().yield;
     case LetKeyword:
-        return ctx->staticStrings().stringLet;
+        return ctx->staticStrings().let;
     default:
         ASSERT_NOT_REACHED();
         return ctx->staticStrings().stringError;

--- a/src/runtime/AtomicString.cpp
+++ b/src/runtime/AtomicString.cpp
@@ -114,6 +114,14 @@ AtomicString::AtomicString(Context* c, String* name)
     init(c->m_atomicStringMap, name);
 }
 
+void AtomicString::initStaticString(AtomicStringMap* ec, String* name)
+{
+    ASSERT(ec->find(name) == ec->end());
+    ec->insert(name);
+    m_string = name;
+    name->m_tag = (size_t)POINTER_VALUE_STRING_SYMBOL_TAG_IN_DATA | (size_t)m_string;
+}
+
 void AtomicString::init(AtomicStringMap* ec, String* name)
 {
     size_t v = name->getTagInFirstDataArea();

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -96,6 +96,7 @@ public:
 
 private:
     void init(AtomicStringMap* ec, String* name);
+    void initStaticString(AtomicStringMap* ec, String* name);
     void init(AtomicStringMap* ec, const LChar* str, size_t len)
     {
         init(ec, new Latin1String(str, len));

--- a/src/runtime/StaticStrings.cpp
+++ b/src/runtime/StaticStrings.cpp
@@ -26,95 +26,97 @@ namespace Escargot {
 void StaticStrings::initStaticStrings(AtomicStringMap* atomicStringMap)
 {
     atomicStringMap->insert(String::emptyString);
-    NegativeInfinity.init(atomicStringMap, "-Infinity", strlen("-Infinity"));
-    stringTrue.init(atomicStringMap, "true", strlen("true"));
-    stringFalse.init(atomicStringMap, "false", strlen("false"));
-    stringPublic.init(atomicStringMap, "public", strlen("public"));
-    stringProtected.init(atomicStringMap, "protected", strlen("protected"));
-    stringPrivate.init(atomicStringMap, "private", strlen("private"));
-    stringStatic.init(atomicStringMap, "static", strlen("static"));
-    stringCatch.init(atomicStringMap, "catch", strlen("catch"));
-    stringDelete.init(atomicStringMap, "delete", strlen("delete"));
-    stringFor.init(atomicStringMap, "for", strlen("for"));
-    stringDefault.init(atomicStringMap, "default", strlen("default"));
-    stringThis.init(atomicStringMap, "this", strlen("this"));
 
-    stringIf.init(atomicStringMap, "if", strlen("if"));
-    stringIn.init(atomicStringMap, "in", strlen("in"));
-    stringDo.init(atomicStringMap, "do", strlen("do"));
-    stringVar.init(atomicStringMap, "var", strlen("var"));
-    stringNew.init(atomicStringMap, "new", strlen("new"));
-    stringTry.init(atomicStringMap, "try", strlen("try"));
-    stringElse.init(atomicStringMap, "else", strlen("else"));
-    stringCase.init(atomicStringMap, "case", strlen("case"));
-    stringVoid.init(atomicStringMap, "void", strlen("void"));
-    stringWith.init(atomicStringMap, "with", strlen("with"));
-    stringEnum.init(atomicStringMap, "enum", strlen("enum"));
-    stringAwait.init(atomicStringMap, "await", strlen("await"));
-    stringWhile.init(atomicStringMap, "while", strlen("while"));
-    stringBreak.init(atomicStringMap, "break", strlen("break"));
-    stringThrow.init(atomicStringMap, "throw", strlen("throw"));
-    stringConst.init(atomicStringMap, "const", strlen("const"));
-    stringClass.init(atomicStringMap, "class", strlen("class"));
-    stringSuper.init(atomicStringMap, "super", strlen("super"));
-    stringReturn.init(atomicStringMap, "return", strlen("return"));
-    stringTypeof.init(atomicStringMap, "typeof", strlen("typeof"));
-    stringSwitch.init(atomicStringMap, "switch", strlen("switch"));
-    stringExport.init(atomicStringMap, "export", strlen("export"));
-    stringImport.init(atomicStringMap, "import", strlen("import"));
-    stringFinally.init(atomicStringMap, "finally", strlen("finally"));
-    stringExtends.init(atomicStringMap, "extends", strlen("extends"));
-    stringFunction.init(atomicStringMap, "function", strlen("function"));
-    stringContinue.init(atomicStringMap, "continue", strlen("continue"));
-    stringDebugger.init(atomicStringMap, "debugger", strlen("debugger"));
-    stringInstanceof.init(atomicStringMap, "instanceof", strlen("instanceof"));
-    stringImplements.init(atomicStringMap, "implements", strlen("implements"));
-    stringInterface.init(atomicStringMap, "interface", strlen("interface"));
-    stringPackage.init(atomicStringMap, "package", strlen("package"));
-    stringYield.init(atomicStringMap, "yield", strlen("yield"));
-    stringLet.init(atomicStringMap, "let", strlen("let"));
-    stringError.init(atomicStringMap, "error", strlen("error"));
+#define INIT_STATIC_STRING(name) name.initStaticString(atomicStringMap, new ASCIIString(#name, strlen(#name)));
+    FOR_EACH_STATIC_STRING(INIT_STATIC_STRING)
+#undef INIT_STATIC_STRING
 
-    defaultRegExpString.init(atomicStringMap, "(?:)", strlen("(?:)"));
+#define INIT_STATIC_STRING(atomicString, name) atomicString.initStaticString(atomicStringMap, new ASCIIString(name, strlen(name)))
+    INIT_STATIC_STRING(NegativeInfinity, "-Infinity");
+    INIT_STATIC_STRING(stringTrue, "true");
+    INIT_STATIC_STRING(stringFalse, "false");
+    INIT_STATIC_STRING(stringPublic, "public");
+    INIT_STATIC_STRING(stringProtected, "protected");
+    INIT_STATIC_STRING(stringPrivate, "private");
+    INIT_STATIC_STRING(stringStatic, "static");
+    INIT_STATIC_STRING(stringCatch, "catch");
+    INIT_STATIC_STRING(stringDelete, "delete");
+    INIT_STATIC_STRING(stringFor, "for");
+    INIT_STATIC_STRING(stringDefault, "default");
+    INIT_STATIC_STRING(stringThis, "this");
 
-    get__proto__.init(atomicStringMap, "get __proto__", strlen("get __proto__"));
-    set__proto__.init(atomicStringMap, "set __proto__", strlen("set __proto__"));
-    getbyteLength.init(atomicStringMap, "get byteLength", strlen("get byteLength"));
-    getbyteOffset.init(atomicStringMap, "get byteOffset", strlen("get byteOffset"));
-    getLength.init(atomicStringMap, "get length", strlen("get length"));
-    getBuffer.init(atomicStringMap, "get buffer", strlen("get buffer"));
-    getSize.init(atomicStringMap, "get size", strlen("get size"));
-    getFlags.init(atomicStringMap, "get flags", strlen("get flags"));
-    getGlobal.init(atomicStringMap, "get global", strlen("get global"));
-    getIgnoreCase.init(atomicStringMap, "get ignoreCase", strlen("get ignoreCase"));
-    getMultiline.init(atomicStringMap, "get multiline", strlen("get multiline"));
-    getSource.init(atomicStringMap, "get source", strlen("get source"));
-    getSticky.init(atomicStringMap, "get sticky", strlen("get sticky"));
-    getUnicode.init(atomicStringMap, "get unicode", strlen("get unicode"));
-    getSymbolSpecies.init(atomicStringMap, "get [Symbol.species]", strlen("get [Symbol.species]"));
-    getSymbolSearch.init(atomicStringMap, "get [Symbol.search]", strlen("get [Symbol.search]"));
-    getSymbolToStringTag.init(atomicStringMap, "get [Symbol.toStringTag]", strlen("get [Symbol.toStringTag]"));
-    symbolSplit.init(atomicStringMap, "[Symbol.split]", strlen("[Symbol.split]"));
-    $Ampersand.init(atomicStringMap, "$&", strlen("$&"));
-    $PlusSign.init(atomicStringMap, "$+", strlen("$+"));
-    $GraveAccent.init(atomicStringMap, "$`", strlen("$`"));
-    $Apostrophe.init(atomicStringMap, "$'", strlen("$'"));
+    INIT_STATIC_STRING(stringIf, "if");
+    INIT_STATIC_STRING(stringIn, "in");
+    INIT_STATIC_STRING(stringDo, "do");
+    INIT_STATIC_STRING(stringVar, "var");
+    INIT_STATIC_STRING(stringNew, "new");
+    INIT_STATIC_STRING(stringTry, "try");
+    INIT_STATIC_STRING(stringElse, "else");
+    INIT_STATIC_STRING(stringCase, "case");
+    INIT_STATIC_STRING(stringVoid, "void");
+    INIT_STATIC_STRING(stringWith, "with");
+    INIT_STATIC_STRING(stringEnum, "enum");
+    INIT_STATIC_STRING(stringAwait, "await");
+    INIT_STATIC_STRING(stringWhile, "while");
+    INIT_STATIC_STRING(stringBreak, "break");
+    INIT_STATIC_STRING(stringThrow, "throw");
+    INIT_STATIC_STRING(stringConst, "const");
+    INIT_STATIC_STRING(stringClass, "class");
+    INIT_STATIC_STRING(stringSuper, "super");
+    INIT_STATIC_STRING(stringReturn, "return");
+    INIT_STATIC_STRING(stringTypeof, "typeof");
+    INIT_STATIC_STRING(stringSwitch, "switch");
+    INIT_STATIC_STRING(stringExport, "export");
+    INIT_STATIC_STRING(stringImport, "import");
+    INIT_STATIC_STRING(stringFinally, "finally");
+    INIT_STATIC_STRING(stringExtends, "extends");
+    INIT_STATIC_STRING(stringContinue, "continue");
+    INIT_STATIC_STRING(stringDebugger, "debugger");
+    INIT_STATIC_STRING(stringInstanceof, "instanceof");
+    INIT_STATIC_STRING(stringError, "error");
 
-    for (unsigned i = 0; i < ESCARGOT_ASCII_TABLE_MAX; i++) {
+    INIT_STATIC_STRING(defaultRegExpString, "(?:)");
+
+    INIT_STATIC_STRING(get__proto__, "get __proto__");
+    INIT_STATIC_STRING(set__proto__, "set __proto__");
+    INIT_STATIC_STRING(getbyteLength, "get byteLength");
+    INIT_STATIC_STRING(getbyteOffset, "get byteOffset");
+    INIT_STATIC_STRING(getLength, "get length");
+    INIT_STATIC_STRING(getBuffer, "get buffer");
+    INIT_STATIC_STRING(getSize, "get size");
+    INIT_STATIC_STRING(getFlags, "get flags");
+    INIT_STATIC_STRING(getGlobal, "get global");
+    INIT_STATIC_STRING(getIgnoreCase, "get ignoreCase");
+    INIT_STATIC_STRING(getMultiline, "get multiline");
+    INIT_STATIC_STRING(getSource, "get source");
+    INIT_STATIC_STRING(getSticky, "get sticky");
+    INIT_STATIC_STRING(getUnicode, "get unicode");
+    INIT_STATIC_STRING(getSymbolSpecies, "get [Symbol.species]");
+    INIT_STATIC_STRING(getSymbolSearch, "get [Symbol.search]");
+    INIT_STATIC_STRING(getSymbolToStringTag, "get [Symbol.toStringTag]");
+    INIT_STATIC_STRING(symbolSplit, "[Symbol.split]");
+
+    INIT_STATIC_STRING($Ampersand, "$&");
+    INIT_STATIC_STRING($PlusSign, "$+");
+    INIT_STATIC_STRING($GraveAccent, "$`");
+    INIT_STATIC_STRING($Apostrophe, "$'");
+#undef INIT_STATIC_STRING
+
+#define INIT_STATIC_NUMBER(num) numbers[num].initStaticString(atomicStringMap, new ASCIIString(#num, strlen(#num)));
+    FOR_EACH_STATIC_NUMBER(INIT_STATIC_NUMBER)
+#undef INIT_STATIC_NUMBER
+
+    for (unsigned i = 0; i < ESCARGOT_ASCII_TABLE_MAX / 2; i++) {
+        const char c = (const char)i;
+        asciiTable[i].init(atomicStringMap, &c, 1);
+    }
+
+    for (unsigned i = ESCARGOT_ASCII_TABLE_MAX / 2; i < ESCARGOT_ASCII_TABLE_MAX; i++) {
         LChar buf[2];
         buf[0] = i;
         buf[1] = 0;
-        asciiTable[i].init(atomicStringMap, buf, 1);
+        asciiTable[i].initStaticString(atomicStringMap, new Latin1String(buf, 1));
     }
-
-    for (unsigned i = 0; i < ESCARGOT_STRINGS_NUMBERS_MAX; i++) {
-        ASCIIStringData s = ::Escargot::dtoa(i);
-        numbers[i].init(atomicStringMap, s.data(), s.size());
-    }
-
-#define INIT_STATIC_STRING(name) name.init(atomicStringMap, #name, strlen(#name));
-    FOR_EACH_STATIC_STRING(INIT_STATIC_STRING)
-#undef INIT_STATIC_STRING
 }
 
 ::Escargot::String* StaticStrings::dtoa(double d) const

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -386,6 +386,135 @@ namespace Escargot {
     F(load)                       \
     F(getCanonicalLocales)
 
+#define FOR_EACH_STATIC_NUMBER(F) \
+    F(0)                          \
+    F(1)                          \
+    F(2)                          \
+    F(3)                          \
+    F(4)                          \
+    F(5)                          \
+    F(6)                          \
+    F(7)                          \
+    F(8)                          \
+    F(9)                          \
+    F(10)                         \
+    F(11)                         \
+    F(12)                         \
+    F(13)                         \
+    F(14)                         \
+    F(15)                         \
+    F(16)                         \
+    F(17)                         \
+    F(18)                         \
+    F(19)                         \
+    F(20)                         \
+    F(21)                         \
+    F(22)                         \
+    F(23)                         \
+    F(24)                         \
+    F(25)                         \
+    F(26)                         \
+    F(27)                         \
+    F(28)                         \
+    F(29)                         \
+    F(30)                         \
+    F(31)                         \
+    F(32)                         \
+    F(33)                         \
+    F(34)                         \
+    F(35)                         \
+    F(36)                         \
+    F(37)                         \
+    F(38)                         \
+    F(39)                         \
+    F(40)                         \
+    F(41)                         \
+    F(42)                         \
+    F(43)                         \
+    F(44)                         \
+    F(45)                         \
+    F(46)                         \
+    F(47)                         \
+    F(48)                         \
+    F(49)                         \
+    F(50)                         \
+    F(51)                         \
+    F(52)                         \
+    F(53)                         \
+    F(54)                         \
+    F(55)                         \
+    F(56)                         \
+    F(57)                         \
+    F(58)                         \
+    F(59)                         \
+    F(60)                         \
+    F(61)                         \
+    F(62)                         \
+    F(63)                         \
+    F(64)                         \
+    F(65)                         \
+    F(66)                         \
+    F(67)                         \
+    F(68)                         \
+    F(69)                         \
+    F(70)                         \
+    F(71)                         \
+    F(72)                         \
+    F(73)                         \
+    F(74)                         \
+    F(75)                         \
+    F(76)                         \
+    F(77)                         \
+    F(78)                         \
+    F(79)                         \
+    F(80)                         \
+    F(81)                         \
+    F(82)                         \
+    F(83)                         \
+    F(84)                         \
+    F(85)                         \
+    F(86)                         \
+    F(87)                         \
+    F(88)                         \
+    F(89)                         \
+    F(90)                         \
+    F(91)                         \
+    F(92)                         \
+    F(93)                         \
+    F(94)                         \
+    F(95)                         \
+    F(96)                         \
+    F(97)                         \
+    F(98)                         \
+    F(99)                         \
+    F(100)                        \
+    F(101)                        \
+    F(102)                        \
+    F(103)                        \
+    F(104)                        \
+    F(105)                        \
+    F(106)                        \
+    F(107)                        \
+    F(108)                        \
+    F(109)                        \
+    F(110)                        \
+    F(111)                        \
+    F(112)                        \
+    F(113)                        \
+    F(114)                        \
+    F(115)                        \
+    F(116)                        \
+    F(117)                        \
+    F(118)                        \
+    F(119)                        \
+    F(120)                        \
+    F(121)                        \
+    F(122)                        \
+    F(123)                        \
+    F(124)                        \
+    F(125)                        \
+    F(126)                        \
+    F(127)
 
 class StaticStrings {
 public:
@@ -434,15 +563,9 @@ public:
     AtomicString stringImport;
     AtomicString stringFinally;
     AtomicString stringExtends;
-    AtomicString stringFunction;
     AtomicString stringContinue;
     AtomicString stringDebugger;
     AtomicString stringInstanceof;
-    AtomicString stringImplements;
-    AtomicString stringInterface;
-    AtomicString stringPackage;
-    AtomicString stringYield;
-    AtomicString stringLet;
     AtomicString stringError;
 
     AtomicString defaultRegExpString;


### PR DESCRIPTION
 - Introduce INIT_STATIC_STRING macro to make adding new static string much easier.
 - Introduce AtomicString::initStaticString to append static string to the static string set directly
   without lookup for an already existing name.
 - Add a number list and remove the dtoa function call for the initialization of string numbers.
 - Split the single character initialization to ASCII and Latin1 string part.

Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu