### PR TITLE
Fix minor bugs

### DIFF
--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -200,21 +200,9 @@ static Value builtinFunctionHasInstanceOf(ExecutionState& state, Value thisValue
     return Value(Object::hasInstance(state, thisValue, argv[0]));
 }
 
-static Value builtinCallerandArgumentsGetterSetter(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
-{
-    if (thisValue.isFunction()) {
-        FunctionObject* function = thisValue.asFunction();
-        bool needsThrower = function->codeBlock()->isStrict() && !function->codeBlock()->hasCallNativeFunctionCode();
-        if (needsThrower || function == state.context()->globalObject()->functionPrototype() || function == state.context()->globalObject()->function() || (function->isConstructor() && function->isClassConstructor())) {
-            state.throwException(new TypeErrorObject(state, String::fromUTF8("", 0)));
-        }
-    }
-    return Value();
-}
-
 void GlobalObject::installFunction(ExecutionState& state)
 {
-    FunctionObject* emptyFunction = new NativeFunctionObject(state, new CodeBlock(state.context(), NativeFunctionInfo(state.context()->staticStrings().Function, builtinFunctionEmptyFunction, 0, 0)),
+    FunctionObject* emptyFunction = new NativeFunctionObject(state, new CodeBlock(state.context(), NativeFunctionInfo(state.context()->staticStrings().Function, builtinFunctionEmptyFunction, 0, NativeFunctionInfo::Strict)),
                                                              NativeFunctionObject::__ForGlobalBuiltin__);
 
     m_functionPrototype = emptyFunction;
@@ -244,15 +232,7 @@ void GlobalObject::installFunction(ExecutionState& state)
     m_functionPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, Value(state.context()->vmInstance()->globalSymbols().hasInstance)),
                                                           ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(AtomicString(state, String::fromASCII("[Symbol.hasInstance]")), builtinFunctionHasInstanceOf, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::NonWritablePresent | ObjectPropertyDescriptor::NonConfigurablePresent)));
 
-    // 8.2.2 - 12
-    // AddRestrictedFunctionProperties(funcProto, realmRec).
-    auto fn = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().caller, builtinCallerandArgumentsGetterSetter, 0, NativeFunctionInfo::Strict));
-    JSGetterSetter gs(fn, fn);
-    ObjectPropertyDescriptor desc(gs, ObjectPropertyDescriptor::ConfigurablePresent);
-    m_functionPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().caller), desc);
-    m_functionPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().arguments), desc);
-
     defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().Function),
                       ObjectPropertyDescriptor(m_function, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 }
-}
+} // namespace Escargot

--- a/src/runtime/GlobalObjectBuiltinGeneratorFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinGeneratorFunction.cpp
@@ -33,7 +33,7 @@ static Value builtinGeneratorFunction(ExecutionState& state, Value thisValue, si
     Value sourceValue = argc >= 1 ? argv[argc - 1] : Value(String::emptyString);
     auto functionSource = FunctionObject::createFunctionSourceFromScriptSource(state, state.context()->staticStrings().anonymous, argumentVectorCount, argv, sourceValue, false, true);
 
-    return new ScriptFunctionObject(state, functionSource.codeBlock, functionSource.outerEnvironment, true, false);
+    return new ScriptFunctionObject(state, functionSource.codeBlock, functionSource.outerEnvironment, true, true);
 }
 
 static Value builtinGeneratorNext(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)

--- a/test/es2015/generator_has-instance.js
+++ b/test/es2015/generator_has-instance.js
@@ -1,0 +1,23 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var GeneratorFunction = Object.getPrototypeOf(function* () {}).constructor;
+function* gDecl() {}
+var gExpr = function* () {};
+
+assert(gDecl instanceof GeneratorFunction)
+assert(gExpr instanceof GeneratorFunction)
+assert(new GeneratorFunction() instanceof GeneratorFunction)
+assert(GeneratorFunction() instanceof GeneratorFunction)

--- a/test/es2015/proxy_with_function_restrict_property.js
+++ b/test/es2015/proxy_with_function_restrict_property.js
@@ -1,0 +1,39 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const handler = {
+    get: function (target, name) {
+        return (
+            name in target ? target[name] : 42
+        );
+    }
+};
+
+var target1 = function () { };
+const proxy1 = new Proxy(target1, handler);
+assert(proxy1.__proto__ === Function.prototype)
+assert(proxy1.caller === null)
+try {
+    proxy1.__proto__.caller
+    assert(false);
+} catch (e) {
+    assert(e instanceof TypeError);
+}
+
+const target2 = {};
+const proxy2 = new Proxy(target2, handler);
+assert(proxy2.__proto__ === Object.prototype)
+assert(proxy2.caller == 42)
+assert(proxy2.__proto__.caller === undefined)

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -164,7 +164,6 @@
   <test id="15.3.4.5-20-3"><reason>TODO</reason></test>
   <test id="15.3.4.5-21-2"><reason>TODO</reason></test>
   <test id="15.3.4.5-21-3"><reason>TODO</reason></test>
-  <test id="BoundFunction_restricted-properties"><reason>TODO</reason></test>
   <test id="S15.3.4.4_A9"><reason>TODO</reason></test>
   <test id="S15.3.4.2_A9"><reason>TODO</reason></test>
   <test id="Symbol.toStringTag"><reason>TODO</reason></test>
@@ -327,6 +326,8 @@
   <test id="unicode_restricted_incomple_quantifier"><reason>TODO</reason></test>
   <test id="unicode_restricted_octal_escape"><reason>TODO</reason></test>
   <test id="unicode_restricted_quantifiable_assertion"><reason>TODO</reason></test>
+  <test id="10.6-13-a-2"><reason>Need to set caller of arguments's callee correctly(not 'null' or 'undefined')</reason></test>
+  <test id="10.6-13-a-3"><reason>Need to set caller of arguments's callee correctly(not 'null' or 'undefined')</reason></test>
   <test id="15.10.6"><reason>TODO</reason></test>
   <test id="S15.10.6.2_A5_T3"><reason>TODO</reason></test>
   <test id="S15.10.6.2_A9"><reason>TODO</reason></test>
@@ -504,7 +505,6 @@
   <test id="number"><reason>TODO</reason></test>
   <test id="numbers-class"><reason>TODO</reason></test>
   <test id="numbers-object"><reason>TODO</reason></test>
-  <test id="ArrowFunction_restricted-properties"><reason>TODO</reason></test>
   <test id="lexical-bindings-overriden-by-formal-parameters-non-strict"><reason>TODO</reason></test>
   <test id="lexical-new.target-closure-returned"><reason>TODO</reason></test>
   <test id="lexical-new.target"><reason>TODO</reason></test>
@@ -740,7 +740,6 @@
   <test id="star-iterable"><reason>TODO</reason></test>
   <test id="star-string"><reason>TODO</reason></test>
   <test id="within-for"><reason>TODO</reason></test>
-  <test id="Generator_restricted-properties"><reason>TODO</reason></test>
   <test id="yield-as-label-in-sloppy"><reason>TODO</reason></test>
   <test id="let-non-strict-access"><reason>TODO</reason></test>
   <test id="let-non-strict-syntax"><reason>TODO</reason></test>


### PR DESCRIPTION
* Mark ScriptFunction instance created by GeneratorFunction constructor as GeneratorFunction
* handle restricted function properties in various cases
* Pass more tests and add internal tests
* Exclude accidentally passed test

Signed-off-by: Boram Bae <boram21.bae@samsung.com>