### PR TITLE
Expand the parsing scope of function to include parameters

### DIFF
--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -139,9 +139,10 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
     // generate common codes
     try {
         ast->generateStatementByteCode(block, &ctx);
+        // add return bytecode at the end of function body
         if (!isGlobalScope && !isEvalMode) {
-            ASSERT(ast->type() == ASTNodeType::BlockStatement);
-            BlockStatementNode* blk = (BlockStatementNode*)ast;
+            ASSERT(ast->type() == ASTNodeType::Function);
+            BlockStatementNode* blk = ((FunctionNode*)ast)->body();
             StatementNode* nd = blk->firstChild();
             StatementNode* last = nullptr;
             while (nd) {

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -194,8 +194,8 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     , m_lexicalBlockIndexFunctionLocatedIn(0)
     , m_parentCodeBlock(nullptr)
 #ifndef NDEBUG
-    , m_locStart(SIZE_MAX, SIZE_MAX, SIZE_MAX)
-    , m_locEnd(SIZE_MAX, SIZE_MAX, SIZE_MAX)
+    , m_bodyStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
+    , m_bodyEndLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
     , m_scopeContext(nullptr)
 #endif
 {
@@ -253,8 +253,9 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
 
 InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTFunctionScopeContext* scopeCtx, ExtendedNodeLOC sourceElementStart, InterpretedCodeBlock* parentBlock, bool isEvalCode, bool isEvalCodeInFunction)
     : m_script(script)
-    , m_paramsSrc((scopeCtx->m_hasRestElement || scopeCtx->m_hasPatternArgument) ? StringView(src, scopeCtx->m_paramsStart.index, scopeCtx->m_locStart.index) : StringView())
-    , m_src(StringView(src, scopeCtx->m_locStart.index, scopeCtx->m_locEnd.index))
+    , m_src(StringView(src, scopeCtx->m_paramsStartLOC.index, scopeCtx->m_bodyEndLOC.index))
+    // FIXME replace m_bodySrc by bodySrcLength
+    , m_bodySrc(StringView(src, scopeCtx->m_bodyStartLOC.index, scopeCtx->m_bodyEndLOC.index))
     , m_sourceElementStart(sourceElementStart)
     , m_identifierOnStackCount(0)
     , m_identifierOnHeapCount(0)
@@ -262,8 +263,8 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     , m_lexicalBlockIndexFunctionLocatedIn(scopeCtx->m_lexicalBlockIndexFunctionLocatedIn)
     , m_parentCodeBlock(parentBlock)
 #ifndef NDEBUG
-    , m_locStart(SIZE_MAX, SIZE_MAX, SIZE_MAX)
-    , m_locEnd(SIZE_MAX, SIZE_MAX, SIZE_MAX)
+    , m_bodyStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
+    , m_bodyEndLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
     , m_scopeContext(nullptr)
 #endif
 {

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -653,10 +653,9 @@ public:
         return m_src;
     }
 
-    const StringView& paramsSrc()
+    const StringView& bodySrc()
     {
-        ASSERT(m_hasArgumentInitializers);
-        return m_paramsSrc;
+        return m_bodySrc;
     }
 
     ExtendedNodeLOC sourceElementStart()
@@ -734,8 +733,8 @@ protected:
     }
 
     Script* m_script;
-    StringView m_paramsSrc; // function parameters elements src
-    StringView m_src; // function source elements src
+    StringView m_src; // function source including parameters
+    StringView m_bodySrc; // function body source
     ExtendedNodeLOC m_sourceElementStart;
 
     FunctionParametersInfoVector m_parametersInfomation;
@@ -750,8 +749,8 @@ protected:
     CodeBlockVector m_childBlocks;
 
 #ifndef NDEBUG
-    ExtendedNodeLOC m_locStart;
-    ExtendedNodeLOC m_locEnd;
+    ExtendedNodeLOC m_bodyStartLOC;
+    ExtendedNodeLOC m_bodyEndLOC;
     ASTFunctionScopeContext* m_scopeContext;
 #endif
 };

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -57,16 +57,12 @@ class ArrowFunctionExpressionNode : public ExpressionNode {
 public:
     friend class ScriptParser;
     ArrowFunctionExpressionNode(PatternNodeVector&& params, Node* body, ASTFunctionScopeContext* scopeContext, bool expression, size_t subCodeBlockIndex)
-        : m_function(AtomicString(), std::move(params), body, scopeContext, false, this)
-        , m_expression(expression)
+        : m_expression(expression)
         , m_subCodeBlockIndex(subCodeBlockIndex - 1)
     {
         scopeContext->m_isArrowFunctionExpression = true;
-    }
-
-    FunctionNode& function()
-    {
-        return m_function;
+        scopeContext->m_nodeType = this->type();
+        scopeContext->m_isGenerator = false;
     }
 
     virtual ASTNodeType type() { return ASTNodeType::ArrowFunctionExpression; }
@@ -77,7 +73,6 @@ public:
     }
 
 private:
-    FunctionNode m_function;
     bool m_expression : 1;
     size_t m_subCodeBlockIndex;
     // defaults: [ Expression ];

--- a/src/parser/ast/BlockStatementNode.h
+++ b/src/parser/ast/BlockStatementNode.h
@@ -28,18 +28,9 @@ namespace Escargot {
 class BlockStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    explicit BlockStatementNode(StatementContainer* body, size_t lexicalBlockIndex = 0, StatementContainer* argumentInitializers = nullptr)
+    explicit BlockStatementNode(StatementContainer* body, size_t lexicalBlockIndex = 0)
         : StatementNode()
         , m_container(body)
-        , m_argumentInitializers(argumentInitializers)
-        , m_lexicalBlockIndex(lexicalBlockIndex)
-    {
-    }
-
-    explicit BlockStatementNode(StatementContainer* body, StatementContainer* argumentInitializers = nullptr, size_t lexicalBlockIndex = 0)
-        : StatementNode()
-        , m_container(body)
-        , m_argumentInitializers(argumentInitializers)
         , m_lexicalBlockIndex(lexicalBlockIndex)
     {
     }
@@ -50,10 +41,6 @@ public:
     virtual ASTNodeType type() { return ASTNodeType::BlockStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context)
     {
-        if (m_argumentInitializers != nullptr) {
-            m_argumentInitializers->generateStatementByteCode(codeBlock, context);
-        }
-
         size_t lexicalBlockIndexBefore = context->m_lexicalBlockIndex;
         ByteCodeBlock::ByteCodeLexicalBlockContext blockContext;
         if (m_lexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
@@ -78,7 +65,6 @@ public:
 
 private:
     RefPtr<StatementContainer> m_container;
-    RefPtr<StatementContainer> m_argumentInitializers;
     LexicalBlockIndex m_lexicalBlockIndex;
 };
 }

--- a/src/parser/ast/DefaultArgumentNode.h
+++ b/src/parser/ast/DefaultArgumentNode.h
@@ -52,6 +52,11 @@ public:
         return m_left.get();
     }
 
+    Node* right()
+    {
+        return m_right.get();
+    }
+
     virtual ASTNodeType type() { return ASTNodeType::DefaultArgument; }
     virtual void generateResultNotRequiredExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context)
     {

--- a/src/parser/ast/FunctionDeclarationNode.h
+++ b/src/parser/ast/FunctionDeclarationNode.h
@@ -20,21 +20,16 @@
 #ifndef FunctionDeclarationNode_h
 #define FunctionDeclarationNode_h
 
-#include "FunctionNode.h"
-
 namespace Escargot {
 
 class FunctionDeclarationNode : public StatementNode {
 public:
     friend class ScriptParser;
     FunctionDeclarationNode(const AtomicString& id, PatternNodeVector&& params, Node* body, ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t /*subCodeBlockIndex not used yet*/)
-        : m_function(id, std::move(params), body, scopeContext, isGenerator, this)
+        : m_isGenerator(isGenerator)
     {
-    }
-
-    FunctionNode& function()
-    {
-        return m_function;
+        scopeContext->m_nodeType = this->type();
+        scopeContext->m_isGenerator = isGenerator;
     }
 
     virtual ASTNodeType type() { return ASTNodeType::FunctionDeclaration; }
@@ -43,8 +38,13 @@ public:
         // do nothing
     }
 
+    bool isGenerator() const
+    {
+        return m_isGenerator;
+    }
+
 private:
-    FunctionNode m_function;
+    bool m_isGenerator;
 };
 }
 

--- a/src/parser/ast/FunctionExpressionNode.h
+++ b/src/parser/ast/FunctionExpressionNode.h
@@ -20,22 +20,17 @@
 #ifndef FunctionExpressionNode_h
 #define FunctionExpressionNode_h
 
-#include "FunctionNode.h"
-
 namespace Escargot {
 
 class FunctionExpressionNode : public ExpressionNode {
 public:
     friend class ScriptParser;
     FunctionExpressionNode(const AtomicString& id, PatternNodeVector&& params, Node* body, ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t subCodeBlockIndex)
-        : m_function(id, std::move(params), body, scopeContext, isGenerator, this)
+        : m_isGenerator(isGenerator)
         , m_subCodeBlockIndex(subCodeBlockIndex - 1)
     {
-    }
-
-    FunctionNode& function()
-    {
-        return m_function;
+        scopeContext->m_nodeType = this->type();
+        scopeContext->m_isGenerator = isGenerator;
     }
 
     virtual ASTNodeType type() { return ASTNodeType::FunctionExpression; }
@@ -52,8 +47,13 @@ public:
         }
     }
 
+    bool isGenerator() const
+    {
+        return m_isGenerator;
+    }
+
 private:
-    FunctionNode m_function;
+    bool m_isGenerator;
     size_t m_subCodeBlockIndex;
     // defaults: [ Expression ];
     // rest: Identifier | null;

--- a/src/parser/ast/FunctionNode.h
+++ b/src/parser/ast/FunctionNode.h
@@ -20,51 +20,41 @@
 #ifndef FunctionNode_h
 #define FunctionNode_h
 
-#include "ExpressionNode.h"
+#include "Node.h"
 #include "StatementNode.h"
-#include "IdentifierNode.h"
+#include "BlockStatementNode.h"
 
 namespace Escargot {
 
-class FunctionNode {
+class FunctionNode : public StatementNode {
 public:
-    FunctionNode(const AtomicString& id, PatternNodeVector&& params, Node* body, ASTFunctionScopeContext* scopeContext, bool isGenerator, Node* node)
-        : m_isGenerator(isGenerator)
-        , m_id(id)
-        , m_params(std::move(params))
+    FunctionNode(StatementContainer* params, BlockStatementNode* body)
+        : StatementNode()
+        , m_params(params)
         , m_body(body)
-        , m_scopeContext(scopeContext)
-    {
-        m_scopeContext->m_nodeType = node->type();
-        m_scopeContext->m_isGenerator = isGenerator;
-    }
-    ~FunctionNode()
     {
     }
 
-    AtomicStringVector paramsToAtomicStringVector()
+    virtual ~FunctionNode()
     {
-        AtomicStringVector ret;
-
-        ret.resizeWithUninitializedValues(m_params.size());
-        for (size_t i = 0; i < m_params.size(); i++) {
-            ret[i] = m_params[i]->asIdentifier()->name();
-        }
-
-        return ret;
     }
 
-    inline const PatternNodeVector& params() { return m_params; }
-    inline Node* body() { return m_body.get(); }
-    inline const AtomicString& id() { return m_id; }
-    ASTFunctionScopeContext* scopeContext() { return m_scopeContext; }
-    inline bool isGenerator() { return m_isGenerator; };
+    virtual ASTNodeType type() { return ASTNodeType::Function; }
+    virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context)
+    {
+        m_params->generateStatementByteCode(codeBlock, context);
+        m_body->generateStatementByteCode(codeBlock, context);
+    }
+
+    BlockStatementNode* body()
+    {
+        ASSERT(!!m_body);
+        return m_body.get();
+    }
+
 private:
-    bool m_isGenerator : 1;
-    AtomicString m_id; // id: Identifier;
-    PatternNodeVector m_params; // params: [ Pattern ];
-    RefPtr<Node> m_body;
-    ASTFunctionScopeContext* m_scopeContext;
+    RefPtr<StatementContainer> m_params;
+    RefPtr<BlockStatementNode> m_body;
 };
 }
 

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -178,6 +178,7 @@ COMPILE_ASSERT(((int)BinaryExpressionGreaterThanOrEqual + 1) == (int)BinaryExpre
 COMPILE_ASSERT(((int)BinaryExpressionLessThan + 1) == (int)BinaryExpressionLessThanOrEqual, "");
 COMPILE_ASSERT(((int)BinaryExpressionLessThanOrEqual - (int)BinaryExpressionEqual) == 7, "");
 
+// Location in the script source code
 struct NodeLOC {
     size_t index;
     explicit NodeLOC(size_t index)
@@ -186,6 +187,7 @@ struct NodeLOC {
     }
 };
 
+// Extended location in the script source code
 struct ExtendedNodeLOC {
     union {
         size_t line;
@@ -218,8 +220,6 @@ class ObjectExpressionNode;
 class StatementNode;
 
 class Node : public RefCounted<Node> {
-    friend class ScriptParser;
-
 protected:
     Node()
         : m_loc(SIZE_MAX)
@@ -601,12 +601,12 @@ struct ASTFunctionScopeContext : public gc {
     // we can use atomic allocator here because there is no pointer value on Vector<m_numeralLiteralData>
     Vector<Value, GCUtil::gc_malloc_atomic_ignore_off_page_allocator<Value>> m_numeralLiteralData;
 
-    ExtendedNodeLOC m_locStart;
-    NodeLOC m_paramsStart;
+    ExtendedNodeLOC m_paramsStartLOC;
+    ExtendedNodeLOC m_bodyStartLOC;
 #ifndef NDEBUG
-    ExtendedNodeLOC m_locEnd;
+    ExtendedNodeLOC m_bodyEndLOC;
 #else
-    NodeLOC m_locEnd;
+    NodeLOC m_bodyEndLOC;
 #endif
 
     void *operator new(size_t size);
@@ -824,16 +824,16 @@ struct ASTFunctionScopeContext : public gc {
         , m_needsToComputeLexicalBlockStuffs(false)
         , m_nodeType(ASTNodeType::Program)
         , m_lexicalBlockIndexFunctionLocatedIn(LEXICAL_BLOCK_INDEX_MAX)
-        , m_locStart(SIZE_MAX, SIZE_MAX, SIZE_MAX)
-        , m_paramsStart(SIZE_MAX)
+        , m_paramsStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
+        , m_bodyStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
 #ifndef NDEBUG
-        , m_locEnd(SIZE_MAX, SIZE_MAX, SIZE_MAX)
+        , m_bodyEndLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
 #else
-        , m_locEnd(SIZE_MAX)
+        , m_bodyEndLOC(SIZE_MAX)
 #endif
     {
         // function is first block context
-        insertBlockScope(0, LEXICAL_BLOCK_INDEX_MAX, m_locStart);
+        insertBlockScope(0, LEXICAL_BLOCK_INDEX_MAX, m_bodyStartLOC);
     }
 };
 

--- a/src/parser/esprima_cpp/esprima.h
+++ b/src/parser/esprima_cpp/esprima.h
@@ -29,6 +29,7 @@
 namespace Escargot {
 
 class ProgramNode;
+class FunctionNode;
 class CodeBlock;
 
 namespace esprima {
@@ -59,7 +60,7 @@ struct Error : public gc {
 #define ESPRIMA_RECURSIVE_LIMIT 1024
 
 RefPtr<ProgramNode> parseProgram(::Escargot::Context* ctx, StringView source, bool strictFromOutside, bool inWith, size_t stackRemain);
-RefPtr<Node> parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock* codeBlock, ASTFunctionScopeContext*& scopeContext, size_t stackRemain);
+RefPtr<FunctionNode> parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock* codeBlock, ASTFunctionScopeContext*& scopeContext, size_t stackRemain);
 }
 }
 

--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -42,7 +42,7 @@ public:
     virtual bool set(ExecutionState& state, const ObjectPropertyName& propertyName, const Value& v, const Value& receiver) override;
     virtual bool setIndexedProperty(ExecutionState& state, const Value& property, const Value& value) override;
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty() override
     {
         return "Arguments";
     }

--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -55,7 +55,7 @@ static Value builtinFunctionConstructor(ExecutionState& state, Value thisValue, 
 static Value builtinFunctionToString(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
     // FIXME: If Type(func) is Object and is either a built-in function object or has an [[ECMAScriptCode]] internal slot, then
-    if (thisValue.isFunction()) {
+    if (LIKELY(thisValue.isFunction())) {
         FunctionObject* fn = thisValue.asFunction();
         StringBuilder builder;
         builder.appendString("function ");
@@ -73,7 +73,7 @@ static Value builtinFunctionToString(ExecutionState& state, Value thisValue, siz
 
         builder.appendString(") ");
         if (fn->codeBlock()->isInterpretedCodeBlock() && fn->codeBlock()->asInterpretedCodeBlock()->script() != nullptr) {
-            StringView src = fn->codeBlock()->asInterpretedCodeBlock()->src();
+            StringView src = fn->codeBlock()->asInterpretedCodeBlock()->bodySrc();
             while (src[src.length() - 1] != '}') {
                 src = StringView(src, 0, src.length() - 1);
             }


### PR DESCRIPTION
* we should parse the parameter list together for each function calls to treat argument initializers such as rest, default parameters
* for each function calls, we first parse the parameter list and then, parse the function body sequentially
* also remove and clearup some unnecessary parsing modules

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>