### PR TITLE
Don't store argc, argv on FunctionEnvironmentRecord.

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -1212,7 +1212,7 @@ public:
 
 static Value publicFunctionBridge(ExecutionState& state, Value thisValue, size_t calledArgc, Value* calledArgv, bool isNewExpression)
 {
-    CodeBlock* dataCb = state.lexicalEnvironment()->record()->asDeclarativeEnvironmentRecord()->asFunctionEnvironmentRecord()->functionObject()->codeBlock();
+    CodeBlock* dataCb = state.callee()->codeBlock();
     CallPublicFunctionData* code = (CallPublicFunctionData*)(dataCb->nativeFunctionData());
     ValueRef** newArgv = ALLOCA(sizeof(ValueRef*) * calledArgc, ValueRef*, state);
     for (size_t i = 0; i < calledArgc; i++) {
@@ -1421,9 +1421,7 @@ std::vector<FunctionObjectRef*> ExecutionStateRef::resolveCallstack()
     while (state) {
         if (state->lexicalEnvironment() && state->lexicalEnvironment()->record()->isDeclarativeEnvironmentRecord()
             && state->lexicalEnvironment()->record()->asDeclarativeEnvironmentRecord()->isFunctionEnvironmentRecord()) {
-            auto r = state->lexicalEnvironment()->record()->asDeclarativeEnvironmentRecord()->asFunctionEnvironmentRecord();
-            FunctionObject* callee = r->functionObject();
-            result.push_back(toRef(callee));
+            result.push_back(toRef(state->callee()));
         }
         state = state->parent();
     }

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -1028,7 +1028,7 @@ Value ByteCodeInterpreter::interpret(ExecutionState& state, ByteCodeBlock* byteC
                 :
             {
                 CreateRestElement* code = (CreateRestElement*)programCounter;
-                registerFile[code->m_registerIndex] = createRestElementOperation(state, state.lexicalEnvironment()->record(), byteCodeBlock);
+                registerFile[code->m_registerIndex] = createRestElementOperation(state, byteCodeBlock);
                 ADD_PROGRAM_COUNTER(CreateRestElement);
                 NEXT_INSTRUCTION();
             }
@@ -2237,14 +2237,14 @@ NEVER_INLINE void ByteCodeInterpreter::createFunctionOperation(ExecutionState& s
     }
 }
 
-NEVER_INLINE ArrayObject* ByteCodeInterpreter::createRestElementOperation(ExecutionState& state, EnvironmentRecord* record, ByteCodeBlock* byteCodeBlock)
+NEVER_INLINE ArrayObject* ByteCodeInterpreter::createRestElementOperation(ExecutionState& state, ByteCodeBlock* byteCodeBlock)
 {
-    ASSERT(record->isDeclarativeEnvironmentRecord() && record->asDeclarativeEnvironmentRecord()->isFunctionEnvironmentRecord());
+    ASSERT(state.callee());
 
     ArrayObject* newArray;
     size_t parameterLen = (size_t)byteCodeBlock->m_codeBlock->parameterCount();
-    size_t argc = record->asDeclarativeEnvironmentRecord()->asFunctionEnvironmentRecord()->argc();
-    Value* argv = record->asDeclarativeEnvironmentRecord()->asFunctionEnvironmentRecord()->argv();
+    size_t argc = state.argc();
+    Value* argv = state.argv();
 
     if (argc > parameterLen) {
         size_t arrLen = argc - parameterLen;

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -87,7 +87,7 @@ public:
     static size_t tryOperation(ExecutionState& state, TryOperation* code, LexicalEnvironment* env, size_t programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
 
     static void createFunctionOperation(ExecutionState& state, CreateFunction* createFunction, ByteCodeBlock* byteCodeBlock, Value* registerFile);
-    static ArrayObject* createRestElementOperation(ExecutionState& state, EnvironmentRecord* record, ByteCodeBlock* byteCodeBlock);
+    static ArrayObject* createRestElementOperation(ExecutionState& state, ByteCodeBlock* byteCodeBlock);
     static void evalOperation(ExecutionState& state, CallEvalFunction* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void classOperation(ExecutionState& state, CreateClass* code, Value* registerFile);
     static void superOperation(ExecutionState& state, SuperReference* code, Value* registerFile);

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -176,10 +176,10 @@ Value Script::executeLocal(ExecutionState& state, Value thisValue, InterpretedCo
             }
         }
 
-        if (fnRecord->hasBinding(newState, arguments).m_index == SIZE_MAX && fnRecord->functionObject()->isScriptFunctionObject()) {
+        if (fnRecord->hasBinding(newState, arguments).m_index == SIZE_MAX && state.callee()->isScriptFunctionObject()) {
             // FIXME check if formal parameters does not contain a rest parameter, any binding patterns, or any initializers.
-            bool isMapped = !fnRecord->functionObject()->codeBlock()->hasArgumentInitializers() && !inStrict;
-            fnRecord->functionObject()->asScriptFunctionObject()->generateArgumentsObject(newState, fnRecord, nullptr, isMapped);
+            bool isMapped = !state.callee()->codeBlock()->hasArgumentInitializers() && !inStrict;
+            state.callee()->asScriptFunctionObject()->generateArgumentsObject(newState, state.argc(), state.argv(), fnRecord, nullptr, isMapped);
         }
     }
 

--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -27,12 +27,13 @@ namespace Escargot {
 
 class FunctionEnvironmentRecord;
 class InterpretedCodeBlock;
+class ScriptFunctionObject;
 
 extern size_t g_argumentsObjectTag;
 
 class ArgumentsObject : public Object {
 public:
-    ArgumentsObject(ExecutionState& state, FunctionEnvironmentRecord* record, bool isMapped);
+    ArgumentsObject(ExecutionState& state, ScriptFunctionObject* sourceFunctionObject, size_t argc, Value* argv, FunctionEnvironmentRecord* environmentRecordWillArgumentsObjectBeLocatedIn, bool isMapped);
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) override;
     virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
@@ -53,6 +54,7 @@ private:
     FunctionEnvironmentRecord* m_targetRecord;
     InterpretedCodeBlock* m_codeBlock;
     TightVector<std::pair<SmallValue, AtomicString>, GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<SmallValue, AtomicString>>> m_parameterMap;
+    size_t m_argc;
     TightVector<bool, GCUtil::gc_malloc_atomic_ignore_off_page_allocator<bool>> m_modifiedArguments;
 
     Value getIndexedPropertyValueQuickly(ExecutionState& state, uint64_t index);

--- a/src/runtime/EnvironmentRecord.cpp
+++ b/src/runtime/EnvironmentRecord.cpp
@@ -248,8 +248,8 @@ void DeclarativeEnvironmentRecordNotIndexed::initializeBinding(ExecutionState& s
 }
 
 template <bool canBindThisValue, bool hasNewTarget>
-FunctionEnvironmentRecordOnHeap<canBindThisValue, hasNewTarget>::FunctionEnvironmentRecordOnHeap(FunctionObject* function, size_t argc, Value* argv)
-    : FunctionEnvironmentRecordWithExtraData<canBindThisValue, hasNewTarget>(function, argc, argv)
+FunctionEnvironmentRecordOnHeap<canBindThisValue, hasNewTarget>::FunctionEnvironmentRecordOnHeap(FunctionObject* function)
+    : FunctionEnvironmentRecordWithExtraData<canBindThisValue, hasNewTarget>(function)
     , m_heapStorage(function->codeBlock()->asInterpretedCodeBlock()->identifierOnHeapCount())
 {
 }
@@ -268,8 +268,8 @@ void FunctionEnvironmentRecordOnHeap<canBindThisValue, hasNewTarget>::setMutable
 }
 
 template <bool canBindThisValue, bool hasNewTarget>
-FunctionEnvironmentRecordNotIndexed<canBindThisValue, hasNewTarget>::FunctionEnvironmentRecordNotIndexed(FunctionObject* function, size_t argc, Value* argv)
-    : FunctionEnvironmentRecordWithExtraData<canBindThisValue, hasNewTarget>(function, argc, argv)
+FunctionEnvironmentRecordNotIndexed<canBindThisValue, hasNewTarget>::FunctionEnvironmentRecordNotIndexed(FunctionObject* function)
+    : FunctionEnvironmentRecordWithExtraData<canBindThisValue, hasNewTarget>(function)
     , m_heapStorage()
 {
     const InterpretedCodeBlock::IdentifierInfoVector& vec = function->codeBlock()->asInterpretedCodeBlock()->identifierInfos();

--- a/src/runtime/EnvironmentRecord.h
+++ b/src/runtime/EnvironmentRecord.h
@@ -689,11 +689,9 @@ struct FunctionEnvironmentRecordPiece<true, true> {
 
 class FunctionEnvironmentRecord : public DeclarativeEnvironmentRecord {
 public:
-    FunctionEnvironmentRecord(FunctionObject* function, size_t argc, Value* argv)
+    FunctionEnvironmentRecord(FunctionObject* function)
         : DeclarativeEnvironmentRecord()
         , m_functionObject(function)
-        , m_argc(argc)
-        , m_argv(argv)
     {
     }
 
@@ -735,21 +733,6 @@ public:
     FunctionObject* functionObject()
     {
         return m_functionObject;
-    }
-
-    size_t argc()
-    {
-        return m_argc;
-    }
-
-    Value* argv()
-    {
-        return m_argv;
-    }
-
-    Value createArgumentsObject(ExecutionState& state, bool isMapped)
-    {
-        return new ArgumentsObject(state, this, isMapped);
     }
 
     virtual bool hasSuperBinding()
@@ -799,8 +782,6 @@ public:
 
 protected:
     FunctionObject* m_functionObject;
-    size_t m_argc;
-    Value* m_argv;
 };
 
 template <bool canBindThisValue, bool hasNewTarget>
@@ -810,8 +791,8 @@ class FunctionEnvironmentRecordWithExtraData : public FunctionEnvironmentRecord 
     friend class ByteCodeInterpreter;
 
 public:
-    ALWAYS_INLINE explicit FunctionEnvironmentRecordWithExtraData(FunctionObject* function, size_t argc, Value* argv)
-        : FunctionEnvironmentRecord(function, argc, argv)
+    ALWAYS_INLINE explicit FunctionEnvironmentRecordWithExtraData(FunctionObject* function)
+        : FunctionEnvironmentRecord(function)
     {
     }
 
@@ -842,8 +823,8 @@ protected:
 template <bool canBindThisValue, bool hasNewTarget>
 class FunctionEnvironmentRecordOnStack : public FunctionEnvironmentRecordWithExtraData<canBindThisValue, hasNewTarget> {
 public:
-    FunctionEnvironmentRecordOnStack(FunctionObject* function, size_t argc, Value* argv)
-        : FunctionEnvironmentRecordWithExtraData<canBindThisValue, hasNewTarget>(function, argc, argv)
+    FunctionEnvironmentRecordOnStack(FunctionObject* function)
+        : FunctionEnvironmentRecordWithExtraData<canBindThisValue, hasNewTarget>(function)
     {
     }
 
@@ -860,7 +841,7 @@ class FunctionEnvironmentRecordOnHeap : public FunctionEnvironmentRecordWithExtr
     friend class ScriptFunctionObject;
 
 public:
-    FunctionEnvironmentRecordOnHeap(FunctionObject* function, size_t argc, Value* argv);
+    FunctionEnvironmentRecordOnHeap(FunctionObject* function);
 
     virtual bool isFunctionEnvironmentRecordOnHeap() override
     {
@@ -944,7 +925,7 @@ class FunctionEnvironmentRecordNotIndexed : public FunctionEnvironmentRecordWith
     friend class LexicalEnvironment;
 
 public:
-    FunctionEnvironmentRecordNotIndexed(FunctionObject* function, size_t argc, Value* argv);
+    FunctionEnvironmentRecordNotIndexed(FunctionObject* function);
 
     virtual bool isFunctionEnvironmentRecordNotIndexed() override
     {
@@ -1007,8 +988,8 @@ private:
 
 class FunctionEnvironmentRecordNotIndexedWithVirtualID : public FunctionEnvironmentRecordNotIndexed<true, true> {
 public:
-    FunctionEnvironmentRecordNotIndexedWithVirtualID(FunctionObject* function, size_t argc, Value* argv)
-        : FunctionEnvironmentRecordNotIndexed(function, argc, argv)
+    FunctionEnvironmentRecordNotIndexedWithVirtualID(FunctionObject* function)
+        : FunctionEnvironmentRecordNotIndexed(function)
     {
     }
 

--- a/src/runtime/ExecutionState.h
+++ b/src/runtime/ExecutionState.h
@@ -56,6 +56,8 @@ public:
         : m_context(context)
         , m_lexicalEnvironment(nullptr)
         , m_callee(nullptr)
+        , m_argc(0)
+        , m_argv(nullptr)
         , m_parent(1)
         , m_inStrictMode(false)
     {
@@ -68,26 +70,32 @@ public:
         , m_lexicalEnvironment(lexicalEnvironment)
         , m_stackBase(parent->stackBase())
         , m_callee(parent->callee())
+        , m_argc(parent->argc())
+        , m_argv(parent->argv())
         , m_parent((size_t)parent + 1)
         , m_inStrictMode(inStrictMode)
     {
     }
 
-    ALWAYS_INLINE ExecutionState(Context* context, ExecutionState* parent, LexicalEnvironment* lexicalEnvironment, FunctionObject* callee, bool inStrictMode)
+    ALWAYS_INLINE ExecutionState(Context* context, ExecutionState* parent, LexicalEnvironment* lexicalEnvironment, FunctionObject* callee, size_t argc, Value* argv, bool inStrictMode)
         : m_context(context)
         , m_lexicalEnvironment(lexicalEnvironment)
         , m_stackBase(parent->stackBase())
         , m_callee(callee)
+        , m_argc(argc)
+        , m_argv(argv)
         , m_parent((size_t)parent + 1)
         , m_inStrictMode(inStrictMode)
     {
     }
 
-    ExecutionState(Context* context, ExecutionState* parent, LexicalEnvironment* lexicalEnvironment, FunctionObject* callee, bool inStrictMode, Value* registerFile)
+    ExecutionState(Context* context, ExecutionState* parent, LexicalEnvironment* lexicalEnvironment, FunctionObject* callee, size_t argc, Value* argv, bool inStrictMode, Value* registerFile)
         : m_context(context)
         , m_lexicalEnvironment(lexicalEnvironment)
         , m_stackBase(parent->stackBase())
         , m_callee(callee)
+        , m_argc(argc)
+        , m_argv(argv)
         , m_parent((size_t)parent + 1)
         , m_inStrictMode(inStrictMode)
     {
@@ -173,6 +181,16 @@ public:
         return m_callee;
     }
 
+    size_t argc()
+    {
+        return m_argc;
+    }
+
+    Value* argv()
+    {
+        return m_argv;
+    }
+
     // http://www.ecma-international.org/ecma-262/6.0/#sec-getnewtarget
     Object* getNewTarget();
     // http://www.ecma-international.org/ecma-262/6.0/#sec-getthisenvironment
@@ -185,6 +203,8 @@ private:
     LexicalEnvironment* m_lexicalEnvironment;
     size_t m_stackBase;
     FunctionObject* m_callee;
+    size_t m_argc;
+    Value* m_argv;
 
     union {
         size_t m_parent;

--- a/src/runtime/NativeFunctionObject.cpp
+++ b/src/runtime/NativeFunctionObject.cpp
@@ -135,7 +135,7 @@ Value NativeFunctionObject::processNativeFunctionCall(ExecutionState& state, con
     }
 
     Value receiver = receiverSrc;
-    ExecutionState newState(ctx, &state, nullptr, this, isStrict);
+    ExecutionState newState(ctx, &state, nullptr, this, argc, argv, isStrict);
 
     if (!isConstruct) {
         // prepare receiver

--- a/src/runtime/ScriptFunctionObject.h
+++ b/src/runtime/ScriptFunctionObject.h
@@ -52,7 +52,7 @@ protected:
         return true;
     }
 
-    void generateArgumentsObject(ExecutionState& state, FunctionEnvironmentRecord* fnRecord, Value* stackStorage, bool isMapped);
+    void generateArgumentsObject(ExecutionState& state, size_t argc, Value* argv, FunctionEnvironmentRecord* environmentRecordWillArgumentsObjectBeLocatedIn, Value* stackStorage, bool isMapped);
     void generateRestParameter(ExecutionState& state, FunctionEnvironmentRecord* record, Value* parameterStorageInStack, const size_t argc, Value* argv);
     void generateByteCodeBlock(ExecutionState& state);
 


### PR DESCRIPTION
Save argc, argv on ExecutionState is enough.
and if function call is end, argv member on env points wrong place.

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>