### PR TITLE
Make to run test cases faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,89 @@ compiler:
 
 matrix:
   include:
+    - name: "linux.debug"
+      addons:
+        apt:
+          packages: [ autoconf, automake, libtool, ninja-build, libicu-dev, gcc-multilib g++-multilib, "libicu-dev:i386" ]
+      script:
+        - cmake -H. -Bout/linux/x64/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin -GNinja
+        - ninja -Cout/linux/x64/debug
+        - cp ./out/linux/x64/debug/escargot ./escargot
+        - tools/run-tests.py --arch=x86_64 sunspider-js internal regression-tests es2015 intl
+        - gcc -shared -fPIC -o backtrace-hooking.so tools/test/test262/backtrace-hooking.c
+        - export GC_FREE_SPACE_DIVISOR=1
+        - export ESCARGOT_LD_PRELOAD=${TRAVIS_BUILD_DIR}/backtrace-hooking.so
+        - tools/run-tests.py --arch=x86_64 test262
+        - unset GC_FREE_SPACE_DIVISOR
+        - unset ESCARGOT_LD_PRELOAD
+        - rm -rf ./out
+        - cmake -H. -Bout/linux/x86/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin -GNinja
+        - ninja -Cout/linux/x86/debug
+        - cp ./out/linux/x86/debug/escargot ./escargot
+        - tools/run-tests.py --arch=x86 sunspider-js internal regression-tests es2015 intl
+        - gcc -shared -m32 -fPIC -o backtrace-hooking.so tools/test/test262/backtrace-hooking.c
+        - export GC_FREE_SPACE_DIVISOR=1
+        - export ESCARGOT_LD_PRELOAD=${TRAVIS_BUILD_DIR}/backtrace-hooking.so
+        - tools/run-tests.py --arch=x86 test262
+
+    - name: "linux.x64.release"
+      addons:
+        apt:
+          packages: [ autoconf, automake, libtool, ninja-build, libicu-dev, npm ]
+      install:
+        - npm install
+      script:
+        - cmake -H. -Bout/linux/x64/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
+        - ninja -Cout/linux/x64/release
+        - cp ./out/linux/x64/release/escargot ./escargot
+        - tools/run-tests.py --arch=x86_64 octane
+        - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js internal jsc-stress v8 spidermonkey regression-tests es2015 intl chakracore
+        - export GC_FREE_SPACE_DIVISOR=1
+        - tools/run-tests.py --arch=x86_64 test262
+
+
+    - name: "linux.x64.release.jetstream"
+      addons:
+        apt:
+          packages: [ autoconf, automake, libtool, ninja-build, libicu-dev, npm ]
+      install:
+        - npm install
+      script:
+        - cmake -H. -Bout/linux/x64/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
+        - ninja -Cout/linux/x64/release
+        - cp ./out/linux/x64/release/escargot ./escargot
+        - travis_wait 30 tools/run-tests.py --arch=x86_64 jetstream-only-simple
+
+
+    - name: "linux.x86.release"
+      addons:
+        apt:
+          packages: [ autoconf, automake, libtool, ninja-build, gcc-multilib g++-multilib, "libicu-dev:i386", npm ]
+      install:
+        - npm install
+      script:
+        - cmake -H. -Bout/linux/x86/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
+        - ninja -Cout/linux/x86/release
+        - cp ./out/linux/x86/release/escargot ./escargot
+        - tools/run-tests.py --arch=x86 octane
+        - tools/run-tests.py --arch=x86 jetstream-only-cdjs sunspider-js internal jsc-stress v8 spidermonkey regression-tests es2015 intl chakracore
+        - export GC_FREE_SPACE_DIVISOR=1
+        - tools/run-tests.py --arch=x86 test262
+
+
+    - name: "linux.x86.release.jetstream"
+      addons:
+        apt:
+          packages: [ autoconf, automake, libtool, ninja-build, gcc-multilib g++-multilib, "libicu-dev:i386", npm ]
+      install:
+        - npm install
+      script:
+        - cmake -H. -Bout/linux/x86/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
+        - ninja -Cout/linux/x86/release
+        - cp ./out/linux/x86/release/escargot ./escargot
+        - travis_wait 30 tools/run-tests.py --arch=x86 jetstream-only-simple
+
+
     - name: "check"
       addons:
         apt:
@@ -40,93 +123,6 @@ matrix:
         # for Gregorian letters (0x10D0-0x10FF). Unfortunately, the test case expects
         # Unicode 1.0 compatible(?) behaviour, i.e., to return letters unmodified.
 
-    - name: "linux.x64.release"
-      addons:
-        apt:
-          packages: [ autoconf, automake, libtool, ninja-build, libicu-dev, npm ]
-      install:
-        - npm install
-      script:
-        - cmake -H. -Bout/linux/x64/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
-        - ninja -Cout/linux/x64/release
-        - cp ./out/linux/x64/release/escargot ./escargot
-        - travis_wait 30 tools/run-tests.py --arch=x86_64 jetstream-only-simple chakracore
-        - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js internal octane jsc-stress v8 spidermonkey regression-tests es2015 intl
-        - tools/run-tests.py --arch=x86_64 test262
-
-    - name: "linux.x64.debug"
-      addons:
-        apt:
-          packages: [ autoconf, automake, libtool, ninja-build, libicu-dev ]
-      script:
-        - cmake -H. -Bout/linux/x64/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin -GNinja
-        - ninja -Cout/linux/x64/debug
-        - cp ./out/linux/x64/debug/escargot ./escargot
-        - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js internal regression-tests es2015 intl
-
-    - name: "linux.x64.debug test262-strict only"
-      addons:
-        apt:
-          packages: [ autoconf, automake, libtool, ninja-build, libicu-dev ]
-      script:
-        - cmake -H. -Bout/linux/x64/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin -GNinja
-        - ninja -Cout/linux/x64/debug
-        - cp ./out/linux/x64/debug/escargot ./escargot
-        - travis_wait 50 tools/run-tests.py --arch=x86_64 test262-strict
-
-    - name: "linux.x64.debug test262-nonstrict only"
-      addons:
-        apt:
-          packages: [ autoconf, automake, libtool, ninja-build, libicu-dev ]
-      script:
-        - cmake -H. -Bout/linux/x64/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin -GNinja
-        - ninja -Cout/linux/x64/debug
-        - cp ./out/linux/x64/debug/escargot ./escargot
-        - travis_wait 50 tools/run-tests.py --arch=x86_64 test262-nonstrict
-
-    - name: "linux.x86.release"
-      addons:
-        apt:
-          packages: [ autoconf, automake, libtool, ninja-build, gcc-multilib g++-multilib, "libicu-dev:i386", npm ]
-      install:
-        - npm install
-      script:
-        - cmake -H. -Bout/linux/x86/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
-        - ninja -Cout/linux/x86/release
-        - cp ./out/linux/x86/release/escargot ./escargot
-        - travis_wait 30 tools/run-tests.py --arch=x86 jetstream-only-simple chakracore
-        - tools/run-tests.py --arch=x86 jetstream-only-cdjs sunspider-js internal octane jsc-stress v8 spidermonkey regression-tests es2015 intl
-        - tools/run-tests.py --arch=x86 test262
-
-    - name: "linux.x86.debug"
-      addons:
-        apt:
-          packages: [ autoconf, automake, libtool, ninja-build, gcc-multilib g++-multilib, "libicu-dev:i386" ]
-      script:
-        - cmake -H. -Bout/linux/x86/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin -GNinja
-        - ninja -Cout/linux/x86/debug
-        - cp ./out/linux/x86/debug/escargot ./escargot
-        - tools/run-tests.py --arch=x86 jetstream-only-cdjs sunspider-js internal regression-tests es2015 intl
-
-    - name: "linux.x86.debug test262-strict only"
-      addons:
-        apt:
-          packages: [ autoconf, automake, libtool, ninja-build, gcc-multilib g++-multilib, "libicu-dev:i386" ]
-      script:
-        - cmake -H. -Bout/linux/x86/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin -GNinja
-        - ninja -Cout/linux/x86/debug
-        - cp ./out/linux/x86/debug/escargot ./escargot
-        - travis_wait 50 tools/run-tests.py --arch=x86 test262-strict
-
-    - name: "linux.x86.debug test262-nonstrict only"
-      addons:
-        apt:
-          packages: [ autoconf, automake, libtool, ninja-build, gcc-multilib g++-multilib, "libicu-dev:i386" ]
-      script:
-        - cmake -H. -Bout/linux/x86/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin -GNinja
-        - ninja -Cout/linux/x86/debug
-        - cp ./out/linux/x86/debug/escargot ./escargot
-        - travis_wait 50 tools/run-tests.py --arch=x86 test262-nonstrict
 
     - name: "SonarQube"
       addons:

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -147,6 +147,11 @@ int main(int argc, char* argv[])
         }
     }
 
+    if (getenv("GC_FREE_SPACE_DIVISOR") && strlen(getenv("GC_FREE_SPACE_DIVISOR"))) {
+        int d = atoi(getenv("GC_FREE_SPACE_DIVISOR"));
+        GC_set_free_space_divisor(d);
+    }
+
     while (runShell) {
         static char buf[2048];
         printf("escargot> ");

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -148,8 +148,31 @@ def run_internal_test(engine, arch):
 
 @runner('test262', default=True)
 def run_test262(engine, arch):
-    run_test262_strict(engine, arch)
-    run_test262_nonstrict(engine, arch)
+    TEST262_OVERRIDE_DIR = join(PROJECT_SOURCE_DIR, 'tools', 'test', 'test262')
+    TEST262_DIR = join(PROJECT_SOURCE_DIR, 'test', 'test262')
+
+    copy(join(TEST262_OVERRIDE_DIR, 'excludelist.orig.xml'), join(TEST262_DIR, 'excludelist.xml'))
+    copy(join(TEST262_OVERRIDE_DIR, 'test262.py'), join(TEST262_DIR, 'tools', 'packaging', 'test262.py')) # for parallel running (we should re-implement this for es6 suite)
+
+    out = open('test262_out', 'w')
+
+    run(['python', join('tools', 'packaging', 'test262.py'),
+         '--command', engine,
+         '--full-summary'],
+        cwd=TEST262_DIR,
+        env={'TZ': 'US/Pacific'},
+        stdout=out,
+        report=True)
+
+    out.close()
+
+    with open('test262_out', 'r') as out:
+        full = out.read()
+        summary = full.split('=== Summary ===')[1]
+        if summary.find('- All tests succeeded') < 0:
+            print(summary)
+            raise Exception('test262 failed')
+        print('test262: All tests passed')
 
 @runner('test262-strict', default=True)
 def run_test262_strict(engine, arch):

--- a/tools/test/test262/backtrace-hooking.c
+++ b/tools/test/test262/backtrace-hooking.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+int backtrace(void **buffer, int size)
+{
+    int i;
+    for (i = 0; i < size; i ++) {
+        buffer[i] = 0;
+    }
+    return size;
+}

--- a/tools/test/test262/test262.py
+++ b/tools/test/test262/test262.py
@@ -49,7 +49,9 @@ EXCLUDE_LIST = xml.dom.minidom.parse(EXCLUDED_FILENAME)
 EXCLUDE_REASON = EXCLUDE_LIST.getElementsByTagName("reason")
 EXCLUDE_LIST = EXCLUDE_LIST.getElementsByTagName("test")
 EXCLUDE_LIST = [x.getAttribute("id") for x in EXCLUDE_LIST]
-
+ESCARGOT_LD_PRELOAD = os.environ.get('ESCARGOT_LD_PRELOAD')
+if ESCARGOT_LD_PRELOAD is None:
+    ESCARGOT_LD_PRELOAD = ""
 
 def BuildOptions():
   result = optparse.OptionParser()
@@ -327,11 +329,16 @@ class TestCase(object):
     stderr = TempFile(prefix="test262-err-")
     try:
       logging.info("exec: %s", str(args))
+
+      my_env = os.environ.copy()
+      my_env["LD_PRELOAD"] = ESCARGOT_LD_PRELOAD
+
       process = subprocess.Popen(
         args,
         shell = IsWindows(),
         stdout = stdout.fd,
-        stderr = stderr.fd
+        stderr = stderr.fd,
+        env = my_env
       )
       code = process.wait()
       out = stdout.Read()

--- a/tools/test/v8/v8.run-tests.py
+++ b/tools/test/v8/v8.run-tests.py
@@ -554,9 +554,7 @@ def ProcessOptions(options):
     VARIANTS = ["default"]
 
   if options.j == 0:
-    # NOTE(Escargot): disable multiprocessing to check regression
-    options.j = 1
-    # options.j = multiprocessing.cpu_count()
+    options.j = multiprocessing.cpu_count()
 
   if options.random_seed_stress_count <= 1 and options.random_seed == 0:
     options.random_seed = RandomSeed()


### PR DESCRIPTION
* Make to run chakracore, v8, jsc-stress test parallelly
* Make to call backtrace() faster on test262. this improves running speed of debug binary.

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>