### PR TITLE
Fix arrow function bugs related to lazy instantiation

### DIFF
--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -3658,7 +3658,10 @@ public:
                         size_t oldSubCodeBlockIndex = this->subCodeBlockIndex;
                         this->subCodeBlockIndex = 0;
 
+                        bool parseSingleFunctionBefore = this->config.parseSingleFunction;
+                        this->config.parseSingleFunction = false;
                         body = this->isolateCoverGrammar(&Parser::assignmentExpression<Parse>);
+                        this->config.parseSingleFunction = parseSingleFunctionBefore;
 
                         this->subCodeBlockIndex = oldSubCodeBlockIndex;
                         this->lexicalBlockIndex = lexicalBlockIndexBefore;
@@ -3668,7 +3671,6 @@ public:
                     bool isExpression = body->type() != BlockStatement;
                     if (isExpression) {
                         if (this->config.parseSingleFunction) {
-                            ASSERT(this->config.parseSingleFunctionChildIndex > 0);
                             this->config.parseSingleFunctionChildIndex++;
                         }
                         scopeContexts.back()->m_locStart.line = nodeStart.line;

--- a/test/regression-tests/issue-343.js
+++ b/test/regression-tests/issue-343.js
@@ -1,0 +1,32 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function FunctionWithInnerArrowFunctionWithBlock(array) {
+  return array.map((row) =>
+    row.map((col) => {
+      return row + col;
+    })
+  )
+}
+
+function FunctionWithArrowFunctionsWithoutBlocks(array) {
+  return array.map((row) => row.map((col) => (row + col)))
+}
+
+var array1 = [[1,2,3], [4,5,6], [7,8,9]];
+var expected = '[["1,2,31","1,2,32","1,2,33"],["4,5,64","4,5,65","4,5,66"],["7,8,97","7,8,98","7,8,99"]]';
+
+assert(JSON.stringify(FunctionWithInnerArrowFunctionWithBlock(array1)) === expected);
+assert(JSON.stringify(FunctionWithArrowFunctionsWithoutBlocks(array1)) === expected);


### PR DESCRIPTION
Fixed a bug when an arrow function with block braces is inside an arrow function without braces handled incorrently during an outer function lazy instantiation.
The inner arrow function treated the most outer simple function as its parent instead of the outer arrow function due to the invalid use of config.parseSingleFunction.
Also the 0 parseFunctionIndex must be valid for arrow functions as well during the lazy instantiation.

This patch fixes #343.

Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu