### PR TITLE
Refactoring source code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
         - gcc -shared -fPIC -o backtrace-hooking.so tools/test/test262/backtrace-hooking.c
         - export GC_FREE_SPACE_DIVISOR=1
         - export ESCARGOT_LD_PRELOAD=${TRAVIS_BUILD_DIR}/backtrace-hooking.so
-        - tools/run-tests.py --arch=x86_64 test262
+        - travis_wait 30 tools/run-tests.py --arch=x86_64 test262
         - unset GC_FREE_SPACE_DIVISOR
         - unset ESCARGOT_LD_PRELOAD
         - rm -rf ./out
@@ -27,7 +27,7 @@ matrix:
         - gcc -shared -m32 -fPIC -o backtrace-hooking.so tools/test/test262/backtrace-hooking.c
         - export GC_FREE_SPACE_DIVISOR=1
         - export ESCARGOT_LD_PRELOAD=${TRAVIS_BUILD_DIR}/backtrace-hooking.so
-        - tools/run-tests.py --arch=x86 test262
+        - travis_wait 30 tools/run-tests.py --arch=x86 test262
 
     - name: "linux.x64.release"
       addons:
@@ -39,10 +39,10 @@ matrix:
         - cmake -H. -Bout/linux/x64/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
         - ninja -Cout/linux/x64/release
         - cp ./out/linux/x64/release/escargot ./escargot
-        - tools/run-tests.py --arch=x86_64 octane
+        - travis_wait 30 tools/run-tests.py --arch=x86_64 octane
         - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js internal jsc-stress v8 spidermonkey regression-tests es2015 intl chakracore
         - export GC_FREE_SPACE_DIVISOR=1
-        - tools/run-tests.py --arch=x86_64 test262
+        - travis_wait 30 tools/run-tests.py --arch=x86_64 test262
 
 
     - name: "linux.x64.release.jetstream"
@@ -68,10 +68,10 @@ matrix:
         - cmake -H. -Bout/linux/x86/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
         - ninja -Cout/linux/x86/release
         - cp ./out/linux/x86/release/escargot ./escargot
-        - tools/run-tests.py --arch=x86 octane
+        - travis_wait 30 tools/run-tests.py --arch=x86 octane
         - tools/run-tests.py --arch=x86 jetstream-only-cdjs sunspider-js internal jsc-stress v8 spidermonkey regression-tests es2015 intl chakracore
         - export GC_FREE_SPACE_DIVISOR=1
-        - tools/run-tests.py --arch=x86 test262
+        - travis_wait 30 tools/run-tests.py --arch=x86 test262
 
 
     - name: "linux.x86.release.jetstream"

--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -1404,7 +1404,7 @@ NullablePtr<FunctionObjectRef> ExecutionStateRef::resolveCallee()
 {
     auto ec = toImpl(this);
     if (ec != nullptr) {
-        auto callee = ec->resolveCallee();
+        auto callee = ec->callee();
         if (callee != nullptr) {
             return toRef(callee);
         }
@@ -1412,19 +1412,18 @@ NullablePtr<FunctionObjectRef> ExecutionStateRef::resolveCallee()
     return nullptr;
 }
 
-std::vector<std::pair<FunctionObjectRef*, ValueRef*>> ExecutionStateRef::resolveCallstack()
+std::vector<FunctionObjectRef*> ExecutionStateRef::resolveCallstack()
 {
     ExecutionState* state = toImpl(this);
 
-    std::vector<std::pair<FunctionObjectRef*, ValueRef*>> result;
+    std::vector<FunctionObjectRef*> result;
 
     while (state) {
         if (state->lexicalEnvironment() && state->lexicalEnvironment()->record()->isDeclarativeEnvironmentRecord()
             && state->lexicalEnvironment()->record()->asDeclarativeEnvironmentRecord()->isFunctionEnvironmentRecord()) {
             auto r = state->lexicalEnvironment()->record()->asDeclarativeEnvironmentRecord()->asFunctionEnvironmentRecord();
             FunctionObject* callee = r->functionObject();
-            Value thisValue = state->registerFile()[0];
-            result.push_back(std::make_pair(toRef(callee), toRef(thisValue)));
+            result.push_back(toRef(callee));
         }
         state = state->parent();
     }

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -299,7 +299,7 @@ public:
     void destroy();
 
     NullablePtr<FunctionObjectRef> resolveCallee(); // resolve nearest callee if exists
-    std::vector<std::pair<FunctionObjectRef*, ValueRef*>> resolveCallstack(); // resolve callee, this value
+    std::vector<FunctionObjectRef*> resolveCallstack(); // resolve list of callee
     GlobalObjectRef* resolveCallerLexicalGlobalObject(); // resolve caller's lexical global object
 
     void throwException(ValueRef* value);

--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -323,9 +323,6 @@ struct ByteCodeGenerateContext {
 
 class ByteCodeGenerator {
 public:
-    static void generateStoreThisValueByteCode(ByteCodeBlock* block, ByteCodeGenerateContext* context);
-    static void generateLoadThisValueByteCode(ByteCodeBlock* block, ByteCodeGenerateContext* context);
-
     static ByteCodeBlock* generateByteCode(Context* c, InterpretedCodeBlock* codeBlock, Node* ast, ASTFunctionScopeContext* scopeCtx, bool isEvalMode = false, bool isOnGlobal = false, bool inWithFromRuntime = false, bool shouldGenerateLOCData = false);
 };
 }

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -86,7 +86,7 @@ public:
 
     static size_t tryOperation(ExecutionState& state, TryOperation* code, LexicalEnvironment* env, size_t programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
 
-    static FunctionObject* createFunctionOperation(ExecutionState& state, CreateFunction* createFunction, ByteCodeBlock* byteCodeBlock, Value* registerFile);
+    static void createFunctionOperation(ExecutionState& state, CreateFunction* createFunction, ByteCodeBlock* byteCodeBlock, Value* registerFile);
     static ArrayObject* createRestElementOperation(ExecutionState& state, EnvironmentRecord* record, ByteCodeBlock* byteCodeBlock);
     static void evalOperation(ExecutionState& state, CallEvalFunction* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void classOperation(ExecutionState& state, CreateClass* code, Value* registerFile);
@@ -104,7 +104,7 @@ public:
     static Value incrementOperation(ExecutionState& state, const Value& value);
     static Value decrementOperation(ExecutionState& state, const Value& value);
 
-    static void processException(ExecutionState& state, const Value& value, size_t programCounter);
+    static void processException(ExecutionState& state, const Value& value, CodeBlock* codeBlock, size_t programCounter);
 };
 }
 

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -188,16 +188,6 @@ public:
         return m_isGenerator;
     }
 
-    bool needToLoadThisValue() const
-    {
-        return m_needToLoadThisValue;
-    }
-
-    void setNeedToLoadThisValue()
-    {
-        m_needToLoadThisValue = true;
-    }
-
     bool hasCallNativeFunctionCode() const
     {
         return m_hasCallNativeFunctionCode;
@@ -238,6 +228,11 @@ public:
     bool isFunctionNameExplicitlyDeclared() const
     {
         return m_isFunctionNameExplicitlyDeclared;
+    }
+
+    bool isEvalCodeInFunction() const
+    {
+        return m_isEvalCodeInFunction;
     }
 
     void setHasEval()
@@ -306,7 +301,6 @@ protected:
     bool m_needsComplexParameterCopy : 1;
     bool m_hasEval : 1;
     bool m_hasWith : 1;
-    bool m_hasSuper : 1;
     bool m_hasYield : 1;
     bool m_inWith : 1;
     bool m_isEvalCode : 1;
@@ -321,7 +315,6 @@ protected:
     bool m_isClassStaticMethod : 1;
     bool m_isGenerator : 1;
     bool m_needsVirtualIDOperation : 1;
-    bool m_needToLoadThisValue : 1;
     bool m_hasArgumentInitializers : 1;
     uint16_t m_parameterCount;
 
@@ -348,8 +341,6 @@ public:
     {
         m_childBlocks.push_back(cb);
     }
-    bool needToStoreThisValue();
-    void captureThis();
     void captureArguments();
     bool tryCaptureIdentifiersFromChildCodeBlock(LexicalBlockIndex blockIndex, AtomicString name);
 
@@ -685,7 +676,7 @@ public:
         return m_byteCodeBlock;
     }
 
-    void markHeapAllocatedEnvironmentFromHere(LexicalBlockIndex blockIndex = 0);
+    void markHeapAllocatedEnvironmentFromHere(LexicalBlockIndex blockIndex = 0, InterpretedCodeBlock* to = nullptr);
 
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;

--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -1630,10 +1630,6 @@ static ALWAYS_INLINE KeywordKind isKeyword(const StringBufferAccessData& data)
             if (second == 'a' && data.equalsSameLength("catch", 2)) {
                 return CatchKeyword;
             } else if (second == 'o' && data.equalsSameLength("const", 2)) {
-                const char* env = getenv("ESCARGOT_TREAT_CONST_AS_VAR");
-                if (env && strlen(env)) {
-                    return VarKeyword;
-                }
                 return ConstKeyword;
             } else if (second == 'l' && data.equalsSameLength("class", 2)) {
                 return ClassKeyword;
@@ -1700,10 +1696,6 @@ static ALWAYS_INLINE KeywordKind isKeyword(const StringBufferAccessData& data)
         break;
     case 'l':
         if (length == 3 && data.equalsSameLength("let", 1)) {
-            const char* env = getenv("ESCARGOT_TREAT_LET_AS_VAR");
-            if (env && strlen(env)) {
-                return VarKeyword;
-            }
             return LetKeyword;
         }
         break;

--- a/src/runtime/Environment.h
+++ b/src/runtime/Environment.h
@@ -32,11 +32,20 @@ class GlobalObject;
 // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-lexical-environments
 class LexicalEnvironment : public gc {
 public:
-    LexicalEnvironment(EnvironmentRecord* record, LexicalEnvironment* outerEnvironment)
+    LexicalEnvironment(EnvironmentRecord* record, LexicalEnvironment* outerEnvironment
+#ifndef NDEBUG
+                       ,
+                       bool isAllocatedOnHeap = true
+#endif
+                       )
         : m_record(record)
         , m_outerEnvironment(outerEnvironment)
+#ifndef NDEBUG
+        , m_isAllocatedOnHeap(isAllocatedOnHeap)
+#endif
     {
     }
+
     EnvironmentRecord* record()
     {
         return m_record;
@@ -59,9 +68,20 @@ public:
         return true;
     }
 
+#ifndef NDEBUG
+    bool isAllocatedOnHeap()
+    {
+        return m_isAllocatedOnHeap;
+    }
+#endif
+
 private:
     EnvironmentRecord* m_record;
     LexicalEnvironment* m_outerEnvironment;
+
+#ifndef NDEBUG
+    bool m_isAllocatedOnHeap;
+#endif
 };
 }
 #endif

--- a/src/runtime/ExecutionState.cpp
+++ b/src/runtime/ExecutionState.cpp
@@ -41,18 +41,6 @@ ExecutionStateRareData* ExecutionState::ensureRareData()
     return rareData();
 }
 
-FunctionObject* ExecutionState::resolveCallee()
-{
-    LexicalEnvironment* env = m_lexicalEnvironment;
-    while (env != nullptr) {
-        if (env->record()->isDeclarativeEnvironmentRecord() && env->record()->asDeclarativeEnvironmentRecord()->isFunctionEnvironmentRecord()) {
-            return env->record()->asDeclarativeEnvironmentRecord()->asFunctionEnvironmentRecord()->functionObject();
-        }
-        env = env->outerEnvironment();
-    }
-    return nullptr;
-}
-
 Object* ExecutionState::getNewTarget()
 {
     EnvironmentRecord* envRec = getThisEnvironment();

--- a/src/runtime/GlobalObject.cpp
+++ b/src/runtime/GlobalObject.cpp
@@ -153,7 +153,7 @@ public:
 
 static Value builtinEval(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    EvalFunctionObject* fn = (EvalFunctionObject*)state.resolveCallee();
+    EvalFunctionObject* fn = (EvalFunctionObject*)state.callee();
     return fn->m_globalObject->eval(state, argv[0]);
 }
 
@@ -189,7 +189,7 @@ Value GlobalObject::eval(ExecutionState& state, const Value& arg)
             }
         }
         ScriptParser parser(state.context());
-        const char* s = "eval input";
+        const char s[] = "eval input";
         bool strictFromOutside = false;
 
         volatile int sp;
@@ -220,9 +220,9 @@ Value GlobalObject::evalLocal(ExecutionState& state, const Value& arg, Value thi
             }
         }
         ScriptParser parser(state.context());
-        const char* s = "eval input";
+        const char s[] = "eval input";
         ExecutionState* current = &state;
-        bool isRunningEvalOnFunction = state.resolveCallee();
+        bool isRunningEvalOnFunction = state.callee();
         bool strictFromOutside = state.inStrictMode();
         while (current != nullptr) {
             if (current->lexicalEnvironment()->record()->isDeclarativeEnvironmentRecord()) {

--- a/src/runtime/GlobalObjectBuiltinIntl.cpp
+++ b/src/runtime/GlobalObjectBuiltinIntl.cpp
@@ -1265,7 +1265,7 @@ static Value builtinIntlCollatorConstructor(ExecutionState& state, Value thisVal
 
 static Value builtinIntlCollatorCompare(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    FunctionObject* callee = state.resolveCallee();
+    FunctionObject* callee = state.callee();
     if (!callee->hasInternalSlot() || !callee->internalSlot()->hasOwnProperty(state, ObjectPropertyName(state, String::fromASCII("initializedCollator")))) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "Method called on incompatible receiver");
     }
@@ -1996,7 +1996,7 @@ static Value builtinIntlDateTimeFormatConstructor(ExecutionState& state, Value t
 
 static Value builtinIntlDateTimeFormatFormat(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    FunctionObject* callee = state.resolveCallee();
+    FunctionObject* callee = state.callee();
     if (!callee->hasInternalSlot() || !callee->internalSlot()->hasOwnProperty(state, ObjectPropertyName(state, String::fromASCII("initializedDateTimeFormat")))) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "Method called on incompatible receiver");
     }
@@ -2405,7 +2405,7 @@ static void initializeNumberFormat(ExecutionState& state, Object* numberFormat, 
 
 static Value builtinIntlNumberFormatFormat(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    FunctionObject* callee = state.resolveCallee();
+    FunctionObject* callee = state.callee();
     if (!callee->hasInternalSlot() || !callee->internalSlot()->hasOwnProperty(state, ObjectPropertyName(state, String::fromASCII("initializedNumberFormat")))) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "Method called on incompatible receiver");
     }

--- a/src/runtime/GlobalObjectBuiltinPromise.cpp
+++ b/src/runtime/GlobalObjectBuiltinPromise.cpp
@@ -358,7 +358,7 @@ static Value builtinPromiseThen(ExecutionState& state, Value thisValue, size_t a
 Value getCapabilitiesExecutorFunction(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
     auto strings = &state.context()->staticStrings();
-    Object* executor = state.resolveCallee();
+    Object* executor = state.callee();
     executor->deleteOwnProperty(state, strings->name);
     Object* executorInternalSlot = executor->ensureInternalSlot(state);
     if (!executorInternalSlot->getOwnProperty(state, strings->resolve).value(state, executorInternalSlot).isUndefined()
@@ -378,7 +378,7 @@ Value getCapabilitiesExecutorFunction(ExecutionState& state, Value thisValue, si
 Value promiseResolveFunction(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
     auto strings = &state.context()->staticStrings();
-    Object* callee = state.resolveCallee();
+    Object* callee = state.callee();
     Object* alreadyResolved = PromiseObject::resolvingFunctionAlreadyResolved(state, callee);
     Object* internalSlot = callee->internalSlot();
     PromiseObject* promise = internalSlot->getOwnProperty(state, strings->Promise).value(state, internalSlot).asObject()->asPromiseObject();
@@ -422,7 +422,7 @@ Value promiseResolveFunction(ExecutionState& state, Value thisValue, size_t argc
 Value promiseRejectFunction(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
     auto strings = &state.context()->staticStrings();
-    Object* callee = state.resolveCallee();
+    Object* callee = state.callee();
     Object* alreadyResolved = PromiseObject::resolvingFunctionAlreadyResolved(state, callee);
     Object* internalSlot = callee->internalSlot();
     PromiseObject* promise = internalSlot->getOwnProperty(state, strings->Promise).value(state, internalSlot).asObject()->asPromiseObject();
@@ -438,7 +438,7 @@ Value promiseRejectFunction(ExecutionState& state, Value thisValue, size_t argc,
 Value promiseAllResolveElementFunction(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
     auto strings = &state.context()->staticStrings();
-    Object* callee = state.resolveCallee();
+    Object* callee = state.callee();
     Value x = argv[0];
     Object* internalSlot = callee->internalSlot();
 

--- a/src/runtime/GlobalObjectBuiltinProxy.cpp
+++ b/src/runtime/GlobalObjectBuiltinProxy.cpp
@@ -47,7 +47,7 @@ static Value builtinProxyRevoke(ExecutionState& state, Value thisValue, size_t a
 {
     auto strings = &state.context()->staticStrings();
 
-    RevokeFunctionObject* revoke = (RevokeFunctionObject*)state.resolveCallee();
+    RevokeFunctionObject* revoke = (RevokeFunctionObject*)state.callee();
     ASSERT(revoke);
 
     // 1. Let p be the value of F’s [[RevocableProxy]] internal slot.

--- a/src/runtime/GlobalObjectBuiltinRegExp.cpp
+++ b/src/runtime/GlobalObjectBuiltinRegExp.cpp
@@ -42,7 +42,7 @@ static Value builtinRegExpConstructor(ExecutionState& state, Value thisValue, si
             // Let patternConstructor be Get(pattern, "constructor").
             Value patternConstructor = pattern.asObject()->get(state, ObjectPropertyName(state.context()->staticStrings().constructor)).value(state, pattern);
             // If SameValue(patternConstructor, newTarget), then return pattern.
-            if (patternConstructor == state.resolveCallee())
+            if (patternConstructor == state.callee())
                 return pattern;
         }
     }

--- a/src/runtime/GlobalRegExpFunctionObject.cpp
+++ b/src/runtime/GlobalRegExpFunctionObject.cpp
@@ -27,39 +27,39 @@ namespace Escargot {
 struct GlobalRegExpFunctionObjectBuiltinFunctions {
     static Value builtinGlobalRegExpFunctionObjectInputGetter(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
     {
-        return state.resolveCallee()->internalSlot()->asGlobalObject()->regexp()->m_status.input;
+        return state.callee()->internalSlot()->asGlobalObject()->regexp()->m_status.input;
     }
 
     static Value builtinGlobalRegExpFunctionObjectInputSetter(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
     {
-        state.resolveCallee()->internalSlot()->asGlobalObject()->regexp()->m_status.input = argv[0].toString(state);
+        state.callee()->internalSlot()->asGlobalObject()->regexp()->m_status.input = argv[0].toString(state);
         return Value();
     }
 
     static Value builtinGlobalRegExpFunctionObjectLastMatchGetter(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
     {
-        return Value(new StringView(state.resolveCallee()->internalSlot()->asGlobalObject()->regexp()->m_status.lastMatch));
+        return Value(new StringView(state.callee()->internalSlot()->asGlobalObject()->regexp()->m_status.lastMatch));
     }
 
     static Value builtinGlobalRegExpFunctionObjectLastParenGetter(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
     {
-        return Value(new StringView(state.resolveCallee()->internalSlot()->asGlobalObject()->regexp()->m_status.lastParen));
+        return Value(new StringView(state.callee()->internalSlot()->asGlobalObject()->regexp()->m_status.lastParen));
     }
 
     static Value builtinGlobalRegExpFunctionObjectLeftContextGetter(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
     {
-        return Value(new StringView(state.resolveCallee()->internalSlot()->asGlobalObject()->regexp()->m_status.leftContext));
+        return Value(new StringView(state.callee()->internalSlot()->asGlobalObject()->regexp()->m_status.leftContext));
     }
 
     static Value builtinGlobalRegExpFunctionObjectRightContextGetter(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
     {
-        return Value(new StringView(state.resolveCallee()->internalSlot()->asGlobalObject()->regexp()->m_status.rightContext));
+        return Value(new StringView(state.callee()->internalSlot()->asGlobalObject()->regexp()->m_status.rightContext));
     }
 
 #define DEFINE_GETTER(number)                                                                                                                                    \
     static Value builtinGlobalRegExpFunctionObjectDollar##number##Getter(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression) \
     {                                                                                                                                                            \
-        auto& status = state.resolveCallee()->internalSlot()->asGlobalObject()->regexp()->m_status;                                                              \
+        auto& status = state.callee()->internalSlot()->asGlobalObject()->regexp()->m_status;                                                                     \
         if (status.pairCount < number) {                                                                                                                         \
             return Value(String::emptyString);                                                                                                                   \
         }                                                                                                                                                        \

--- a/src/runtime/NativeFunctionObject.cpp
+++ b/src/runtime/NativeFunctionObject.cpp
@@ -122,10 +122,6 @@ Value NativeFunctionObject::processNativeFunctionCall(ExecutionState& state, con
 
     CallNativeFunctionData* code = m_codeBlock->nativeFunctionData();
 
-    // TODO don't make LexicalEnvironment if possiable
-    FunctionEnvironmentRecordSimple record(this, 0, nullptr);
-    LexicalEnvironment env(&record, nullptr);
-
     size_t len = m_codeBlock->parameterCount();
     if (argc < len) {
         Value* newArgv = (Value*)alloca(sizeof(Value) * len);
@@ -139,7 +135,7 @@ Value NativeFunctionObject::processNativeFunctionCall(ExecutionState& state, con
     }
 
     Value receiver = receiverSrc;
-    ExecutionState newState(ctx, &state, &env, isStrict, &receiver);
+    ExecutionState newState(ctx, &state, nullptr, this, isStrict);
 
     if (!isConstruct) {
         // prepare receiver
@@ -179,7 +175,7 @@ Value NativeFunctionObject::processNativeFunctionCall(ExecutionState& state, con
         }
         return result;
     } catch (const Value& v) {
-        ByteCodeInterpreter::processException(newState, v, SIZE_MAX);
+        ByteCodeInterpreter::processException(newState, v, m_codeBlock, SIZE_MAX);
         return Value();
     }
 }

--- a/src/runtime/ScriptArrowFunctionObject.cpp
+++ b/src/runtime/ScriptArrowFunctionObject.cpp
@@ -34,6 +34,6 @@ public:
 
 Value ScriptArrowFunctionObject::call(ExecutionState& state, const Value& thisValue, const size_t argc, NULLABLE Value* argv)
 {
-    return FunctionObjectProcessCallGenerator::processCall<ScriptArrowFunctionObject, false, ScriptArrowFunctionObjectThisValueBinder, FunctionObjectNewTargetBinder, FunctionObjectReturnValueBinder>(state, this, thisValue, argc, argv, nullptr);
+    return FunctionObjectProcessCallGenerator::processCall<ScriptArrowFunctionObject, false, false, false, ScriptArrowFunctionObjectThisValueBinder, FunctionObjectNewTargetBinder, FunctionObjectReturnValueBinder>(state, this, thisValue, argc, argv, nullptr);
 }
 }

--- a/src/runtime/ScriptClassConstructorFunctionObject.cpp
+++ b/src/runtime/ScriptClassConstructorFunctionObject.cpp
@@ -122,7 +122,7 @@ Object* ScriptClassConstructorFunctionObject::construct(ExecutionState& state, c
     // Else, ReturnIfAbrupt(result).
     // Return envRec.GetThisBinding().
     // -> perform at ScriptClassConstructorFunctionObjectReturnValueBinderWithConstruct
-    return FunctionObjectProcessCallGenerator::processCall<ScriptClassConstructorFunctionObject, true, ScriptClassConstructorFunctionObjectThisValueBinder,
+    return FunctionObjectProcessCallGenerator::processCall<ScriptClassConstructorFunctionObject, true, true, true, ScriptClassConstructorFunctionObjectThisValueBinder,
                                                            ScriptClassConstructorFunctionObjectNewTargetBinderWithConstruct, ScriptClassConstructorFunctionObjectReturnValueBinderWithConstruct>(state, this, thisArgument, argc, argv, newTarget)
         .asObject();
 }

--- a/src/runtime/ScriptFunctionObject.h
+++ b/src/runtime/ScriptFunctionObject.h
@@ -31,8 +31,6 @@ public:
     ScriptFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, bool isConstructor, bool isGenerator);
 
 protected:
-    ScriptFunctionObject(ExecutionState& state, size_t defaultSpace); // function for derived classes. derived class MUST initlize member variable of FunctionObject.
-
     friend class FunctionObjectProcessCallGenerator;
     // https://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist
     virtual Value call(ExecutionState& state, const Value& thisValue, const size_t argc, NULLABLE Value* argv) override;


### PR DESCRIPTION
* Remove some unused function, variables
* Remove LexicalEnvironment from NativeFunctionObject
* Don't save stack-allocated LexicalEnvironment on ScriptFunctionObject. it may cause memory leak from stack
* Don't store newTarget, ThisBinded value on FunctionEnvironmentRecord if possible(we don't need these values except class functions)

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>