### PR TITLE
Don't update the inlineCache if the referred property is removed.

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -1850,6 +1850,11 @@ NEVER_INLINE void ByteCodeInterpreter::setObjectPreComputedCaseOperationCacheMis
         newItem.m_objectStructure = obj->structure();
 
         obj->setOwnPropertyThrowsExceptionWhenStrictMode(state, idx, value, willBeObject);
+        // Don't update the inline cache if the property is removed by a setter function.
+        if (UNLIKELY(obj->structure()->findProperty(state, name) == SIZE_MAX)) {
+            return;
+        }
+
         auto desc = obj->structure()->readProperty(state, idx).m_descriptor;
         if (desc.isPlainDataProperty() && desc.isWritable()) {
             inlineCache.m_cachedIndex = idx;

--- a/test/regression-tests/issue-289.js
+++ b/test/regression-tests/issue-289.js
@@ -1,0 +1,22 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var o = { set foo (a) { var a = delete o.foo } };
+
+o.foo = 0;
+assert(typeof o.foo === 'undefined');
+
+o.foo = 1;
+assert(o.foo === 1);


### PR DESCRIPTION
There can be cases when the object properties are removed in their setter functions. 
This patch fixes #289.