### PR TITLE
Fix bugs related to ProxyObject

### DIFF
--- a/test/es2015/reflect-set-target-setter-is-undefined.js
+++ b/test/es2015/reflect-set-target-setter-is-undefined.js
@@ -1,0 +1,29 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var target = {};
+
+Object.defineProperty(target, 'attr', {
+  configurable: false,
+  set: undefined
+});
+
+var p = new Proxy(target, {
+  set: function() {
+      return true;
+  }
+});
+
+assertThrows('Reflect.set(p, "attr", 1)', TypeError);


### PR DESCRIPTION
* Use a 'hasValue' to check whether desc is undefined or not.
* Throw a TypeError if the target descriptor's setter is undefined In ProxyObject's [[set]]
* Add an internal Test

Signed-off-by: Boram Bae <boram21.bae@samsung.com>