### PR TITLE
Fix ProxyObject to call with proper Property type

### DIFF
--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -150,6 +150,15 @@ public:
         }
     }
 
+    Value toPropertyKeyValue() const
+    {
+        if (isUIntType()) {
+            return Value(String::fromDouble(uintValue()));
+        } else {
+            return propertyName().toValue();
+        }
+    }
+
 private:
     bool m_isUIntType : 1;
     union ObjectPropertyNameData {

--- a/src/runtime/ProxyObject.cpp
+++ b/src/runtime/ProxyObject.cpp
@@ -141,7 +141,7 @@ bool ProxyObject::defineOwnProperty(ExecutionState& state, const ObjectPropertyN
     // 10. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P, descObj»)).
     // 11. ReturnIfAbrupt(booleanTrapResult).
     bool booleanTrapResult;
-    Value arguments[] = { target, P.toPlainValue(state), Value(ObjectPropertyDescriptor::fromObjectPropertyDescriptor(state, desc)) };
+    Value arguments[] = { target, P.toPropertyKeyValue(), Value(ObjectPropertyDescriptor::fromObjectPropertyDescriptor(state, desc)) };
     booleanTrapResult = Object::call(state, trap, handler, 3, arguments).toBoolean(state);
 
     // 12. If booleanTrapResult is false, return false.
@@ -216,7 +216,7 @@ bool ProxyObject::deleteOwnProperty(ExecutionState& state, const ObjectPropertyN
     // 9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
     // 10. ReturnIfAbrupt(booleanTrapResult).
     bool booleanTrapResult;
-    Value arguments[] = { target, P.toPlainValue(state) };
+    Value arguments[] = { target, P.toPropertyKeyValue() };
     booleanTrapResult = Object::call(state, trap, handler, 2, arguments).toBoolean(state);
 
     // 11. If booleanTrapResult is false, return false.
@@ -273,7 +273,7 @@ ObjectGetResult ProxyObject::getOwnProperty(ExecutionState& state, const ObjectP
     // 9. Let trapResultObj be Call(trap, handler, «target, P»).
     // 10. ReturnIfAbrupt(trapResultObj).
     Value trapResultObj;
-    Value arguments[] = { target, P.toPlainValue(state) };
+    Value arguments[] = { target, P.toPropertyKeyValue() };
     trapResultObj = Object::call(state, trap, handler, 2, arguments);
 
     // 11. If Type(trapResultObj) is neither Object nor Undefined, throw a TypeError exception.
@@ -418,7 +418,7 @@ bool ProxyObject::hasProperty(ExecutionState& state, const ObjectPropertyName& p
     // 9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
     // 10. ReturnIfAbrupt(booleanTrapResult).
     bool booleanTrapResult;
-    Value arguments[] = { target, propertyName.toPlainValue(state) };
+    Value arguments[] = { target, propertyName.toPropertyKeyValue() };
     booleanTrapResult = Object::call(state, trap, handler, 2, arguments).toBoolean(state);
 
     // 11. If booleanTrapResult is false, then
@@ -804,7 +804,7 @@ ObjectGetResult ProxyObject::get(ExecutionState& state, const ObjectPropertyName
     // 9. Let trapResult be Call(trap, handler, «target, P, Receiver»).
     // 10. ReturnIfAbrupt(trapResult).
     Value trapResult;
-    Value arguments[] = { target, propertyName.toPlainValue(state), Value(this) };
+    Value arguments[] = { target, propertyName.toPropertyKeyValue(), Value(this) };
     trapResult = Object::call(state, trap, handler, 3, arguments);
 
     // 11. Let targetDesc be target.[[GetOwnProperty]](P).
@@ -867,7 +867,7 @@ bool ProxyObject::set(ExecutionState& state, const ObjectPropertyName& propertyN
     // 9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P, V, Receiver»)).
     // 10. ReturnIfAbrupt(booleanTrapResult).
     bool booleanTrapResult;
-    Value arguments[] = { target, propertyName.toPlainValue(state), v, receiver };
+    Value arguments[] = { target, propertyName.toPropertyKeyValue(), v, receiver };
     booleanTrapResult = Object::call(state, trap, handler, 4, arguments).toBoolean(state);
 
     // 11. If booleanTrapResult is false, return false.

--- a/test/es2015/proxy-propertyKey-typeof.js
+++ b/test/es2015/proxy-propertyKey-typeof.js
@@ -1,0 +1,41 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// dummy call, to invoke proxy's get
+function dummyCall() {
+}
+
+// check if string conversion is done
+var stringHandler = {
+    get: function(obj, prop) {
+        assert(typeof prop == "string")
+    }
+};
+var proxyStringExample = new Proxy({}, stringHandler);
+var proxyArray = new Array(0);
+dummyCall(proxyArray[1])
+
+
+// check if symbol type is handled correctly
+var symbolHandler = {
+    get: function(obj, prop) {
+        assert(typeof prop == "symbol")
+    }
+};
+var proxySymbolExample = new Proxy({}, symbolHandler);
+const SymbolKey = Symbol();
+
+proxySymbolExample[SymbolKey] = 123;
+dummyCall(proxySymbolExample[SymbolKey])


### PR DESCRIPTION
Before the patch escargot called while doing `P.toPlainValue` which causes `[number]`
property names to be converted into numbers, instead of using them as property keys
and passing them along as string, while it should pass string or symbol by definition
in:
http://www.ecma-international.org/ecma-262/6.0/#sec-ispropertykey

Co-authored-by: Robert Fancsik frobert@inf.u-szeged.hu
Signed-off-by: Bela Toth tbela@inf.u-szeged.hu