### PR TITLE
Remove label check during byte code generation.

### DIFF
--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -85,7 +85,6 @@ struct ByteCodeGenerateContext {
         , m_forInOfVarBinding(false)
         , m_registerStack(new std::vector<ByteCodeRegisterIndex>())
         , m_lexicallyDeclaredNames(new std::vector<std::pair<size_t, AtomicString>>())
-        , m_currentLabels(new std::vector<std::pair<String*, size_t>>())
         , m_offsetToBasePointer(0)
         , m_positionToContinue(0)
         , m_tryStatementScopeCount(0)
@@ -120,7 +119,6 @@ struct ByteCodeGenerateContext {
         , m_forInOfVarBinding(contextBefore.m_forInOfVarBinding)
         , m_registerStack(contextBefore.m_registerStack)
         , m_lexicallyDeclaredNames(contextBefore.m_lexicallyDeclaredNames)
-        , m_currentLabels(contextBefore.m_currentLabels)
         , m_offsetToBasePointer(contextBefore.m_offsetToBasePointer)
         , m_positionToContinue(contextBefore.m_positionToContinue)
         , m_tryStatementScopeCount(contextBefore.m_tryStatementScopeCount)
@@ -304,7 +302,6 @@ struct ByteCodeGenerateContext {
     std::shared_ptr<std::vector<std::pair<size_t, AtomicString>>> m_lexicallyDeclaredNames;
     std::vector<size_t> m_breakStatementPositions;
     std::vector<size_t> m_continueStatementPositions;
-    std::shared_ptr<std::vector<std::pair<String*, size_t>>> m_currentLabels;
     std::vector<std::pair<String*, size_t>> m_labeledBreakStatmentPositions;
     std::vector<std::pair<String*, size_t>> m_labeledContinueStatmentPositions;
     std::vector<size_t> m_getObjectCodePositions;

--- a/src/parser/ast/ContinueLabelStatementNode.h
+++ b/src/parser/ast/ContinueLabelStatementNode.h
@@ -38,18 +38,6 @@ public:
     {
         codeBlock->pushCode(Jump(ByteCodeLOC(m_loc.index), SIZE_MAX), context, this);
         context->pushLabeledContinuePositions(codeBlock->lastCodePosition<Jump>(), m_label);
-
-        for (size_t i = 0; i < context->m_currentLabels->size(); i++) {
-            if (m_label->equals(context->m_currentLabels->at(i).first) && context->m_currentLabels->at(i).second) {
-                ByteCodeGenerateError err;
-                err.m_index = m_loc.index;
-                auto ret = codeBlock->computeNodeLOC(codeBlock->m_codeBlock->src(), codeBlock->m_codeBlock->sourceElementStart(), m_loc.index);
-                char message[512];
-                snprintf(message, sizeof(message), "Line %zu: Undefined label %s", ret.line, m_label->toUTF8StringData().data());
-                err.m_message = message;
-                throw err;
-            }
-        }
     }
 
 private:

--- a/src/parser/ast/LabeledStatementNode.h
+++ b/src/parser/ast/LabeledStatementNode.h
@@ -41,21 +41,12 @@ public:
     virtual ASTNodeType type() { return ASTNodeType::LabeledStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context)
     {
-        if (m_statementNode->type() == ASTNodeType::SwitchStatement) {
-            context->m_currentLabels->push_back(std::make_pair(m_label, 1));
-        } else {
-            context->m_currentLabels->push_back(std::make_pair(m_label, 0));
-        }
-
         size_t start = codeBlock->currentCodeSize();
         context->m_positionToContinue = start;
         m_statementNode->generateStatementByteCode(codeBlock, context);
         size_t end = codeBlock->currentCodeSize();
         context->consumeLabeledBreakPositions(codeBlock, end, m_label, context->m_tryStatementScopeCount);
         context->consumeLabeledContinuePositions(codeBlock, context->m_positionToContinue, m_label, context->m_tryStatementScopeCount);
-
-        RELEASE_ASSERT(context->m_currentLabels->back().first->equals(m_label));
-        context->m_currentLabels->erase(context->m_currentLabels->end() - 1);
     }
 
 private:


### PR DESCRIPTION
Since labels are properly checked by the parser now, there is no need to check them at the byte code generation phase.