### PR TITLE
Create rest parameter through bytecode interpretation

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -69,6 +69,7 @@ struct GlobalVariableAccessCacheItem;
     F(CreateSpreadObject, 1, 0)                       \
     F(CreateFunction, 1, 0)                           \
     F(CreateClass, 0, 0)                              \
+    F(CreateRestElement, 0, 0)                        \
     F(SuperReference, 1, 0)                           \
     F(CallSuper, -1, 0)                               \
     F(LoadThisBinding, 0, 0)                          \
@@ -433,6 +434,23 @@ public:
         } else {
             printf("create class r%d : r%d { r%d }", (int)m_classConstructorRegisterIndex, (int)m_superClassRegisterIndex, (int)m_classPrototypeRegisterIndex);
         }
+    }
+#endif
+};
+
+class CreateRestElement : public ByteCode {
+public:
+    CreateRestElement(const ByteCodeLOC& loc, const size_t registerIndex)
+        : ByteCode(Opcode::CreateRestElementOpcode, loc)
+        , m_registerIndex(registerIndex)
+    {
+    }
+
+    ByteCodeRegisterIndex m_registerIndex;
+#ifndef NDEBUG
+    void dump(const char* byteCodeStart)
+    {
+        printf("Create RestElement -> r%d", (int)m_registerIndex);
     }
 #endif
 };

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -284,6 +284,11 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
                 assignStackIndexIfNeeded(cd->m_registerIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
             }
+            case CreateRestElementOpcode: {
+                CreateRestElement* cd = (CreateRestElement*)currentCode;
+                assignStackIndexIfNeeded(cd->m_registerIndex, stackBase, stackBaseWillBe, stackVariableSize);
+                break;
+            }
             case CreateObjectOpcode: {
                 CreateObject* cd = (CreateObject*)currentCode;
                 assignStackIndexIfNeeded(cd->m_registerIndex, stackBase, stackBaseWillBe, stackVariableSize);

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -87,6 +87,7 @@ public:
     static size_t tryOperation(ExecutionState& state, TryOperation* code, LexicalEnvironment* env, size_t programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
 
     static FunctionObject* createFunctionOperation(ExecutionState& state, CreateFunction* createFunction, ByteCodeBlock* byteCodeBlock, Value* registerFile);
+    static ArrayObject* createRestElementOperation(ExecutionState& state, EnvironmentRecord* record, ByteCodeBlock* byteCodeBlock);
     static void evalOperation(ExecutionState& state, CallEvalFunction* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void classOperation(ExecutionState& state, CreateClass* code, Value* registerFile);
     static void superOperation(ExecutionState& state, SuperReference* code, Value* registerFile);

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -208,9 +208,9 @@ public:
         return m_usesArgumentsObject;
     }
 
-    bool usesRestParameter() const
+    bool hasArgumentInitializers() const
     {
-        return m_hasRestElement;
+        return m_hasArgumentInitializers;
     }
 
     AtomicString functionName() const
@@ -322,8 +322,7 @@ protected:
     bool m_isGenerator : 1;
     bool m_needsVirtualIDOperation : 1;
     bool m_needToLoadThisValue : 1;
-    bool m_hasRestElement : 1;
-    bool m_shouldReparseArguments : 1;
+    bool m_hasArgumentInitializers : 1;
     uint16_t m_parameterCount;
 
     AtomicString m_functionName;
@@ -507,11 +506,6 @@ public:
         return m_parentCodeBlock == nullptr;
     }
 
-    bool shouldReparseArguments()
-    {
-        return m_shouldReparseArguments;
-    }
-
     bool hasDescendantUsesNonIndexedVariableStorage()
     {
         return m_hasDescendantUsesNonIndexedVariableStorage;
@@ -670,7 +664,7 @@ public:
 
     const StringView& paramsSrc()
     {
-        ASSERT(m_shouldReparseArguments);
+        ASSERT(m_hasArgumentInitializers);
         return m_paramsSrc;
     }
 

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -178,7 +178,7 @@ Value Script::executeLocal(ExecutionState& state, Value thisValue, InterpretedCo
 
         if (fnRecord->hasBinding(newState, arguments).m_index == SIZE_MAX && fnRecord->functionObject()->isScriptFunctionObject()) {
             // FIXME check if formal parameters does not contain a rest parameter, any binding patterns, or any initializers.
-            bool isMapped = !fnRecord->functionObject()->codeBlock()->usesRestParameter() && !inStrict;
+            bool isMapped = !fnRecord->functionObject()->codeBlock()->hasArgumentInitializers() && !inStrict;
             fnRecord->functionObject()->asScriptFunctionObject()->generateArgumentsObject(newState, fnRecord, nullptr, isMapped);
         }
     }

--- a/src/parser/ast/AST.h
+++ b/src/parser/ast/AST.h
@@ -96,6 +96,7 @@
 #include "ProgramNode.h"
 #include "RegExpLiteralNode.h"
 #include "RegisterReferenceNode.h"
+#include "RestElementNode.h"
 #include "ReturnStatmentNode.h"
 #include "SequenceExpressionNode.h"
 #include "SpreadElementNode.h"

--- a/src/parser/ast/ArrayPatternNode.h
+++ b/src/parser/ast/ArrayPatternNode.h
@@ -23,6 +23,7 @@
 #include "AssignmentExpressionSimpleNode.h"
 #include "IdentifierNode.h"
 #include "ExpressionNode.h"
+#include "RestElementNode.h"
 #include "Node.h"
 #include "PatternNode.h"
 #include "RegisterReferenceNode.h"
@@ -154,7 +155,7 @@ public:
             size_t restIndex = context->getRegister();
             codeBlock->pushCode(BindingRestElement(ByteCodeLOC(m_loc.index), iteratorIdx, restIndex), context, this);
             RefPtr<RegisterReferenceNode> registerRef = adoptRef(new RegisterReferenceNode(restIndex));
-            RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new AssignmentExpressionSimpleNode(element.get(), registerRef.get()));
+            RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new AssignmentExpressionSimpleNode(((RestElementNode*)element.get())->argument(), registerRef.get()));
             assign->m_loc = m_loc;
             assign->generateResultNotRequiredExpressionByteCode(codeBlock, context);
             assign->giveupChildren();

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -586,8 +586,7 @@ struct ASTFunctionScopeContext : public gc {
     bool m_hasSuper : 1;
     bool m_hasManyNumeralLiteral : 1;
     bool m_hasRestElement : 1;
-    bool m_hasPatternNode : 1;
-    bool m_hasNonIdentArgument : 1;
+    bool m_hasPatternArgument : 1;
     bool m_needsToComputeLexicalBlockStuffs : 1;
     unsigned int m_nodeType : 2; // it is actually NodeType but used on FunctionExpression, ArrowFunctionExpression, FunctionDeclaration only
     LexicalBlockIndex m_lexicalBlockIndexFunctionLocatedIn : 16;
@@ -822,8 +821,6 @@ struct ASTFunctionScopeContext : public gc {
         , m_hasSuper(false)
         , m_hasManyNumeralLiteral(false)
         , m_hasRestElement(false)
-        , m_hasPatternNode(false)
-        , m_hasNonIdentArgument(false)
         , m_needsToComputeLexicalBlockStuffs(false)
         , m_nodeType(ASTNodeType::Program)
         , m_lexicalBlockIndexFunctionLocatedIn(LEXICAL_BLOCK_INDEX_MAX)

--- a/src/parser/ast/RestElementNode.h
+++ b/src/parser/ast/RestElementNode.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#ifndef RestElementNode_h
+#define RestElementNode_h
+
+#include "IdentifierNode.h"
+#include "Node.h"
+
+namespace Escargot {
+
+class RestElementNode : public ExpressionNode {
+public:
+    RestElementNode(IdentifierNode* argument)
+        : ExpressionNode()
+    {
+        m_argument = argument;
+    }
+
+    virtual ~RestElementNode()
+    {
+    }
+
+    virtual ASTNodeType type() { return ASTNodeType::RestElement; }
+    IdentifierNode* argument()
+    {
+        return m_argument.get();
+    }
+
+    virtual void generateResultNotRequiredExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context)
+    {
+        size_t restElementRegister = m_argument->getRegister(codeBlock, context);
+        codeBlock->pushCode(CreateRestElement(ByteCodeLOC(m_loc.index), restElementRegister), context, this);
+        m_argument->generateStoreByteCode(codeBlock, context, restElementRegister, false);
+    }
+
+protected:
+    RefPtr<IdentifierNode> m_argument;
+};
+}
+
+#endif

--- a/src/runtime/EnvironmentRecord.h
+++ b/src/runtime/EnvironmentRecord.h
@@ -689,10 +689,26 @@ class FunctionEnvironmentRecordSimple : public FunctionEnvironmentRecord {
     friend class LexicalEnvironment;
 
 public:
-    ALWAYS_INLINE explicit FunctionEnvironmentRecordSimple(FunctionObject* function)
+    ALWAYS_INLINE explicit FunctionEnvironmentRecordSimple(FunctionObject* function, size_t argc, Value* argv)
         : FunctionEnvironmentRecord(function)
+        , m_argc(argc)
+        , m_argv(argv)
     {
     }
+
+    virtual size_t argc() override
+    {
+        return m_argc;
+    }
+
+    virtual Value* argv() override
+    {
+        return m_argv;
+    }
+
+private:
+    size_t m_argc;
+    Value* m_argv;
 };
 
 class FunctionEnvironmentRecordOnHeap : public FunctionEnvironmentRecord {

--- a/src/runtime/FunctionObjectInlines.h
+++ b/src/runtime/FunctionObjectInlines.h
@@ -122,7 +122,7 @@ public:
 
         if (LIKELY(codeBlock->canAllocateEnvironmentOnStack())) {
             // no capture, very simple case
-            record = new (alloca(sizeof(FunctionEnvironmentRecordSimple))) FunctionEnvironmentRecordSimple(self);
+            record = new (alloca(sizeof(FunctionEnvironmentRecordSimple))) FunctionEnvironmentRecordSimple(self, argc, argv);
             lexEnv = new (alloca(sizeof(LexicalEnvironment))) LexicalEnvironment(record, self->outerEnvironment());
         } else {
             if (LIKELY(codeBlock->canUseIndexedVariableStorage())) {
@@ -254,7 +254,7 @@ public:
 
             // FIXME
             if (UNLIKELY(codeBlock->usesArgumentsObject())) {
-                bool isMapped = !codeBlock->usesRestParameter() && !isStrict;
+                bool isMapped = !codeBlock->hasArgumentInitializers() && !isStrict;
                 self->generateArgumentsObject(*newState, record, stackStorage, isMapped);
             }
 
@@ -278,12 +278,8 @@ public:
 
         if (UNLIKELY(codeBlock->usesArgumentsObject())) {
             // FIXME check if formal parameters does not contain a rest parameter, any binding patterns, or any initializers.
-            bool isMapped = !codeBlock->usesRestParameter() && !isStrict;
+            bool isMapped = !codeBlock->hasArgumentInitializers() && !isStrict;
             self->generateArgumentsObject(newState, record, stackStorage, isMapped);
-        }
-
-        if (UNLIKELY(codeBlock->usesRestParameter())) {
-            self->generateRestParameter(newState, record, stackStorage + 2, argc, argv);
         }
 
         // run function

--- a/src/runtime/NativeFunctionObject.cpp
+++ b/src/runtime/NativeFunctionObject.cpp
@@ -123,7 +123,7 @@ Value NativeFunctionObject::processNativeFunctionCall(ExecutionState& state, con
     CallNativeFunctionData* code = m_codeBlock->nativeFunctionData();
 
     // TODO don't make LexicalEnvironment if possiable
-    FunctionEnvironmentRecordSimple record(this);
+    FunctionEnvironmentRecordSimple record(this, 0, nullptr);
     LexicalEnvironment env(&record, nullptr);
 
     size_t len = m_codeBlock->parameterCount();


### PR DESCRIPTION
* CreateRestElement bytecode is newly added for generating a rest parameter
* RestElementNode is added to handle patterns in rest parameter later
* rest parameter is created at the first part of the function body execution

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>