### PR TITLE
Update lexical environment stuffs

### DIFF
--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -314,8 +314,8 @@ typedef uint16_t ByteCodeRegisterIndex;
 #define KEEP_NUMERAL_LITERDATA_IN_REGISTERFILE_LIMIT 16
 #endif
 
-typedef uint16_t LexcialBlockIndex;
-#define LEXCIAL_BLOCK_INDEX_MAX (std::numeric_limits<ByteCodeRegisterIndex>::max())
+typedef uint16_t LexicalBlockIndex;
+#define LEXICAL_BLOCK_INDEX_MAX (std::numeric_limits<LexicalBlockIndex>::max())
 
 #if !defined(STACK_GROWS_DOWN) && !defined(STACK_GROWS_UP)
 #define STACK_GROWS_DOWN

--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -92,12 +92,12 @@ void ByteCodeBlock::fillLocDataIfNeeded(Context* c)
     // TODO
     // give correct stack limit to parser
     if (m_codeBlock->asInterpretedCodeBlock()->isGlobalScopeCodeBlock()) {
-        RefPtr<ProgramNode> nd = esprima::parseProgram(c, m_codeBlock->asInterpretedCodeBlock()->src(), m_codeBlock->asInterpretedCodeBlock()->isStrict(), SIZE_MAX);
-        block = ByteCodeGenerator::generateByteCode(c, m_codeBlock->asInterpretedCodeBlock(), nd.get(), nd->scopeContext(), m_isEvalMode, m_isOnGlobal, true);
+        RefPtr<ProgramNode> nd = esprima::parseProgram(c, m_codeBlock->asInterpretedCodeBlock()->src(), m_codeBlock->asInterpretedCodeBlock()->isStrict(), m_codeBlock->inWith(), SIZE_MAX);
+        block = ByteCodeGenerator::generateByteCode(c, m_codeBlock->asInterpretedCodeBlock(), nd.get(), nd->scopeContext(), m_isEvalMode, m_isOnGlobal, false, true);
     } else {
         ASTFunctionScopeContext* scopeContext = nullptr;
         auto body = esprima::parseSingleFunction(c, m_codeBlock->asInterpretedCodeBlock(), scopeContext, SIZE_MAX);
-        block = ByteCodeGenerator::generateByteCode(c, m_codeBlock->asInterpretedCodeBlock(), body.get(), scopeContext, m_isEvalMode, m_isOnGlobal, true);
+        block = ByteCodeGenerator::generateByteCode(c, m_codeBlock->asInterpretedCodeBlock(), body.get(), scopeContext, m_isEvalMode, m_isOnGlobal, false, true);
     }
     m_locData = block->m_locData;
     block->m_locData = nullptr;

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -33,8 +33,9 @@ class LexicalEnvironment;
 struct GetObjectInlineCache;
 struct SetObjectInlineCache;
 struct EnumerateObjectData;
-class GetGlobalObject;
-class SetGlobalObject;
+class GetGlobalVariable;
+class SetGlobalVariable;
+class InitializeGlobalVariable;
 class CallFunctionInWithScope;
 class CallEvalFunction;
 class CreateClass;
@@ -79,8 +80,9 @@ public:
 
     static Object* fastToObject(ExecutionState& state, const Value& obj);
 
-    static Value getGlobalObjectSlowCase(ExecutionState& state, Object* go, GetGlobalObject* code, ByteCodeBlock* block);
-    static void setGlobalObjectSlowCase(ExecutionState& state, Object* go, SetGlobalObject* code, const Value& value, ByteCodeBlock* block);
+    static Value getGlobalVariableSlowCase(ExecutionState& state, Object* go, GetGlobalVariable* code, ByteCodeBlock* block);
+    static void setGlobalVariableSlowCase(ExecutionState& state, Object* go, SetGlobalVariable* code, const Value& value, ByteCodeBlock* block);
+    static void initializeGlobalVariable(ExecutionState& state, InitializeGlobalVariable* code, const Value& value);
 
     static size_t tryOperation(ExecutionState& state, TryOperation* code, LexicalEnvironment* env, size_t programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
 

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -33,98 +33,126 @@
 
 namespace Escargot {
 
-Value Script::execute(ExecutionState& state, bool isEvalMode, bool needNewEnv)
+Value Script::execute(ExecutionState& state, bool isExecuteOnEvalFunction, bool inStrictMode)
 {
-    ASSERT(m_topCodeBlock != nullptr);
-
-    LexicalEnvironment* globalEnvironment = new LexicalEnvironment(new GlobalEnvironmentRecord(state, m_topCodeBlock, state.context()->globalObject(), isEvalMode, !needNewEnv), nullptr);
     ExecutionState newState(state.context());
+    ExecutionState* codeExecutionState = &newState;
 
-    if (UNLIKELY(needNewEnv)) {
+    EnvironmentRecord* globalRecord = new GlobalEnvironmentRecord(state, m_topCodeBlock, state.context()->globalObject(), &state.context()->globalDeclarativeRecord(), &state.context()->globalDeclarativeStorage());
+    LexicalEnvironment* globalLexicalEnvironment = new LexicalEnvironment(globalRecord, nullptr);
+    newState.setLexicalEnvironment(globalLexicalEnvironment, m_topCodeBlock->isStrict());
+
+    if (inStrictMode && isExecuteOnEvalFunction) {
         // NOTE: ES5 10.4.2.1 eval in strict mode
-        newState.setParent(new ExecutionState(&state, globalEnvironment, m_topCodeBlock->isStrict()));
+        EnvironmentRecord* newVariableRecord = new DeclarativeEnvironmentRecordNotIndexed(state, true);
+        ExecutionState* newVariableState = new ExecutionState(state.context());
+        newVariableState->setLexicalEnvironment(new LexicalEnvironment(newVariableRecord, globalLexicalEnvironment), m_topCodeBlock->isStrict());
+        newVariableState->setParent(&newState);
+        codeExecutionState = newVariableState;
+    }
 
-        EnvironmentRecord* record = new DeclarativeEnvironmentRecordNotIndexed(state, m_topCodeBlock->identifierInfos());
-        newState.setLexicalEnvironment(new LexicalEnvironment(record, globalEnvironment), m_topCodeBlock->isStrict());
-    } else {
-        newState.setLexicalEnvironment(globalEnvironment, m_topCodeBlock->isStrict());
+    const InterpretedCodeBlock::IdentifierInfoVector& vec = m_topCodeBlock->identifierInfos();
+    size_t len = vec.size();
+    for (size_t i = 0; i < len; i++) {
+        // https://www.ecma-international.org/ecma-262/5.1/#sec-10.5
+        // Step 2. If code is eval code, then let configurableBindings be true.
+        if (vec[i].m_isVarDeclaration) {
+            codeExecutionState->lexicalEnvironment()->record()->createBinding(*codeExecutionState, vec[i].m_name, isExecuteOnEvalFunction, vec[i].m_isMutable, true);
+        }
+    }
+
+    if (!isExecuteOnEvalFunction) {
+        const auto& globalLexicalVector = m_topCodeBlock->blockInfo(0)->m_identifiers;
+        size_t len = globalLexicalVector.size();
+        for (size_t i = 0; i < len; i++) {
+            codeExecutionState->lexicalEnvironment()->record()->createBinding(*codeExecutionState, globalLexicalVector[i].m_name, false, globalLexicalVector[i].m_isMutable, false);
+        }
     }
 
     Value thisValue(state.context()->globalObject());
 
     size_t literalStorageSize = m_topCodeBlock->byteCodeBlock()->m_numeralLiteralData.size();
-    Value* registerFile = (Value*)alloca((m_topCodeBlock->byteCodeBlock()->m_requiredRegisterFileSizeInValueSize + 1 + literalStorageSize) * sizeof(Value));
+    Value* registerFile = (Value*)ALLOCA((m_topCodeBlock->byteCodeBlock()->m_requiredRegisterFileSizeInValueSize + 1 + literalStorageSize + m_topCodeBlock->lexicalBlockStackAllocatedIdentifierMaximumDepth()) * sizeof(Value), Value, state);
     registerFile[0] = Value();
     Value* stackStorage = registerFile + m_topCodeBlock->byteCodeBlock()->m_requiredRegisterFileSizeInValueSize;
     stackStorage[0] = thisValue;
-    Value* literalStorage = stackStorage + 1;
+    Value* literalStorage = stackStorage + 1 + m_topCodeBlock->lexicalBlockStackAllocatedIdentifierMaximumDepth();
     Value* src = m_topCodeBlock->byteCodeBlock()->m_numeralLiteralData.data();
     for (size_t i = 0; i < literalStorageSize; i++) {
         literalStorage[i] = src[i];
     }
 
-    Value resultValue = ByteCodeInterpreter::interpret(newState, m_topCodeBlock->byteCodeBlock(), 0, registerFile);
+    Value resultValue = ByteCodeInterpreter::interpret(*codeExecutionState, m_topCodeBlock->byteCodeBlock(), 0, registerFile);
     clearStack<512>();
 
     return resultValue;
 }
 
 // NOTE: eval by direct call
-Value Script::executeLocal(ExecutionState& state, Value thisValue, InterpretedCodeBlock* parentCodeBlock, bool needNewRecord)
+Value Script::executeLocal(ExecutionState& state, Value thisValue, InterpretedCodeBlock* parentCodeBlock, bool isStrictModeOutside, bool isEvalCodeOnFunction)
 {
     ASSERT(m_topCodeBlock != nullptr);
 
-    bool isOnGlobal = true;
-    FunctionEnvironmentRecord* fnRecord = nullptr;
-    {
-        LexicalEnvironment* env = state.lexicalEnvironment();
-        while (env) {
-            if (env->record()->isDeclarativeEnvironmentRecord() && env->record()->asDeclarativeEnvironmentRecord()->isFunctionEnvironmentRecord()) {
-                isOnGlobal = false;
-                fnRecord = env->record()->asDeclarativeEnvironmentRecord()->asFunctionEnvironmentRecord();
-                break;
-            }
-            env = env->outerEnvironment();
-        }
-    }
-
     EnvironmentRecord* record;
     bool inStrict = false;
-    if (UNLIKELY(needNewRecord)) {
+    if (UNLIKELY(isStrictModeOutside)) {
         // NOTE: ES5 10.4.2.1 eval in strict mode
         inStrict = true;
-        record = new DeclarativeEnvironmentRecordNotIndexed();
+        record = new DeclarativeEnvironmentRecordNotIndexed(state, true);
     } else {
         record = state.lexicalEnvironment()->record();
     }
 
     const InterpretedCodeBlock::IdentifierInfoVector& vec = m_topCodeBlock->identifierInfos();
-    size_t len = vec.size();
-    EnvironmentRecord* recordToAddVariable = record;
+    size_t vecLen = vec.size();
+
+    // test there was let on block scope
     LexicalEnvironment* e = state.lexicalEnvironment();
-    while (!recordToAddVariable->isEvalTarget()) {
+    while (e) {
+        if (e->record()->isDeclarativeEnvironmentRecord() && e->record()->asDeclarativeEnvironmentRecord()->isFunctionEnvironmentRecord()) {
+            break;
+        }
+        if (e->record()->isGlobalEnvironmentRecord()) {
+            break;
+        }
+
+        for (size_t i = 0; i < vecLen; i++) {
+            if (vec[i].m_isVarDeclaration) {
+                auto slot = e->record()->hasBinding(state, vec[i].m_name);
+                if (slot.m_isLexicallyDeclared && slot.m_index != SIZE_MAX) {
+                    ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, vec[i].m_name.string(), false, String::emptyString, errorMessage_DuplicatedIdentifier);
+                }
+            }
+        }
+
+        e = e->outerEnvironment();
+    }
+
+    EnvironmentRecord* recordToAddVariable = record;
+    e = state.lexicalEnvironment();
+    while (!recordToAddVariable->isVarDeclarationTarget()) {
         e = e->outerEnvironment();
         recordToAddVariable = e->record();
     }
-    for (size_t i = 0; i < len; i++) {
+    for (size_t i = 0; i < vecLen; i++) {
         if (vec[i].m_isVarDeclaration) {
             recordToAddVariable->createBinding(state, vec[i].m_name, inStrict ? false : true, true);
         }
     }
-    LexicalEnvironment* newEnvironment = new LexicalEnvironment(record, state.lexicalEnvironment());
 
+    LexicalEnvironment* newEnvironment = new LexicalEnvironment(record, state.lexicalEnvironment());
     ExecutionState newState(&state, newEnvironment, m_topCodeBlock->isStrict());
 
     size_t stackStorageSize = m_topCodeBlock->totalStackAllocatedVariableSize();
     size_t identifierOnStackCount = m_topCodeBlock->identifierOnStackCount();
     size_t literalStorageSize = m_topCodeBlock->byteCodeBlock()->m_numeralLiteralData.size();
-    Value* registerFile = ALLOCA((m_topCodeBlock->byteCodeBlock()->m_requiredRegisterFileSizeInValueSize + stackStorageSize + literalStorageSize) * sizeof(Value), Value, state);
+    Value* registerFile = ALLOCA((m_topCodeBlock->byteCodeBlock()->m_requiredRegisterFileSizeInValueSize + stackStorageSize + literalStorageSize + m_topCodeBlock->lexicalBlockStackAllocatedIdentifierMaximumDepth()) * sizeof(Value), Value, state);
     registerFile[0] = Value();
     Value* stackStorage = registerFile + m_topCodeBlock->byteCodeBlock()->m_requiredRegisterFileSizeInValueSize;
     for (size_t i = 0; i < identifierOnStackCount; i++) {
         stackStorage[i] = Value();
     }
-    Value* literalStorage = stackStorage + stackStorageSize;
+    Value* literalStorage = stackStorage + stackStorageSize + m_topCodeBlock->lexicalBlockStackAllocatedIdentifierMaximumDepth();
     Value* src = m_topCodeBlock->byteCodeBlock()->m_numeralLiteralData.data();
     for (size_t i = 0; i < literalStorageSize; i++) {
         literalStorage[i] = src[i];
@@ -132,8 +160,21 @@ Value Script::executeLocal(ExecutionState& state, Value thisValue, InterpretedCo
 
     stackStorage[0] = thisValue;
 
-    if (!isOnGlobal && m_topCodeBlock->usesArgumentsObject()) {
+    if (isEvalCodeOnFunction && m_topCodeBlock->usesArgumentsObject()) {
         AtomicString arguments = state.context()->staticStrings().arguments;
+
+        FunctionEnvironmentRecord* fnRecord = nullptr;
+        {
+            LexicalEnvironment* env = state.lexicalEnvironment();
+            while (env) {
+                if (env->record()->isDeclarativeEnvironmentRecord() && env->record()->asDeclarativeEnvironmentRecord()->isFunctionEnvironmentRecord()) {
+                    fnRecord = env->record()->asDeclarativeEnvironmentRecord()->asFunctionEnvironmentRecord();
+                    break;
+                }
+                env = env->outerEnvironment();
+            }
+        }
+
         if (fnRecord->hasBinding(newState, arguments).m_index == SIZE_MAX) {
             fnRecord->functionObject()->generateArgumentsObject(newState, fnRecord, nullptr);
         }

--- a/src/parser/Script.h
+++ b/src/parser/Script.h
@@ -52,7 +52,7 @@ public:
             Vector<StackTrace, GCUtil::gc_malloc_ignore_off_page_allocator<StackTrace>> stackTrace;
         } error;
     };
-    Value execute(ExecutionState& state, bool isEvalMode = false, bool needNewEnv = false);
+    Value execute(ExecutionState& state, bool isExecuteOnEvalFunction = false, bool inStrictMode = false);
     String* fileName()
     {
         return m_fileName;
@@ -69,7 +69,7 @@ public:
     }
 
 private:
-    Value executeLocal(ExecutionState& state, Value thisValue, InterpretedCodeBlock* parentCodeBlock, bool needNewEnv = false);
+    Value executeLocal(ExecutionState& state, Value thisValue, InterpretedCodeBlock* parentCodeBlock, bool isStrictModeOutside = false, bool isEvalCodeOnFunction = false);
     String* m_fileName;
     String* m_src;
     InterpretedCodeBlock* m_topCodeBlock;

--- a/src/parser/ScriptParser.h
+++ b/src/parser/ScriptParser.h
@@ -38,19 +38,19 @@ class ScriptParser : public gc {
 public:
     explicit ScriptParser(Context* c);
 
-    Script* initializeScript(ExecutionState& state, StringView scriptSource, String* fileName, InterpretedCodeBlock* parentCodeBlock, bool strictFromOutside, bool isEvalCodeInFunction, bool isEvalMode, bool isOnGlobal, size_t stackSizeRemain, bool needByteCodeGeneration = true);
-    Script* initializeScript(ExecutionState& state, String* scriptSource, String* fileName, bool strictFromOutside = false, bool isEvalCodeInFunction = false, bool isEvalMode = false, bool isOnGlobal = true, size_t stackSizeRemain = SIZE_MAX)
+    Script* initializeScript(ExecutionState& state, StringView scriptSource, String* fileName, InterpretedCodeBlock* parentCodeBlock, bool strictFromOutside, bool isEvalCodeInFunction, bool isEvalMode, bool inWithOperation, size_t stackSizeRemain, bool needByteCodeGeneration);
+    Script* initializeScript(ExecutionState& state, String* scriptSource, String* fileName, bool strictFromOutside = false, bool isRunningEvalOnFunction = false, bool isEvalMode = false, size_t stackSizeRemain = SIZE_MAX)
     {
-        return initializeScript(state, StringView(scriptSource, 0, scriptSource->length()), fileName, nullptr, strictFromOutside, isEvalCodeInFunction, isEvalMode, isOnGlobal, stackSizeRemain);
+        return initializeScript(state, StringView(scriptSource, 0, scriptSource->length()), fileName, nullptr, strictFromOutside, isRunningEvalOnFunction, isEvalMode, false, stackSizeRemain, true);
     }
 
     void generateFunctionByteCode(ExecutionState& state, InterpretedCodeBlock* codeBlock, size_t stackSizeRemain);
 
 private:
-    InterpretedCodeBlock* generateCodeBlockTreeFromAST(Context* ctx, StringView source, Script* script, ProgramNode* program);
-    InterpretedCodeBlock* generateCodeBlockTreeFromASTWalker(Context* ctx, StringView source, Script* script, ASTFunctionScopeContext* scopeCtx, InterpretedCodeBlock* parentCodeBlock);
+    InterpretedCodeBlock* generateCodeBlockTreeFromAST(Context* ctx, StringView source, Script* script, ProgramNode* program, bool isEvalCode, bool isEvalCodeInFunction);
+    InterpretedCodeBlock* generateCodeBlockTreeFromASTWalker(Context* ctx, StringView source, Script* script, ASTFunctionScopeContext* scopeCtx, InterpretedCodeBlock* parentCodeBlock, bool isEvalCode, bool isEvalCodeInFunction);
     void generateCodeBlockTreeFromASTWalkerPostProcess(InterpretedCodeBlock* cb);
-    void generateProgramCodeBlock(ExecutionState& state, StringView scriptSource, Script* script, InterpretedCodeBlock* parentCodeBlock, bool strictFromOutside, bool isEvalCodeInFunction, bool isEvalMode, bool isOnGlobal, size_t stackSizeRemain, bool needByteCodeGeneration);
+    void generateProgramCodeBlock(ExecutionState& state, StringView scriptSource, Script* script, InterpretedCodeBlock* parentCodeBlock, bool strictFromOutside, bool isEvalCodeInFunction, bool isEvalMode, bool inWithOperation, size_t stackSizeRemain, bool needByteCodeGeneration);
 #ifndef NDEBUG
     void dumpCodeBlockTree(InterpretedCodeBlock* topCodeBlock);
 #endif

--- a/src/parser/ast/ArrayPatternNode.h
+++ b/src/parser/ast/ArrayPatternNode.h
@@ -73,7 +73,7 @@ public:
 
         if (m_default != nullptr) {
             size_t undefinedIndex = context->getRegister();
-            codeBlock->pushCode(GetGlobalObject(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+            codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
             size_t cmpIndex = context->getRegister();
             codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), m_initIdx, undefinedIndex, cmpIndex), context, this);
@@ -110,7 +110,7 @@ public:
                 } else if (element->isAssignmentExpressionSimple()) {
                     AssignmentExpressionSimpleNode* assignNode = element->asAssignmentExpressionSimple();
                     size_t undefinedIndex = context->getRegister();
-                    codeBlock->pushCode(GetGlobalObject(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+                    codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
                     size_t cmpIndex = context->getRegister();
                     codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), iteratorValueIdx, undefinedIndex, cmpIndex), context, this);

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -84,8 +84,6 @@ public:
             }
         }
         ASSERT(blk);
-        if (context->m_isWithScope && !context->m_isEvalCode)
-            blk->setInWithScope();
         codeBlock->pushCode(CreateFunction(ByteCodeLOC(m_loc.index), dstIndex, blk), context, this);
         context->m_feCounter++;
     }

--- a/src/parser/ast/BlockStatementNode.h
+++ b/src/parser/ast/BlockStatementNode.h
@@ -56,7 +56,7 @@ public:
 
         size_t lexicalBlockIndexBefore = context->m_lexicalBlockIndex;
         ByteCodeBlock::ByteCodeLexicalBlockContext blockContext;
-        if (m_lexicalBlockIndex != LEXCIAL_BLOCK_INDEX_MAX) {
+        if (m_lexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
             context->m_lexicalBlockIndex = m_lexicalBlockIndex;
             InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(m_lexicalBlockIndex);
             blockContext = codeBlock->pushLexicalBlock(context, bi, this);
@@ -65,7 +65,7 @@ public:
         size_t start = codeBlock->currentCodeSize();
         m_container->generateStatementByteCode(codeBlock, context);
 
-        if (m_lexicalBlockIndex != LEXCIAL_BLOCK_INDEX_MAX) {
+        if (m_lexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
             codeBlock->finalizeLexicalBlock(context, blockContext);
             context->m_lexicalBlockIndex = lexicalBlockIndexBefore;
         }
@@ -79,7 +79,7 @@ public:
 private:
     RefPtr<StatementContainer> m_container;
     RefPtr<StatementContainer> m_argumentInitializers;
-    LexcialBlockIndex m_lexicalBlockIndex;
+    LexicalBlockIndex m_lexicalBlockIndex;
 };
 }
 

--- a/src/parser/ast/CatchClauseNode.h
+++ b/src/parser/ast/CatchClauseNode.h
@@ -33,12 +33,12 @@ class FunctionDeclarationNode;
 class CatchClauseNode : public Node {
 public:
     friend class ScriptParser;
-    CatchClauseNode(Node *param, Node *guard, Node *body, std::vector<FunctionDeclarationNode *> &fd)
+    CatchClauseNode(Node *param, Node *guard, Node *body, LexicalBlockIndex paramLexicalBlockIndex)
         : Node()
-        , m_param((IdentifierNode *)param)
+        , m_param(param)
         , m_guard((ExpressionNode *)guard)
         , m_body((BlockStatementNode *)body)
-        , m_innerFDs(std::move(fd))
+        , m_paramLexicalBlockIndex(paramLexicalBlockIndex)
     {
     }
 
@@ -46,7 +46,7 @@ public:
     {
     }
 
-    IdentifierNode *param()
+    Node *param()
     {
         return m_param.get();
     }
@@ -56,17 +56,17 @@ public:
         return m_body.get();
     }
 
-    std::vector<FunctionDeclarationNode *> &innerFDs()
+    LexicalBlockIndex paramLexicalBlockIndex()
     {
-        return m_innerFDs;
+        return m_paramLexicalBlockIndex;
     }
 
     virtual ASTNodeType type() { return ASTNodeType::CatchClause; }
 private:
-    RefPtr<IdentifierNode> m_param;
+    RefPtr<Node> m_param;
     RefPtr<ExpressionNode> m_guard;
     RefPtr<BlockStatementNode> m_body;
-    std::vector<FunctionDeclarationNode *> m_innerFDs;
+    LexicalBlockIndex m_paramLexicalBlockIndex;
 };
 
 typedef std::vector<RefPtr<Node>> CatchClauseNodeVector;

--- a/src/parser/ast/ClassDeclarationNode.h
+++ b/src/parser/ast/ClassDeclarationNode.h
@@ -29,9 +29,9 @@ namespace Escargot {
 class ClassDeclarationNode : public StatementNode {
 public:
     friend class ScriptParser;
-    ClassDeclarationNode(RefPtr<IdentifierNode> id, RefPtr<Node> superClass, RefPtr<ClassBodyNode> classBody)
+    ClassDeclarationNode(RefPtr<IdentifierNode> id, RefPtr<Node> superClass, RefPtr<ClassBodyNode> classBody, LexicalBlockIndex classBodyLexicalBlockIndex)
         : StatementNode()
-        , m_class(id, superClass, classBody)
+        , m_class(id, superClass, classBody, classBodyLexicalBlockIndex)
     {
     }
 
@@ -47,7 +47,13 @@ public:
         context->m_classInfo.m_superIndex = m_class.superClass() ? context->getRegister() : SIZE_MAX;
         context->m_classInfo.m_name = classIdent ? classIdent.get()->name() : AtomicString();
 
-        codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), classIndex, context->m_classInfo.m_bodyIndex, context->m_classInfo.m_superIndex, context->m_classInfo.m_name, nullptr, 1), context, this);
+        size_t lexicalBlockIndexBefore = context->m_lexicalBlockIndex;
+        ByteCodeBlock::ByteCodeLexicalBlockContext blockContext;
+        if (m_class.classBodyLexicalBlockIndex() != LEXICAL_BLOCK_INDEX_MAX) {
+            context->m_lexicalBlockIndex = m_class.classBodyLexicalBlockIndex();
+            InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(m_class.classBodyLexicalBlockIndex());
+            blockContext = codeBlock->pushLexicalBlock(context, bi, this);
+        }
 
         if (m_class.superClass() != nullptr) {
             m_class.superClass()->generateExpressionByteCode(codeBlock, context, context->m_classInfo.m_superIndex);
@@ -56,15 +62,24 @@ public:
         if (m_class.classBody()->hasConstructor()) {
             m_class.classBody()->constructor()->generateExpressionByteCode(codeBlock, context, classIndex);
         } else {
-            codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), classIndex, context->m_classInfo.m_bodyIndex, context->m_classInfo.m_superIndex, context->m_classInfo.m_name, nullptr, 2), context, this);
+            codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), classIndex, context->m_classInfo.m_bodyIndex, context->m_classInfo.m_superIndex, context->m_classInfo.m_name, nullptr), context, this);
         }
 
         m_class.classBody()->generateClassInitializer(codeBlock, context, classIndex);
 
-        codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), classIndex, context->m_classInfo.m_bodyIndex, context->m_classInfo.m_superIndex, context->m_classInfo.m_name, nullptr, 3), context, this);
+        if (m_class.classBodyLexicalBlockIndex() != LEXICAL_BLOCK_INDEX_MAX) {
+            // Initialize class name
+            context->m_isLexicallyDeclaredBindingInitialization = true;
+            classIdent->generateStoreByteCode(codeBlock, context, classIndex, false);
+            ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
 
-        classIdent->generateResolveAddressByteCode(codeBlock, context);
+            codeBlock->finalizeLexicalBlock(context, blockContext);
+            context->m_lexicalBlockIndex = lexicalBlockIndexBefore;
+        }
+
+        context->m_isLexicallyDeclaredBindingInitialization = true;
         classIdent->generateStoreByteCode(codeBlock, context, classIndex, false);
+        ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
 
         if (context->m_classInfo.m_superIndex != SIZE_MAX) {
             context->giveUpRegister(); // for drop m_superIndex

--- a/src/parser/ast/ClassNode.h
+++ b/src/parser/ast/ClassNode.h
@@ -27,8 +27,9 @@ namespace Escargot {
 
 class ClassNode {
 public:
-    ClassNode(RefPtr<IdentifierNode>& id, RefPtr<Node> superClass, RefPtr<ClassBodyNode> classBody)
-        : m_id(id)
+    ClassNode(RefPtr<IdentifierNode>& id, RefPtr<Node> superClass, RefPtr<ClassBodyNode> classBody, LexicalBlockIndex classBodyLexicalBlockIndex)
+        : m_classBodyLexicalBlockIndex(classBodyLexicalBlockIndex)
+        , m_id(id)
         , m_superClass(superClass)
         , m_classBody(classBody)
     {
@@ -38,7 +39,9 @@ public:
     inline const RefPtr<IdentifierNode>& id() { return m_id; }
     inline const RefPtr<Node> superClass() { return m_superClass; }
     inline const RefPtr<ClassBodyNode> classBody() { return m_classBody; }
+    inline LexicalBlockIndex classBodyLexicalBlockIndex() { return m_classBodyLexicalBlockIndex; }
 private:
+    LexicalBlockIndex m_classBodyLexicalBlockIndex;
     RefPtr<IdentifierNode> m_id; // Id
     RefPtr<Node> m_superClass;
     RefPtr<ClassBodyNode> m_classBody;

--- a/src/parser/ast/DefaultArgumentNode.h
+++ b/src/parser/ast/DefaultArgumentNode.h
@@ -56,7 +56,7 @@ public:
     virtual void generateResultNotRequiredExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context)
     {
         size_t undefinedIndex = context->getRegister();
-        codeBlock->pushCode(GetGlobalObject(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+        codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
         size_t src0 = m_left->getRegister(codeBlock, context);
         m_left->generateExpressionByteCode(codeBlock, context, src0);

--- a/src/parser/ast/FunctionExpressionNode.h
+++ b/src/parser/ast/FunctionExpressionNode.h
@@ -56,11 +56,8 @@ public:
             }
         }
         ASSERT(blk);
-        if (context->m_isWithScope && !context->m_isEvalCode)
-            blk->setInWithScope();
-
         if (UNLIKELY(blk->isClassConstructor())) {
-            codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), dstIndex, context->m_classInfo.m_bodyIndex, context->m_classInfo.m_superIndex, context->m_classInfo.m_name, blk, 2), context, this);
+            codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), dstIndex, context->m_classInfo.m_bodyIndex, context->m_classInfo.m_superIndex, context->m_classInfo.m_name, blk), context, this);
         } else {
             codeBlock->pushCode(CreateFunction(ByteCodeLOC(m_loc.index), dstIndex, blk), context, this);
         }

--- a/src/parser/ast/ObjectPatternNode.h
+++ b/src/parser/ast/ObjectPatternNode.h
@@ -83,7 +83,7 @@ public:
 
             if (value != nullptr && !value->isPattern()) {
                 size_t undefinedIndex = context->getRegister();
-                codeBlock->pushCode(GetGlobalObject(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+                codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
                 size_t cmpIndex = context->getRegister();
                 codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), objIndex, undefinedIndex, cmpIndex), context, this);
@@ -123,7 +123,7 @@ public:
                 }
 
                 size_t undefinedIndex = context->getRegister();
-                codeBlock->pushCode(GetGlobalObject(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+                codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
                 size_t cmpIndex = context->getRegister();
                 codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), valueIndex, undefinedIndex, cmpIndex), context, this);

--- a/src/parser/esprima_cpp/esprima.h
+++ b/src/parser/esprima_cpp/esprima.h
@@ -58,7 +58,7 @@ struct Error : public gc {
 
 #define ESPRIMA_RECURSIVE_LIMIT 1024
 
-RefPtr<ProgramNode> parseProgram(::Escargot::Context* ctx, StringView source, bool strictFromOutside, size_t stackRemain);
+RefPtr<ProgramNode> parseProgram(::Escargot::Context* ctx, StringView source, bool strictFromOutside, bool inWith, size_t stackRemain);
 RefPtr<Node> parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock* codeBlock, ASTFunctionScopeContext*& scopeContext, size_t stackRemain);
 }
 }

--- a/src/runtime/Context.h
+++ b/src/runtime/Context.h
@@ -42,6 +42,15 @@ class JobQueue;
 class ByteCodeBlock;
 class ToStringRecursionPreventer;
 
+struct IdentifierRecord {
+    AtomicString m_name;
+    bool m_canDelete : 1;
+    bool m_isMutable : 1;
+    bool m_isVarDeclaration : 1;
+};
+
+typedef Vector<IdentifierRecord, GCUtil::gc_malloc_atomic_ignore_off_page_allocator<IdentifierRecord>> IdentifierRecordVector;
+
 typedef Value (*VirtualIdentifierCallback)(ExecutionState& state, Value name);
 typedef Value (*SecurityPolicyCheckCallback)(ExecutionState& state, bool isEval);
 
@@ -190,6 +199,16 @@ public:
         return m_securityPolicyCheckCallback;
     }
 
+    IdentifierRecordVector& globalDeclarativeRecord()
+    {
+        return m_globalDeclarativeRecord;
+    }
+
+    SmallValueVector& globalDeclarativeStorage()
+    {
+        return m_globalDeclarativeStorage;
+    }
+
 private:
     VMInstance* m_instance;
 
@@ -199,6 +218,8 @@ private:
     StaticStrings& m_staticStrings;
     GlobalObject* m_globalObject;
     ScriptParser* m_scriptParser;
+    IdentifierRecordVector m_globalDeclarativeRecord;
+    SmallValueVector m_globalDeclarativeStorage;
     Vector<CodeBlock*, GCUtil::gc_malloc_ignore_off_page_allocator<CodeBlock*>>& m_compiledCodeBlocks;
     WTF::BumpPointerAllocator* m_bumpPointerAllocator;
     RegExpCacheMap* m_regexpCache;

--- a/src/runtime/ErrorObject.cpp
+++ b/src/runtime/ErrorObject.cpp
@@ -26,6 +26,7 @@ const char* errorMessage_NotImplemented = "Not implemented";
 const char* errorMessage_IsNotDefined = "%s is not defined";
 const char* errorMessage_IsNotInitialized = "Cannot access '%s' before initialization";
 const char* errorMessage_DuplicatedIdentifier = "Identifier '%s' has already been declared";
+const char* errorMessage_TooManyGlobalLexicalVariables = "There are too many global lexical variables in script";
 const char* errorMessage_AssignmentToConstantVariable = "Assignment to constant variable '%s'";
 const char* errorMessage_DefineProperty_Default = "Cannot define property '%s'";
 const char* errorMessage_DefineProperty_LengthNotWritable = "Cannot modify property '%s': 'length' is not writable";

--- a/src/runtime/ErrorObject.h
+++ b/src/runtime/ErrorObject.h
@@ -31,6 +31,7 @@ extern const char* errorMessage_NotImplemented; // FIXME to be removed
 extern const char* errorMessage_IsNotDefined;
 extern const char* errorMessage_IsNotInitialized;
 extern const char* errorMessage_DuplicatedIdentifier;
+extern const char* errorMessage_TooManyGlobalLexicalVariables;
 extern const char* errorMessage_AssignmentToConstantVariable;
 extern const char* errorMessage_DefineProperty_Default;
 extern const char* errorMessage_DefineProperty_LengthNotWritable;

--- a/src/runtime/ExecutionState.h
+++ b/src/runtime/ExecutionState.h
@@ -56,7 +56,6 @@ public:
         , m_registerFile(nullptr)
         , m_parent(1)
         , m_inStrictMode(false)
-        , m_onGoingClassConstruction(false)
         , m_onGoingSuperCall(false)
     {
         volatile int sp;
@@ -70,7 +69,6 @@ public:
         , m_registerFile(registerFile)
         , m_parent((size_t)parent + 1)
         , m_inStrictMode(inStrictMode)
-        , m_onGoingClassConstruction(false)
         , m_onGoingSuperCall(false)
     {
     }
@@ -82,7 +80,6 @@ public:
         , m_registerFile(registerFile)
         , m_parent((size_t)parent + 1)
         , m_inStrictMode(inStrictMode)
-        , m_onGoingClassConstruction(false)
         , m_onGoingSuperCall(false)
     {
     }
@@ -161,19 +158,9 @@ public:
         return m_inStrictMode;
     }
 
-    bool isOnGoingClassConstruction()
-    {
-        return m_onGoingClassConstruction;
-    }
-
     bool isOnGoingSuperCall()
     {
         return m_onGoingSuperCall;
-    }
-
-    void setOnGoingClassConstruction(bool startClassConstruction)
-    {
-        m_onGoingClassConstruction = startClassConstruction;
     }
 
     void setOnGoingSuperCall(bool onGoingSuperCall)
@@ -198,7 +185,6 @@ private:
     };
 
     bool m_inStrictMode : 1;
-    bool m_onGoingClassConstruction : 1;
     bool m_onGoingSuperCall : 1;
 };
 }

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -217,7 +217,7 @@ public:
     void installOthers(ExecutionState& state);
 
     Value eval(ExecutionState& state, const Value& arg);
-    Value evalLocal(ExecutionState& state, const Value& arg, Value thisValue, InterpretedCodeBlock* parentCodeBlock);
+    Value evalLocal(ExecutionState& state, const Value& arg, Value thisValue, InterpretedCodeBlock* parentCodeBlock, bool inWithOperation); // we get isInWithOperation as parameter because this affects bytecode
 
     virtual const char* internalClassProperty()
     {

--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -73,7 +73,7 @@ static Value builtinFunctionConstructor(ExecutionState& state, Value thisValue, 
         srcToTest.appendString("\r\n){ }");
         String* cur = srcToTest.finalize(&state);
         state.context()->vmInstance()->parsedSourceCodes().push_back(cur);
-        esprima::parseProgram(state.context(), StringView(cur, 0, cur->length()), false, SIZE_MAX);
+        esprima::parseProgram(state.context(), StringView(cur, 0, cur->length()), false, false, SIZE_MAX);
     } catch (esprima::Error& orgError) {
         ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "there is a script parse error in parameter name");
     }
@@ -108,7 +108,7 @@ static Value builtinFunctionConstructor(ExecutionState& state, Value thisValue, 
     Script* script = parser.initializeScript(state, StringView(scriptSource, 0, scriptSource->length()), new ASCIIString("Function Constructor input"), nullptr, false, false, false, false, SIZE_MAX, false);
     InterpretedCodeBlock* cb = script->topCodeBlock()->childBlocks()[0];
     cb->updateSourceElementStart(3, 1);
-    LexicalEnvironment* globalEnvironment = new LexicalEnvironment(new GlobalEnvironmentRecord(state, script->topCodeBlock(), state.context()->globalObject()), nullptr);
+    LexicalEnvironment* globalEnvironment = new LexicalEnvironment(new GlobalEnvironmentRecord(state, script->topCodeBlock(), state.context()->globalObject(), &state.context()->globalDeclarativeRecord(), &state.context()->globalDeclarativeStorage()), nullptr);
     return new FunctionObject(state, cb, globalEnvironment);
 }
 

--- a/src/runtime/PropertyName.h
+++ b/src/runtime/PropertyName.h
@@ -88,6 +88,12 @@ public:
         return ((String*)m_data);
     }
 
+    AtomicString asAtomicString() const
+    {
+        ASSERT(hasAtomicString());
+        return AtomicString(((String*)(m_data - PROPERTY_NAME_ATOMIC_STRING_VIAS)));
+    }
+
     bool isIndexString() const
     {
         return isPlainString() && ::Escargot::isIndexString(plainString());

--- a/src/runtime/SmallValue.h
+++ b/src/runtime/SmallValue.h
@@ -144,6 +144,18 @@ extern size_t g_doubleInSmallValueTag;
 
 class SmallValue {
 public:
+    enum ForceUninitializedTag { ForceUninitialized };
+    enum EmptyValueInitTag { EmptyValue };
+
+    SmallValue(ForceUninitializedTag)
+    {
+    }
+
+    SmallValue(EmptyValueInitTag)
+    {
+        m_data.payload = (intptr_t)(ValueEmpty);
+    }
+
     SmallValue()
     {
         m_data.payload = (intptr_t)(ValueUndefined);

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -39,7 +39,7 @@ NEVER_INLINE bool eval(Escargot::Context* context, Escargot::String* str, Escarg
 
     Escargot::SandBox::SandBoxResult sandBoxResult = sb.run([&]() -> Escargot::Value {
         Escargot::Script* script = context->scriptParser().initializeScript(state, str, fileName);
-        return script->execute(stateForInit, false, false);
+        return script->execute(stateForInit);
     });
 
     result.result = sandBoxResult.result;

--- a/src/util/Vector.h
+++ b/src/util/Vector.h
@@ -226,6 +226,18 @@ public:
         return m_buffer[idx];
     }
 
+    T& at(const size_t& idx)
+    {
+        ASSERT(idx < m_size);
+        return m_buffer[idx];
+    }
+
+    const T& at(const size_t& idx) const
+    {
+        ASSERT(idx < m_size);
+        return m_buffer[idx];
+    }
+
     T* data()
     {
         return m_buffer;

--- a/test/es2015/for-statment-per-iteration-lexcial-env.js
+++ b/test/es2015/for-statment-per-iteration-lexcial-env.js
@@ -1,0 +1,146 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assertCount = 0;
+function assertAndCount(e) {
+    assert(e)
+    assertCount++;
+}
+
+var count = 0;
+
+for (let x = 0; x < 5;) {
+  x++;
+  for (let y = 0; y < 2;) {
+    y++;
+    count++;
+    continue;
+  }
+}
+assertAndCount(count == 10)
+
+count = 0;
+for (let x = 0; x < 5;) {
+  x++;
+  for (let y = 0; y < 2;) {
+    y++;
+    count++;
+    try {
+      continue;
+    } catch(e) {}
+  }
+}
+assertAndCount(count == 10)
+
+
+function fun() {
+
+  count = 0;
+  for (let x = 0; x < 5;) {
+    x++;
+    for (let y = 0; y < 2;) {
+      y++;
+      count++;
+      continue;
+    }
+  }
+  assertAndCount(count == 10)
+
+  count = 0;
+  for (let x = 0; x < 5;) {
+    x++;
+    for (let y = 0; y < 2;) {
+      y++;
+      count++;
+      try {
+          continue;
+      } catch(e) {}
+    }
+  }
+  assertAndCount(count == 10)
+}
+
+fun();
+
+
+count = 0;
+for (let x = 0; x < 5;) {
+  x++;
+  for (let y = 0; y < 2;) {
+    y++;
+    count++; function capture() { y }
+    continue;
+  }
+}
+assertAndCount(count == 10)
+
+count = 0;
+for (let x = 0; x < 5;) {
+  x++;
+  for (let y = 0; y < 2;) {
+    y++;
+    count++; function capture() { y }
+    try {
+      continue;
+    } catch(e) {}
+  }
+}
+assertAndCount(count == 10)
+
+
+function fun2() {
+
+  count = 0;
+  for (let x = 0; x < 5;) {
+    x++;
+    for (let y = 0; y < 2;) {
+      y++;
+      count++; function capture() { y }
+      continue;
+    }
+  }
+  assertAndCount(count == 10)
+
+  count = 0;
+  for (let x = 0; x < 5;) {
+    x++;
+    for (let y = 0; y < 2;) {
+      y++;
+      count++; function capture() { y }
+      try {
+          continue;
+      } catch(e) {}
+    }
+  }
+  assertAndCount(count == 10)
+}
+
+fun2();
+
+count = 0;
+for (let x = 0; x < 5;) {
+  x++;
+  for (let y = 0; y < 2;) {
+    y++;
+    count++;
+    try {
+      break;
+    } catch(e) {}
+  }
+}
+assertAndCount(count == 5)
+
+
+assert(assertCount == 9)

--- a/test/es2015/generator.js
+++ b/test/es2015/generator.js
@@ -117,34 +117,38 @@ assert(gen.next().value === 'b');
 assert(gen.next().done === true);
 
 // Generator as an object methodSection
-class Foo {
-  *generator () {
-    yield 1;
-    yield 2;
-    yield 3;
+{
+  class Foo {
+    *generator () {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
   }
+
+  var f = new Foo ();
+  var gen = f.generator();
+
+  assert(gen.next().value === 1);
+  assert(gen.next().value === 2);
+  assert(gen.next().value === 3);
+  assert(gen.next().done === true);
 }
 
-var f = new Foo ();
-var gen = f.generator();
-
-assert(gen.next().value === 1);
-assert(gen.next().value === 2);
-assert(gen.next().value === 3);
-assert(gen.next().done === true);
-
-// Generator as a computed property
-class Foo {
-  *[Symbol.iterator] () {
-    yield 1;
-    yield 2;
+{
+  // Generator as a computed property
+  class Foo {
+    *[Symbol.iterator] () {
+      yield 1;
+      yield 2;
+    }
   }
-}
 
-var array = Array.from(new Foo);
-assert(array.length === 2);
-assert(array[0] === 1);
-assert(array[1] === 2);
+  var array = Array.from(new Foo);
+  assert(array.length === 2);
+  assert(array[0] === 1);
+  assert(array[1] === 2);
+}
 
 var SomeObj = {
   *[Symbol.iterator] () {

--- a/test/es2015/treat-catch-variable-as-let.js
+++ b/test/es2015/treat-catch-variable-as-let.js
@@ -1,0 +1,85 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// pass if there is no compile error
+function fo() {
+  try {} catch(e) {}
+  var e;
+}
+
+function foo() {
+    try {
+  } catch(e) {
+    try {
+
+    } catch(e2) {
+        var e;
+    }
+  }
+}
+
+
+function F()
+{
+  e = 100;
+  assert(e == 100)
+  try
+  {
+      throw 200;
+      assert(false)
+  }
+  catch(e)
+  {
+    assert(e == 200)
+    var e = 300;
+    assert(e == 300)
+  }
+
+  assert(e == 100)
+}
+
+F()
+
+function F2()
+{
+  try
+  {
+      throw 200;
+      assert(false)
+  }
+  catch(e)
+  {
+    var e;
+  }
+
+  assert(e === undefined)
+}
+
+F2()
+
+try {
+  eval("try {} catch(e) { function e() {} }")
+  assert(false)
+} catch (e) {
+  assert(e instanceof SyntaxError)
+}
+
+try {
+  eval("try {} catch([e]) { var e }")
+  assert(false)
+} catch (e) {
+  assert(e instanceof SyntaxError)
+}
+


### PR DESCRIPTION
* treat variable in catch() as let
* add lexical environment record data into global environment for saving global permanently
* re-implement variable access bytecode generation
* re-implement class initialize operation
* re-implement global variable access bytecode for support lexcial variables in global
* fix bugs related with per-iteration lexical environment in for-statement

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>