### PR TITLE
Improve performance

### DIFF
--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -65,6 +65,16 @@ int ByteCode::dumpJumpPosition(size_t pos, const char* byteCodeStart)
 {
     return (int)(pos - (size_t)byteCodeStart);
 }
+
+void GetGlobalVariable::dump(const char* byteCodeStart)
+{
+    printf("get global variable r%d <- global.%s", (int)m_registerIndex, m_slot->m_propertyName.string()->toUTF8StringData().data());
+}
+
+void SetGlobalVariable::dump(const char* byteCodeStart)
+{
+    printf("set global variable global.%s <- r%d", m_slot->m_propertyName.string()->toUTF8StringData().data(), (int)m_registerIndex);
+}
 #endif
 
 void* ByteCodeBlock::operator new(size_t size)

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -30,6 +30,7 @@
 namespace Escargot {
 class ObjectStructure;
 class Node;
+struct GlobalVariableAccessCacheItem;
 
 // <OpcodeName, PushCount, PopCount>
 #define FOR_EACH_BYTECODE_OP(F)                       \
@@ -831,58 +832,37 @@ public:
 #endif
 };
 
-// TODO store these variables in Context and share it for performance
 class GetGlobalVariable : public ByteCode {
 public:
-    GetGlobalVariable(const ByteCodeLOC& loc, const size_t registerIndex, PropertyName propertyName)
+    GetGlobalVariable(const ByteCodeLOC& loc, const size_t registerIndex, GlobalVariableAccessCacheItem* slot)
         : ByteCode(Opcode::GetGlobalVariableOpcode, loc)
         , m_registerIndex(registerIndex)
-        , m_lexicalIndexCache(std::numeric_limits<uint16_t>::max())
-        , m_propertyName(propertyName)
+        , m_slot(slot)
     {
-        ASSERT(propertyName.hasAtomicString());
-        m_cachedAddress = nullptr;
-        m_cachedStructure = nullptr;
     }
 
     ByteCodeRegisterIndex m_registerIndex;
-    uint16_t m_lexicalIndexCache;
-    PropertyName m_propertyName;
-    void* m_cachedAddress;
-    ObjectStructure* m_cachedStructure;
+    GlobalVariableAccessCacheItem* m_slot;
+
 #ifndef NDEBUG
-    void dump(const char* byteCodeStart)
-    {
-        printf("get global variable r%d <- global.%s", (int)m_registerIndex, m_propertyName.plainString()->toUTF8StringData().data());
-    }
+    void dump(const char* byteCodeStart);
 #endif
 };
 
-// TODO store these variables in Context and share it for performance
 class SetGlobalVariable : public ByteCode {
 public:
-    SetGlobalVariable(const ByteCodeLOC& loc, const size_t registerIndex, PropertyName propertyName)
+    SetGlobalVariable(const ByteCodeLOC& loc, const size_t registerIndex, GlobalVariableAccessCacheItem* slot)
         : ByteCode(Opcode::SetGlobalVariableOpcode, loc)
         , m_registerIndex(registerIndex)
-        , m_lexicalIndexCache(std::numeric_limits<uint16_t>::max())
-        , m_propertyName(propertyName)
+        , m_slot(slot)
     {
-        ASSERT(propertyName.hasAtomicString());
-        m_cachedAddress = nullptr;
-        m_cachedStructure = nullptr;
     }
 
     ByteCodeRegisterIndex m_registerIndex;
-    uint16_t m_lexicalIndexCache;
-    PropertyName m_propertyName;
-    void* m_cachedAddress;
-    ObjectStructure* m_cachedStructure;
+    GlobalVariableAccessCacheItem* m_slot;
 
 #ifndef NDEBUG
-    void dump(const char* byteCodeStart)
-    {
-        printf("set global variable global.%s <- r%d", m_propertyName.plainString()->toUTF8StringData().data(), (int)m_registerIndex);
-    }
+    void dump(const char* byteCodeStart);
 #endif
 };
 

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -33,8 +33,7 @@ class LexicalEnvironment;
 struct GetObjectInlineCache;
 struct SetObjectInlineCache;
 struct EnumerateObjectData;
-class GetGlobalVariable;
-class SetGlobalVariable;
+struct GlobalVariableAccessCacheItem;
 class InitializeGlobalVariable;
 class CallFunctionInWithScope;
 class CallEvalFunction;
@@ -80,8 +79,8 @@ public:
 
     static Object* fastToObject(ExecutionState& state, const Value& obj);
 
-    static Value getGlobalVariableSlowCase(ExecutionState& state, Object* go, GetGlobalVariable* code, ByteCodeBlock* block);
-    static void setGlobalVariableSlowCase(ExecutionState& state, Object* go, SetGlobalVariable* code, const Value& value, ByteCodeBlock* block);
+    static Value getGlobalVariableSlowCase(ExecutionState& state, Object* go, GlobalVariableAccessCacheItem* slot, ByteCodeBlock* block);
+    static void setGlobalVariableSlowCase(ExecutionState& state, Object* go, GlobalVariableAccessCacheItem* slot, const Value& value, ByteCodeBlock* block);
     static void initializeGlobalVariable(ExecutionState& state, InitializeGlobalVariable* code, const Value& value);
 
     static size_t tryOperation(ExecutionState& state, TryOperation* code, LexicalEnvironment* env, size_t programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);

--- a/src/parser/ast/ArrayPatternNode.h
+++ b/src/parser/ast/ArrayPatternNode.h
@@ -73,7 +73,7 @@ public:
 
         if (m_default != nullptr) {
             size_t undefinedIndex = context->getRegister();
-            codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+            codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
             size_t cmpIndex = context->getRegister();
             codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), m_initIdx, undefinedIndex, cmpIndex), context, this);
@@ -110,7 +110,7 @@ public:
                 } else if (element->isAssignmentExpressionSimple()) {
                     AssignmentExpressionSimpleNode* assignNode = element->asAssignmentExpressionSimple();
                     size_t undefinedIndex = context->getRegister();
-                    codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+                    codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
                     size_t cmpIndex = context->getRegister();
                     codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), iteratorValueIdx, undefinedIndex, cmpIndex), context, this);

--- a/src/parser/ast/DefaultArgumentNode.h
+++ b/src/parser/ast/DefaultArgumentNode.h
@@ -56,7 +56,7 @@ public:
     virtual void generateResultNotRequiredExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context)
     {
         size_t undefinedIndex = context->getRegister();
-        codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+        codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
         size_t src0 = m_left->getRegister(codeBlock, context);
         m_left->generateExpressionByteCode(codeBlock, context, src0);

--- a/src/parser/ast/IdentifierNode.h
+++ b/src/parser/ast/IdentifierNode.h
@@ -97,7 +97,7 @@ public:
                     if (isLexicallyDeclaredBindingInitialization) {
                         codeBlock->pushCode(InitializeGlobalVariable(ByteCodeLOC(m_loc.index), srcRegister, m_name), context, this);
                     } else {
-                        codeBlock->pushCode(SetGlobalVariable(ByteCodeLOC(m_loc.index), srcRegister, m_name), context, this);
+                        codeBlock->pushCode(SetGlobalVariable(ByteCodeLOC(m_loc.index), srcRegister, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(m_name)), context, this);
                     }
                 }
             } else {
@@ -118,7 +118,7 @@ public:
                         if (isLexicallyDeclaredBindingInitialization) {
                             codeBlock->pushCode(InitializeGlobalVariable(ByteCodeLOC(m_loc.index), srcRegister, m_name), context, this);
                         } else {
-                            codeBlock->pushCode(SetGlobalVariable(ByteCodeLOC(m_loc.index), srcRegister, m_name), context, this);
+                            codeBlock->pushCode(SetGlobalVariable(ByteCodeLOC(m_loc.index), srcRegister, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(m_name)), context, this);
                         }
                     } else {
                         if (isLexicallyDeclaredBindingInitialization) {
@@ -151,7 +151,7 @@ public:
                     ASSERT(!context->m_codeBlock->asInterpretedCodeBlock()->canAllocateEnvironmentOnStack());
                     codeBlock->pushCode(LoadByName(ByteCodeLOC(m_loc.index), dstRegister, m_name), context, this);
                 } else {
-                    codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), dstRegister, PropertyName(m_name)), context, this);
+                    codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), dstRegister, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(m_name)), context, this);
                 }
             } else {
                 if (info.m_isStackAllocated) {
@@ -163,7 +163,7 @@ public:
                         codeBlock->pushCode(Move(ByteCodeLOC(m_loc.index), REGULAR_REGISTER_LIMIT + info.m_index, dstRegister), context, this);
                 } else {
                     if (info.m_isGlobalLexicalVariable) {
-                        codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), dstRegister, PropertyName(m_name)), context, this);
+                        codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), dstRegister, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(m_name)), context, this);
                     } else {
                         codeBlock->pushCode(LoadByHeapIndex(ByteCodeLOC(m_loc.index), dstRegister, info.m_upperIndex, info.m_index), context, this);
                     }

--- a/src/parser/ast/ObjectPatternNode.h
+++ b/src/parser/ast/ObjectPatternNode.h
@@ -83,7 +83,7 @@ public:
 
             if (value != nullptr && !value->isPattern()) {
                 size_t undefinedIndex = context->getRegister();
-                codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+                codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
                 size_t cmpIndex = context->getRegister();
                 codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), objIndex, undefinedIndex, cmpIndex), context, this);
@@ -123,7 +123,7 @@ public:
                 }
 
                 size_t undefinedIndex = context->getRegister();
-                codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, PropertyName(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
+                codeBlock->pushCode(GetGlobalVariable(ByteCodeLOC(m_loc.index), undefinedIndex, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(codeBlock->m_codeBlock->context()->staticStrings().undefined)), context, this);
 
                 size_t cmpIndex = context->getRegister();
                 codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), valueIndex, undefinedIndex, cmpIndex), context, this);

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -137,6 +137,22 @@ namespace std {
 template <>
 struct is_fundamental<Escargot::AtomicString> : public true_type {
 };
+
+template <>
+struct hash<Escargot::AtomicString> {
+    size_t operator()(Escargot::AtomicString const& x) const
+    {
+        return std::hash<size_t*>{}((size_t*)x.string());
+    }
+};
+
+template <>
+struct equal_to<Escargot::AtomicString> {
+    bool operator()(Escargot::AtomicString const& a, Escargot::AtomicString const& b) const
+    {
+        return a == b;
+    }
+};
 }
 
 #endif

--- a/src/runtime/EnvironmentRecord.cpp
+++ b/src/runtime/EnvironmentRecord.cpp
@@ -62,10 +62,6 @@ void GlobalEnvironmentRecord::createBinding(ExecutionState& state, const AtomicS
         r.m_isVarDeclaration = false;
         r.m_name = name;
 
-        if (UNLIKELY(m_globalDeclarativeRecord->size() == std::numeric_limits<uint16_t>::max() - 1)) {
-            ErrorObject::throwBuiltinError(state, ErrorObject::RangeError, errorMessage_TooManyGlobalLexicalVariables);
-        }
-
         m_globalDeclarativeRecord->push_back(r);
         m_globalDeclarativeStorage->push_back(SmallValue(SmallValue::EmptyValue));
     }

--- a/src/runtime/ErrorObject.cpp
+++ b/src/runtime/ErrorObject.cpp
@@ -26,7 +26,6 @@ const char* errorMessage_NotImplemented = "Not implemented";
 const char* errorMessage_IsNotDefined = "%s is not defined";
 const char* errorMessage_IsNotInitialized = "Cannot access '%s' before initialization";
 const char* errorMessage_DuplicatedIdentifier = "Identifier '%s' has already been declared";
-const char* errorMessage_TooManyGlobalLexicalVariables = "There are too many global lexical variables in script";
 const char* errorMessage_AssignmentToConstantVariable = "Assignment to constant variable '%s'";
 const char* errorMessage_DefineProperty_Default = "Cannot define property '%s'";
 const char* errorMessage_DefineProperty_LengthNotWritable = "Cannot modify property '%s': 'length' is not writable";

--- a/src/runtime/ErrorObject.h
+++ b/src/runtime/ErrorObject.h
@@ -31,7 +31,6 @@ extern const char* errorMessage_NotImplemented; // FIXME to be removed
 extern const char* errorMessage_IsNotDefined;
 extern const char* errorMessage_IsNotInitialized;
 extern const char* errorMessage_DuplicatedIdentifier;
-extern const char* errorMessage_TooManyGlobalLexicalVariables;
 extern const char* errorMessage_AssignmentToConstantVariable;
 extern const char* errorMessage_DefineProperty_Default;
 extern const char* errorMessage_DefineProperty_LengthNotWritable;

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -87,6 +87,7 @@ public:
         , m_datePrototype(nullptr)
         , m_regexp(nullptr)
         , m_regexpPrototype(nullptr)
+        , m_regexpSplitMethod(nullptr)
         , m_math(nullptr)
         , m_eval(nullptr)
         , m_throwTypeError(nullptr)
@@ -382,6 +383,11 @@ public:
     Object* regexpPrototype()
     {
         return m_regexpPrototype;
+    }
+
+    FunctionObject* regexpSplitMethod()
+    {
+        return m_regexpSplitMethod;
     }
 
     Object* json()
@@ -681,6 +687,7 @@ private:
 
     GlobalRegExpFunctionObject* m_regexp;
     Object* m_regexpPrototype;
+    FunctionObject* m_regexpSplitMethod;
 
     Object* m_math;
 

--- a/src/runtime/GlobalObjectBuiltinRegExp.cpp
+++ b/src/runtime/GlobalObjectBuiltinRegExp.cpp
@@ -492,8 +492,9 @@ void GlobalObject::installRegExp(ExecutionState& state)
                                                         ObjectPropertyDescriptor(new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().getSymbolSearch, builtinRegExpSearch, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     // $21.2.5.11 RegExp.prototype[@@split]
+    m_regexpSplitMethod = new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().symbolSplit, builtinRegExpSplit, 1, NativeFunctionInfo::Strict));
     m_regexpPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, state.context()->vmInstance()->globalSymbols().split),
-                                                        ObjectPropertyDescriptor(new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().symbolSplit, builtinRegExpSplit, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
+                                                        ObjectPropertyDescriptor(m_regexpSplitMethod, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().RegExp),
                       ObjectPropertyDescriptor(m_regexp, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/Value.cpp
+++ b/src/runtime/Value.cpp
@@ -57,14 +57,6 @@ bool Value::isIterable() const
     return false;
 }
 
-bool Value::isCallable() const
-{
-    if (!isObject() || !asObject()->isCallable()) {
-        return false;
-    }
-    return true;
-}
-
 bool Value::isConstructor() const
 {
     if (!isObject() || !asObject()->isConstructor()) {

--- a/src/runtime/ValueInlines.h
+++ b/src/runtime/ValueInlines.h
@@ -659,6 +659,14 @@ inline bool Value::isPrimitive() const
 #endif
 }
 
+inline bool Value::isCallable() const
+{
+    if (UNLIKELY(!isPointerValue() || !asPointerValue()->isCallable())) {
+        return false;
+    }
+    return true;
+}
+
 // https://www.ecma-international.org/ecma-262/6.0/#sec-tonumber
 inline double Value::toNumber(ExecutionState& state) const
 {

--- a/test/es2015/symbol-split.js
+++ b/test/es2015/symbol-split.js
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-var assert = print;
-
 assert(RegExp.prototype.hasOwnProperty(Symbol.split));
 assert(RegExp.prototype[Symbol.split] instanceof Function);
 assert(RegExp.prototype[Symbol.split].name == "[Symbol.split]");


### PR DESCRIPTION
* Optmize String.protype.split function.
  when separator comes to RegExpObject split function, we have to call @@split function when there is a @@split function.
  old one is correct implementation but performance is bad...
  but we already have optmized split function with RegExp in builtinStringSplit.
  I make to use old one when if user didn't defined own @@split function.
  RegExp test score is changed from 57 to 280 in my computer.

* Make Value::isCallable inline-able.
* Make to use shared data among {Get,Set}GlobalVariable. this may reduce usage & improve performance

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>