### PR TITLE
Skip the parsing of arrow function body in scan mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
         - travis_wait 30 tools/run-tests.py --arch=x86_64 octane
         - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js internal jsc-stress v8 spidermonkey regression-tests es2015 intl chakracore
         - export GC_FREE_SPACE_DIVISOR=1
-        - travis_wait 30 tools/run-tests.py --arch=x86_64 test262
+        - travis_wait 40 tools/run-tests.py --arch=x86_64 test262
 
 
     - name: "linux.x64.release.jetstream"
@@ -71,7 +71,7 @@ matrix:
         - travis_wait 30 tools/run-tests.py --arch=x86 octane
         - tools/run-tests.py --arch=x86 jetstream-only-cdjs sunspider-js internal jsc-stress v8 spidermonkey regression-tests es2015 intl chakracore
         - export GC_FREE_SPACE_DIVISOR=1
-        - travis_wait 30 tools/run-tests.py --arch=x86 test262
+        - travis_wait 40 tools/run-tests.py --arch=x86 test262
 
 
     - name: "linux.x86.release.jetstream"

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -56,9 +56,8 @@ private:
 class ArrowFunctionExpressionNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    ArrowFunctionExpressionNode(PatternNodeVector&& params, Node* body, ASTFunctionScopeContext* scopeContext, bool expression, size_t subCodeBlockIndex)
-        : m_expression(expression)
-        , m_subCodeBlockIndex(subCodeBlockIndex - 1)
+    ArrowFunctionExpressionNode(PatternNodeVector&& params, ASTFunctionScopeContext* scopeContext, size_t subCodeBlockIndex)
+        : m_subCodeBlockIndex(subCodeBlockIndex - 1)
     {
         scopeContext->m_isArrowFunctionExpression = true;
         scopeContext->m_nodeType = this->type();
@@ -73,7 +72,6 @@ public:
     }
 
 private:
-    bool m_expression : 1;
     size_t m_subCodeBlockIndex;
     // defaults: [ Expression ];
     // rest: Identifier | null;

--- a/src/parser/ast/FunctionDeclarationNode.h
+++ b/src/parser/ast/FunctionDeclarationNode.h
@@ -25,7 +25,7 @@ namespace Escargot {
 class FunctionDeclarationNode : public StatementNode {
 public:
     friend class ScriptParser;
-    FunctionDeclarationNode(const AtomicString& id, PatternNodeVector&& params, Node* body, ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t /*subCodeBlockIndex not used yet*/)
+    FunctionDeclarationNode(const AtomicString& id, PatternNodeVector&& params, ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t /*subCodeBlockIndex not used yet*/)
         : m_isGenerator(isGenerator)
     {
         scopeContext->m_nodeType = this->type();

--- a/src/parser/ast/FunctionExpressionNode.h
+++ b/src/parser/ast/FunctionExpressionNode.h
@@ -25,7 +25,7 @@ namespace Escargot {
 class FunctionExpressionNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    FunctionExpressionNode(const AtomicString& id, PatternNodeVector&& params, Node* body, ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t subCodeBlockIndex)
+    FunctionExpressionNode(const AtomicString& id, PatternNodeVector&& params, ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t subCodeBlockIndex)
         : m_isGenerator(isGenerator)
         , m_subCodeBlockIndex(subCodeBlockIndex - 1)
     {


### PR DESCRIPTION
* arrow function body is skipped in scan mode to match parseSingleFunctionChildIndex consistently with normal function body block
* extract parameter names right after pushing a scope context

NOTE) this patch also resolves #343 in general way

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>