### PR TITLE
Remove redundant parameter modules

### DIFF
--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -96,8 +96,8 @@ int getValidValueInInterpretedCodeBlock(void* ptr, GC_mark_custom_result* arr)
     arr[1].to = (GC_word*)current->m_script;
     arr[2].from = (GC_word*)&current->m_identifierInfos;
     arr[2].to = (GC_word*)current->m_identifierInfos.data();
-    arr[3].from = (GC_word*)&current->m_parametersInfomation;
-    arr[3].to = (GC_word*)current->m_parametersInfomation.data();
+    arr[3].from = (GC_word*)&current->m_parameterNames;
+    arr[3].to = (GC_word*)current->m_parameterNames.data();
     arr[4].from = (GC_word*)&current->m_parentCodeBlock;
     arr[4].to = (GC_word*)current->m_parentCodeBlock;
     arr[5].from = (GC_word*)&current->m_childBlocks;

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -363,16 +363,9 @@ public:
     /* capture ok, block vector index(if not block variable, returns SIZE_MAX) */
     std::pair<bool, size_t> tryCaptureIdentifiersFromChildCodeBlock(LexicalBlockIndex blockIndex, AtomicString name);
 
-    struct FunctionParametersInfo {
-        bool m_isHeapAllocated : 1;
-        bool m_isDuplicated : 1;
-        int32_t m_index;
-        AtomicString m_name;
-    };
-    typedef TightVector<FunctionParametersInfo, GCUtil::gc_malloc_atomic_allocator<FunctionParametersInfo>> FunctionParametersInfoVector;
-    const FunctionParametersInfoVector& parametersInfomation() const
+    const AtomicStringTightVector& parameterNames() const
     {
-        return m_parametersInfomation;
+        return m_parameterNames;
     }
 
     struct IndexedIdentifierInfo {
@@ -663,8 +656,8 @@ public:
 
     bool hasParameter(const AtomicString& name)
     {
-        for (size_t i = 0; i < m_parametersInfomation.size(); i++) {
-            if (m_parametersInfomation[i].m_name == name) {
+        for (size_t i = 0; i < m_parameterNames.size(); i++) {
+            if (m_parameterNames[i] == name) {
                 return true;
             }
         }
@@ -760,7 +753,7 @@ protected:
     StringView m_bodySrc; // function body source
     ExtendedNodeLOC m_sourceElementStart;
 
-    FunctionParametersInfoVector m_parametersInfomation;
+    AtomicStringTightVector m_parameterNames;
     uint16_t m_identifierOnStackCount; // this member variable only count `var`
     uint16_t m_identifierOnHeapCount; // this member variable only count `var`
     uint16_t m_lexicalBlockStackAllocatedIdentifierMaximumDepth; // this member variable only count `let`

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -590,7 +590,6 @@ struct ASTFunctionScopeContext : public gc {
     bool m_hasManyNumeralLiteral : 1;
     bool m_hasArrowParameterPlaceHolder : 1;
     bool m_hasParameterOtherThanIdentifier : 1;
-    bool m_hasRestElement : 1;
     bool m_needsToComputeLexicalBlockStuffs : 1;
     bool m_hasImplictFunctionName : 1;
     unsigned int m_nodeType : 2; // it is actually NodeType but used on FunctionExpression, ArrowFunctionExpression, FunctionDeclaration only
@@ -827,7 +826,6 @@ struct ASTFunctionScopeContext : public gc {
         , m_hasManyNumeralLiteral(false)
         , m_hasArrowParameterPlaceHolder(false)
         , m_hasParameterOtherThanIdentifier(false)
-        , m_hasRestElement(false)
         , m_needsToComputeLexicalBlockStuffs(false)
         , m_hasImplictFunctionName(false)
         , m_nodeType(ASTNodeType::Program)

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -344,8 +344,11 @@ public:
 #endif
             } else if (params[i]->type() == RestElement) {
                 hasParameterOtherThanIdentifier = true;
-                scopeContexts.back()->m_hasRestElement = true;
-                id = ((RestElementNode*)params[i].get())->argument()->name();
+                scopeContexts.back()->m_parameters.erase(i);
+#ifndef NDEBUG
+                shouldHaveEqualNumberOfParameterListAndParameterName = false;
+#endif
+                break;
             } else {
                 RELEASE_ASSERT_NOT_REACHED();
             }

--- a/src/runtime/ArgumentsObject.cpp
+++ b/src/runtime/ArgumentsObject.cpp
@@ -73,7 +73,6 @@ ArgumentsObject::ArgumentsObject(ExecutionState& state, ScriptFunctionObject* so
     , m_sourceFunctionObject(sourceFunctionObject)
     , m_argc(argc)
 {
-    // FIXME Assert: formal parameters does not contain a rest parameter, any binding patterns, or any initializers. It may contain duplicate identifiers.
     // Let len be the number of elements in argumentsList.
     int len = argc;
     m_parameterMap.resizeWithUninitializedValues(len);
@@ -83,7 +82,7 @@ ArgumentsObject::ArgumentsObject(ExecutionState& state, ScriptFunctionObject* so
 
         // https://www.ecma-international.org/ecma-262/6.0/#sec-createmappedargumentsobject
         // Let numberOfParameters be the number of elements in parameterNames
-        int numberOfParameters = m_sourceFunctionObject->codeBlock()->asInterpretedCodeBlock()->parametersInfomation().size();
+        int numberOfParameters = m_sourceFunctionObject->codeBlock()->asInterpretedCodeBlock()->parameterNames().size();
         // Let index be 0.
         int index = 0;
         // Repeat while index < len ,
@@ -108,7 +107,7 @@ ArgumentsObject::ArgumentsObject(ExecutionState& state, ScriptFunctionObject* so
         // Repeat while index ≥ 0 ,
         while (index >= 0) {
             // Let name be parameterNames[index].
-            AtomicString name = m_sourceFunctionObject->codeBlock()->asInterpretedCodeBlock()->parametersInfomation()[index].m_name;
+            AtomicString name = m_sourceFunctionObject->codeBlock()->asInterpretedCodeBlock()->parameterNames()[index];
             // If name is not an element of mappedNames, then
             if (std::find(mappedNames.begin(), mappedNames.end(), name) == mappedNames.end()) {
                 // Add name as an element of the list mappedNames.

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -110,7 +110,7 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
     }
 
     try {
-        srcToTest.appendString("\r\n){ }");
+        srcToTest.appendString(") { }");
         String* cur = srcToTest.finalize(&state);
         state.context()->vmInstance()->parsedSourceCodes().push_back(cur);
         esprima::parseProgram(state.context(), StringView(cur, 0, cur->length()), false, false, SIZE_MAX);
@@ -135,7 +135,7 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
             ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "there is unbalanced braces(}) in Function Constructor input");
         }
     }
-    src.appendString("\n){\n");
+    src.appendString(") {\n");
     src.appendString(source);
     src.appendString("\n}");
 

--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -58,30 +58,21 @@ static Value builtinFunctionToString(ExecutionState& state, Value thisValue, siz
     if (LIKELY(thisValue.isFunction())) {
         FunctionObject* fn = thisValue.asFunction();
         StringBuilder builder;
-        builder.appendString("function ");
-        if (!fn->codeBlock()->hasImplictFunctionName()) {
-            builder.appendString(fn->codeBlock()->functionName().string());
-        }
-        builder.appendString("(");
-
-        if (fn->codeBlock()->isInterpretedCodeBlock()) {
-            for (size_t i = 0; i < fn->codeBlock()->asInterpretedCodeBlock()->parametersInfomation().size(); i++) {
-                builder.appendString(fn->codeBlock()->asInterpretedCodeBlock()->parametersInfomation()[i].m_name.string());
-                if (i < (fn->codeBlock()->asInterpretedCodeBlock()->parametersInfomation().size() - 1)) {
-                    builder.appendString(", ");
-                }
+        if (!fn->codeBlock()->isArrowFunctionExpression()) {
+            builder.appendString("function ");
+            if (!fn->codeBlock()->hasImplictFunctionName()) {
+                builder.appendString(fn->codeBlock()->functionName().string());
             }
         }
 
-        builder.appendString(") ");
         if (fn->codeBlock()->isInterpretedCodeBlock() && fn->codeBlock()->asInterpretedCodeBlock()->script() != nullptr) {
-            StringView src = fn->codeBlock()->asInterpretedCodeBlock()->bodySrc();
+            StringView src = fn->codeBlock()->asInterpretedCodeBlock()->src();
             while (src[src.length() - 1] != '}') {
                 src = StringView(src, 0, src.length() - 1);
             }
             builder.appendString(new StringView(src));
         } else {
-            builder.appendString("{ [native code] }");
+            builder.appendString("() { [native code] }");
         }
 
         return builder.finalize(&state);

--- a/src/runtime/ScriptFunctionObject.cpp
+++ b/src/runtime/ScriptFunctionObject.cpp
@@ -213,29 +213,4 @@ void ScriptFunctionObject::generateArgumentsObject(ExecutionState& state, size_t
         }
     }
 }
-
-void ScriptFunctionObject::generateRestParameter(ExecutionState& state, FunctionEnvironmentRecord* record, Value* parameterStorageInStack, const size_t argc, Value* argv)
-{
-    ArrayObject* newArray;
-    size_t parameterLen = (size_t)m_codeBlock->parameterCount();
-
-    if (argc > parameterLen) {
-        size_t arrLen = argc - parameterLen;
-        newArray = new ArrayObject(state, (double)arrLen);
-        for (size_t i = 0; i < arrLen; i++) {
-            newArray->setIndexedProperty(state, Value(i), argv[parameterLen + i]);
-        }
-    } else {
-        newArray = new ArrayObject(state);
-    }
-
-    InterpretedCodeBlock::FunctionParametersInfo lastInfo = const_cast<InterpretedCodeBlock::FunctionParametersInfoVector&>(m_codeBlock->asInterpretedCodeBlock()->parametersInfomation()).back();
-    if (!m_codeBlock->canUseIndexedVariableStorage()) {
-        record->initializeBinding(state, lastInfo.m_name, Value(newArray));
-    } else if (lastInfo.m_isHeapAllocated) {
-        record->heapStorage()[lastInfo.m_index] = newArray;
-    } else {
-        parameterStorageInStack[lastInfo.m_index] = newArray;
-    }
-}
 }

--- a/src/runtime/ScriptFunctionObject.h
+++ b/src/runtime/ScriptFunctionObject.h
@@ -54,7 +54,6 @@ protected:
     }
 
     void generateArgumentsObject(ExecutionState& state, size_t argc, Value* argv, FunctionEnvironmentRecord* environmentRecordWillArgumentsObjectBeLocatedIn, Value* stackStorage, bool isMapped);
-    void generateRestParameter(ExecutionState& state, FunctionEnvironmentRecord* record, Value* parameterStorageInStack, const size_t argc, Value* argv);
     void generateByteCodeBlock(ExecutionState& state);
 
     LexicalEnvironment* m_outerEnvironment;

--- a/test/es2015/implicit-names.js
+++ b/test/es2015/implicit-names.js
@@ -41,10 +41,10 @@ var test = function t() {
     assert(o.b.name === "b")
     assert(o.c.name === "c")
     assert(g.name === "g")
-    assert(a.name ==="a")
+    assert(a.name === "a")
     assert(f.name === "f")
     assert(d.name === 'a')
-    assert(d.toString() === "function () { }");
+    assert(d.toString() === "() => { }");
 
 }
 test();

--- a/tools/test/v8/v8.mjsunit.status
+++ b/tools/test/v8/v8.mjsunit.status
@@ -921,6 +921,7 @@
   'regress/regress-1530': [SKIP],
   'regress/regress-447561': [SKIP],
   'regress/regress-crbug-618788': [SKIP],
+  'regress/regress-2470': [SKIP],
 
   # Symbol
   'regress/regress-5780': [SKIP],


### PR DESCRIPTION
* CodeBlock has essential parameter name list only
* toString builtin function is fixed to use the entire source instead of body source
* some TCs are fixed upto the spec

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>