### PR TITLE
Fix several modules in  parser

### DIFF
--- a/src/parser/ast/AST.h
+++ b/src/parser/ast/AST.h
@@ -72,7 +72,7 @@
 #include "ContinueLabelStatementNode.h"
 #include "ContinueStatementNode.h"
 #include "DirectiveNode.h"
-#include "DefaultArgumentNode.h"
+#include "AssignmentPatternNode.h"
 #include "DoWhileStatementNode.h"
 #include "EmptyNode.h"
 #include "EmptyStatementNode.h"

--- a/src/parser/ast/ArrayPatternNode.h
+++ b/src/parser/ast/ArrayPatternNode.h
@@ -128,24 +128,28 @@ public:
                     size_t jPos = codeBlock->lastCodePosition<Jump>();
                     codeBlock->peekCode<JumpIfFalse>(pos)->m_jumpPosition = codeBlock->currentCodeSize();
 
-                    RefPtr<RegisterReferenceNode> registerRef = adoptRef(new RegisterReferenceNode(iteratorValueIdx));
-                    RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new AssignmentExpressionSimpleNode(assignNode->left(), registerRef.get()));
+                    RefPtr<RegisterReferenceNode> registerRef = adoptRef(new (alloca(sizeof(RegisterReferenceNode))) RegisterReferenceNode(iteratorValueIdx));
+                    RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new (alloca(sizeof(AssignmentExpressionSimpleNode))) AssignmentExpressionSimpleNode(assignNode->left(), registerRef.get()));
                     assign->m_loc = m_loc;
                     context->m_isLexicallyDeclaredBindingInitialization = isLexicallyDeclaredBindingInitialization;
                     assign->generateResultNotRequiredExpressionByteCode(codeBlock, context);
                     ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
                     assign->giveupChildren();
+                    assign.release().leakRef();
+                    registerRef.release().leakRef();
 
                     Jump* j = codeBlock->peekCode<Jump>(jPos);
                     j->m_jumpPosition = codeBlock->currentCodeSize();
                 } else {
-                    RefPtr<RegisterReferenceNode> registerRef = adoptRef(new RegisterReferenceNode(iteratorValueIdx));
-                    RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new AssignmentExpressionSimpleNode(element.get(), registerRef.get()));
+                    RefPtr<RegisterReferenceNode> registerRef = adoptRef(new (alloca(sizeof(RegisterReferenceNode))) RegisterReferenceNode(iteratorValueIdx));
+                    RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new (alloca(sizeof(AssignmentExpressionSimpleNode))) AssignmentExpressionSimpleNode(element.get(), registerRef.get()));
                     assign->m_loc = m_loc;
                     context->m_isLexicallyDeclaredBindingInitialization = isLexicallyDeclaredBindingInitialization;
                     assign->generateResultNotRequiredExpressionByteCode(codeBlock, context);
                     ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
                     assign->giveupChildren();
+                    assign.release().leakRef();
+                    registerRef.release().leakRef();
                 }
             }
         }
@@ -154,11 +158,13 @@ public:
             RefPtr<Node> element = m_elements[m_elements.size() - 1];
             size_t restIndex = context->getRegister();
             codeBlock->pushCode(BindingRestElement(ByteCodeLOC(m_loc.index), iteratorIdx, restIndex), context, this);
-            RefPtr<RegisterReferenceNode> registerRef = adoptRef(new RegisterReferenceNode(restIndex));
-            RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new AssignmentExpressionSimpleNode(((RestElementNode*)element.get())->argument(), registerRef.get()));
+            RefPtr<RegisterReferenceNode> registerRef = adoptRef(new (alloca(sizeof(RegisterReferenceNode))) RegisterReferenceNode(restIndex));
+            RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new (alloca(sizeof(AssignmentExpressionSimpleNode))) AssignmentExpressionSimpleNode(((RestElementNode*)element.get())->argument(), registerRef.get()));
             assign->m_loc = m_loc;
             assign->generateResultNotRequiredExpressionByteCode(codeBlock, context);
             assign->giveupChildren();
+            assign.release().leakRef();
+            registerRef.release().leakRef();
         }
 
         context->giveUpRegister(); // for iteratorIdx

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -143,7 +143,7 @@ enum ASTNodeType {
     ClassElement,
     ClassMethod,
     SuperExpression,
-    DefaultArgument,
+    AssignmentPattern,
     ArrayPattern,
     ObjectPattern,
     RegisterReference,
@@ -208,7 +208,7 @@ struct ExtendedNodeLOC {
 };
 
 class LiteralNode;
-class DefaultArgumentNode;
+class AssignmentPatternNode;
 class IdentifierNode;
 class ArrayExpressionNode;
 class AssignmentExpressionSimpleNode;
@@ -294,15 +294,15 @@ public:
         return (IdentifierNode *)this;
     }
 
-    bool isDefaultArgument()
+    bool isAssignmentPattern()
     {
-        return type() == ASTNodeType::DefaultArgument;
+        return type() == ASTNodeType::AssignmentPattern;
     }
 
-    DefaultArgumentNode *asDefaultArgument()
+    AssignmentPatternNode *asAssignmentPattern()
     {
-        ASSERT(isDefaultArgument());
-        return (DefaultArgumentNode *)this;
+        ASSERT(isAssignmentPattern());
+        return (AssignmentPatternNode *)this;
     }
 
     bool isArrayPattern()

--- a/src/parser/ast/ObjectPatternNode.h
+++ b/src/parser/ast/ObjectPatternNode.h
@@ -144,8 +144,8 @@ public:
                     key = value->asAssignmentExpressionSimple()->left();
                     break;
                 }
-                case DefaultArgument: {
-                    key = value->asDefaultArgument()->left();
+                case AssignmentPattern: {
+                    key = value->asAssignmentPattern()->left();
                     break;
                 }
                 case Identifier: {
@@ -164,13 +164,15 @@ public:
                 throw err;
             }
 
-            RefPtr<RegisterReferenceNode> registerRef = adoptRef(new RegisterReferenceNode(valueIndex));
-            RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new AssignmentExpressionSimpleNode(key, registerRef.get()));
+            RefPtr<RegisterReferenceNode> registerRef = adoptRef(new (alloca(sizeof(RegisterReferenceNode))) RegisterReferenceNode(valueIndex));
+            RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new (alloca(sizeof(AssignmentExpressionSimpleNode))) AssignmentExpressionSimpleNode(key, registerRef.get()));
             assign->m_loc = m_loc;
             context->m_isLexicallyDeclaredBindingInitialization = isLexicallyDeclaredBindingInitialization;
             assign->generateResultNotRequiredExpressionByteCode(codeBlock, context);
             ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
             assign->giveupChildren();
+            assign.release().leakRef();
+            registerRef.release().leakRef();
 
             Jump* j = codeBlock->peekCode<Jump>(jPos);
             j->m_jumpPosition = codeBlock->currentCodeSize();

--- a/src/parser/ast/TryStatementNode.h
+++ b/src/parser/ast/TryStatementNode.h
@@ -67,13 +67,15 @@ public:
 
             auto catchedValueRegister = context->getRegister();
             codeBlock->peekCode<TryOperation>(pos)->m_catchedValueRegisterIndex = catchedValueRegister;
-            RefPtr<RegisterReferenceNode> registerRef = adoptRef(new RegisterReferenceNode(catchedValueRegister));
-            RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new AssignmentExpressionSimpleNode(m_handler->param(), registerRef.get()));
+            RefPtr<RegisterReferenceNode> registerRef = adoptRef(new (alloca(sizeof(RegisterReferenceNode))) RegisterReferenceNode(catchedValueRegister));
+            RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new (alloca(sizeof(AssignmentExpressionSimpleNode))) AssignmentExpressionSimpleNode(m_handler->param(), registerRef.get()));
             assign->m_loc = m_handler->m_loc;
             context->m_isLexicallyDeclaredBindingInitialization = true;
             assign->generateResultNotRequiredExpressionByteCode(codeBlock, context);
             ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
             assign->giveupChildren();
+            assign.release().leakRef();
+            registerRef.release().leakRef();
 
             context->giveUpRegister();
 


### PR DESCRIPTION
* check duplicated parameter names at once
* temporal nodes are allocated on stack
* remove unnecessary structs and flags
* sync parsing part of default parameter to that of esprima code

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>