### PR TITLE
Implement lazy-creation of `arguments` object.

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -128,6 +128,7 @@ struct GlobalVariableAccessCacheItem;
     F(Yield, 0, 0)                                    \
     F(YieldDelegate, 1, 0)                            \
     F(BlockOperation, 0, 0)                           \
+    F(EnsureArgumentsObject, 0, 0)                    \
     F(End, 0, 0)
 
 enum Opcode {
@@ -2057,6 +2058,21 @@ public:
     void dump(const char* byteCodeStart)
     {
         printf("block operation (%p) -> end %d", m_blockInfo, (int)m_blockEndPosition);
+    }
+#endif
+};
+
+class EnsureArgumentsObject : public ByteCode {
+public:
+    EnsureArgumentsObject(const ByteCodeLOC& loc)
+        : ByteCode(Opcode::EnsureArgumentsObjectOpcode, loc)
+    {
+    }
+
+#ifndef NDEBUG
+    void dump(const char* byteCodeStart)
+    {
+        printf("ensure arguments object");
     }
 #endif
 };

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -573,10 +573,6 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
                 assignStackIndexIfNeeded(cd->m_dstIdx, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
             }
-            case BlockOperationOpcode: {
-                BlockOperation* cd = (BlockOperation*)currentCode;
-                break;
-            }
             case TryOperationOpcode: {
                 TryOperation* cd = (TryOperation*)currentCode;
                 assignStackIndexIfNeeded(cd->m_catchedValueRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -104,6 +104,8 @@ public:
     static Value incrementOperation(ExecutionState& state, const Value& value);
     static Value decrementOperation(ExecutionState& state, const Value& value);
 
+    static void ensureArgumentsObjectOperation(ExecutionState& state, ByteCodeBlock* byteCodeBlock, Value* registerFile);
+
     static void processException(ExecutionState& state, const Value& value, CodeBlock* codeBlock, size_t programCounter);
 };
 }

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -148,6 +148,11 @@ public:
         return m_canAllocateEnvironmentOnStack;
     }
 
+    bool isKindOfFunction() const
+    {
+        return m_isFunctionDeclaration || m_isFunctionExpression || m_isArrowFunctionExpression || m_isClassConstructor || m_isClassMethod || m_isClassStaticMethod || m_isGenerator || m_hasCallNativeFunctionCode;
+    }
+
     bool isFunctionDeclaration() const
     {
         return m_isFunctionDeclaration;

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -69,6 +69,9 @@ public:
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstIndex)
     {
         CodeBlock* blk = context->m_codeBlock->asInterpretedCodeBlock()->childBlocks()[m_subCodeBlockIndex];
+        if (blk->usesArgumentsObject() && !codeBlock->m_codeBlock->isArrowFunctionExpression()) {
+            codeBlock->pushCode(EnsureArgumentsObject(ByteCodeLOC(m_loc.index)), context, this);
+        }
         codeBlock->pushCode(CreateFunction(ByteCodeLOC(m_loc.index), dstIndex, SIZE_MAX, blk), context, this);
     }
 

--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -29,8 +29,6 @@ class FunctionEnvironmentRecord;
 class InterpretedCodeBlock;
 class ScriptFunctionObject;
 
-extern size_t g_argumentsObjectTag;
-
 class ArgumentsObject : public Object {
 public:
     ArgumentsObject(ExecutionState& state, ScriptFunctionObject* sourceFunctionObject, size_t argc, Value* argv, FunctionEnvironmentRecord* environmentRecordWillArgumentsObjectBeLocatedIn, bool isMapped);
@@ -47,12 +45,27 @@ public:
         return "Arguments";
     }
 
+    virtual bool isInlineCacheable() override
+    {
+        return false;
+    }
+
+    virtual bool isArgumentsObject() const override
+    {
+        return true;
+    }
+
+    ScriptFunctionObject* sourceFunctionObject() const
+    {
+        return m_sourceFunctionObject;
+    }
+
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 
 private:
     FunctionEnvironmentRecord* m_targetRecord;
-    InterpretedCodeBlock* m_codeBlock;
+    ScriptFunctionObject* m_sourceFunctionObject;
     TightVector<std::pair<SmallValue, AtomicString>, GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<SmallValue, AtomicString>>> m_parameterMap;
     size_t m_argc;
     TightVector<bool, GCUtil::gc_malloc_atomic_ignore_off_page_allocator<bool>> m_modifiedArguments;

--- a/src/runtime/FunctionObjectInlines.h
+++ b/src/runtime/FunctionObjectInlines.h
@@ -259,12 +259,6 @@ public:
                 newTargetBinder(*newState, self, newTarget, record);
             }
 
-            // FIXME
-            if (UNLIKELY(codeBlock->usesArgumentsObject())) {
-                bool isMapped = !codeBlock->hasArgumentInitializers() && !isStrict;
-                self->generateArgumentsObject(*newState, argc, argv, record, stackStorage, isMapped);
-            }
-
             GeneratorObject* gen = new GeneratorObject(state, newState, blk);
             newState->setGeneratorTarget(gen);
             return gen;
@@ -281,12 +275,6 @@ public:
         if (isConstructCall) {
             NewTargetBinder newTargetBinder;
             newTargetBinder(newState, self, newTarget, record);
-        }
-
-        if (UNLIKELY(codeBlock->usesArgumentsObject())) {
-            // FIXME check if formal parameters does not contain a rest parameter, any binding patterns, or any initializers.
-            bool isMapped = !codeBlock->hasArgumentInitializers() && !isStrict;
-            self->generateArgumentsObject(newState, argc, argv, record, stackStorage, isMapped);
         }
 
         // run function

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -32,6 +32,7 @@ class Object;
 class FunctionObject;
 class RegExpObject;
 class ErrorObject;
+class ArgumentsObject;
 class ArrayBufferObject;
 class ArrayBufferView;
 class DataViewObject;
@@ -570,6 +571,12 @@ public:
     {
         ASSERT(isDataViewObject());
         return (DataViewObject*)this;
+    }
+
+    ArgumentsObject* asArgumentsObject()
+    {
+        ASSERT(isArgumentsObject());
+        return (ArgumentsObject*)this;
     }
 
     template <typename TypedArrayType>

--- a/src/runtime/PointerValue.h
+++ b/src/runtime/PointerValue.h
@@ -240,6 +240,11 @@ public:
         return false;
     }
 
+    virtual bool isArgumentsObject() const
+    {
+        return false;
+    }
+
     virtual bool isCallable() const
     {
         return false;

--- a/src/runtime/ScriptFunctionObject.h
+++ b/src/runtime/ScriptFunctionObject.h
@@ -26,6 +26,7 @@ namespace Escargot {
 
 class ScriptFunctionObject : public FunctionObject {
     friend class Script;
+    friend class ByteCodeInterpreter;
 
 public:
     ScriptFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, bool isConstructor, bool isGenerator);

--- a/test/es2015/arrow-function-arguments-object.js
+++ b/test/es2015/arrow-function-arguments-object.js
@@ -1,0 +1,20 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function ff() {
+    var a = (k) => { return () => { return arguments[0] + 1;}};
+    return a(1)();
+}
+assert(ff(1) == 2)


### PR DESCRIPTION
* Store ArgumentsObject into Env record with functionObject
* Introduce gc memory leak checker
* Don't save stack pointer in ArgumentsObject

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>