### PR TITLE
Refactor code

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -908,11 +908,11 @@ Value ByteCodeInterpreter::interpret(ExecutionState* state, ByteCodeBlock* byteC
                                 }
 
                                 Value nextValue = iteratorValue(*state, next);
-                                arr->defineOwnProperty(*state, ObjectPropertyName(*state, Value(i + spreadCount + code->m_baseIndex)), ObjectPropertyDescriptor(nextValue, ObjectPropertyDescriptor::AllPresent));
+                                arr->defineOwnProperty(*state, ObjectPropertyName(*state, i + spreadCount + code->m_baseIndex), ObjectPropertyDescriptor(nextValue, ObjectPropertyDescriptor::AllPresent));
                                 spreadCount++;
                             }
                         } else {
-                            arr->defineOwnProperty(*state, ObjectPropertyName(*state, Value(i + spreadCount + code->m_baseIndex)), ObjectPropertyDescriptor(element, ObjectPropertyDescriptor::AllPresent));
+                            arr->defineOwnProperty(*state, ObjectPropertyName(*state, i + spreadCount + code->m_baseIndex), ObjectPropertyDescriptor(element, ObjectPropertyDescriptor::AllPresent));
                         }
                     }
                 }

--- a/src/runtime/ArgumentsObject.cpp
+++ b/src/runtime/ArgumentsObject.cpp
@@ -261,6 +261,21 @@ ObjectGetResult ArgumentsObject::getIndexedProperty(ExecutionState& state, const
     return result;
 }
 
+ObjectHasPropertyResult ArgumentsObject::hasIndexedProperty(ExecutionState& state, const Value& propertyName)
+{
+    Value::ValueIndex index = propertyName.tryToUseAsIndex(state);
+    if (LIKELY(!isModifiedArgument(index) && isMatchedArgument(index))) {
+        return ObjectHasPropertyResult(ObjectGetResult(getIndexedPropertyValueQuickly(state, index), true, true, true));
+    }
+
+    if (isMatchedArgument(index)) {
+        ObjectGetResult result = Object::getOwnProperty(state, ObjectPropertyName(state, propertyName));
+        ASSERT(result.hasValue());
+        return ObjectHasPropertyResult(ObjectGetResult(getIndexedPropertyValueQuickly(state, index), result.isWritable(), result.isEnumerable(), result.isConfigurable()));
+    }
+    return hasProperty(state, ObjectPropertyName(state, propertyName));
+}
+
 bool ArgumentsObject::set(ExecutionState& state, const ObjectPropertyName& propertyName, const Value& v, const Value& receiver)
 {
     if (UNLIKELY(!receiver.isObject() || receiver.asObject() != this)) {

--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -37,6 +37,7 @@ public:
     virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) override;
     virtual ObjectGetResult getIndexedProperty(ExecutionState& state, const Value& property) override;
+    virtual ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override;
     virtual bool set(ExecutionState& state, const ObjectPropertyName& propertyName, const Value& v, const Value& receiver) override;
     virtual bool setIndexedProperty(ExecutionState& state, const Value& property, const Value& value) override;
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -66,6 +66,7 @@ public:
     }
     virtual void sort(ExecutionState& state, const std::function<bool(const Value& a, const Value& b)>& comp) override;
     virtual ObjectGetResult getIndexedProperty(ExecutionState& state, const Value& property) override;
+    virtual ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override;
     virtual bool setIndexedProperty(ExecutionState& state, const Value& property, const Value& value) override;
     virtual bool preventExtensions(ExecutionState&) override;
 

--- a/src/runtime/GlobalObjectBuiltinTypedArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinTypedArray.cpp
@@ -677,7 +677,7 @@ static Value builtinTypedArrayLastIndexOf(ExecutionState& state, Value thisValue
                 return Value(k);
             }
         } else {
-            double result;
+            int64_t result;
             Object::nextIndexBackward(state, O, k, -1, false, result);
             k = result;
             continue;

--- a/src/runtime/ProxyObject.h
+++ b/src/runtime/ProxyObject.h
@@ -91,7 +91,7 @@ public:
 
     virtual bool preventExtensions(ExecutionState& state) override;
 
-    virtual bool hasProperty(ExecutionState& state, const ObjectPropertyName& propertyName) override;
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& propertyName) override;
 
     virtual ValueVector ownPropertyKeys(ExecutionState& state) override;
 

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -35,7 +35,7 @@ typedef BasicString<LChar, GCUtil::gc_malloc_atomic_allocator<LChar>> Latin1Stri
 typedef BasicString<char, GCUtil::gc_malloc_atomic_allocator<char>> UTF8StringData;
 typedef BasicString<char16_t, GCUtil::gc_malloc_atomic_allocator<char16_t>> UTF16StringData;
 typedef BasicString<char32_t, GCUtil::gc_malloc_atomic_allocator<char32_t>> UTF32StringData;
-typedef Vector<String*, GCUtil::gc_malloc_atomic_allocator<String*>> StringVector;
+typedef Vector<String*, GCUtil::gc_malloc_allocator<String*>> StringVector;
 
 typedef std::basic_string<char, std::char_traits<char>> ASCIIStringDataNonGCStd;
 typedef std::basic_string<LChar, std::char_traits<LChar>> Latin1StringDataNonGCStd;

--- a/src/runtime/StringObject.cpp
+++ b/src/runtime/StringObject.cpp
@@ -100,6 +100,18 @@ ObjectGetResult StringObject::getIndexedProperty(ExecutionState& state, const Va
     return get(state, ObjectPropertyName(state, property));
 }
 
+ObjectHasPropertyResult StringObject::hasIndexedProperty(ExecutionState& state, const Value& propertyName)
+{
+    Value::ValueIndex idx = propertyName.tryToUseAsIndex(state);
+    if (idx != Value::InvalidIndexValue) {
+        size_t strLen = m_primitiveValue->length();
+        if (LIKELY(idx < strLen)) {
+            return ObjectHasPropertyResult(ObjectGetResult(Value(String::fromCharCode(m_primitiveValue->charAt(idx))), false, true, false));
+        }
+    }
+    return hasProperty(state, ObjectPropertyName(state, propertyName));
+}
+
 StringIteratorObject::StringIteratorObject(ExecutionState& state, String* s)
     : IteratorObject(state)
     , m_string(s)

--- a/src/runtime/StringObject.h
+++ b/src/runtime/StringObject.h
@@ -49,6 +49,7 @@ public:
     virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual ObjectGetResult getIndexedProperty(ExecutionState& state, const Value& property) override;
+    virtual ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override;
     virtual uint64_t length(ExecutionState& state) override
     {
         return m_primitiveValue->length();

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -385,6 +385,16 @@ public:
         return get(state, ObjectPropertyName(state, property));
     }
 
+    ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override
+    {
+        Value::ValueIndex idx = propertyName.tryToUseAsIndex(state);
+        if (LIKELY(idx != Value::InvalidIndexValue) && LIKELY((unsigned)idx < arraylength())) {
+            unsigned idxPosition = idx * typedArrayElementSize;
+            return ObjectHasPropertyResult(ObjectGetResult(getValueFromBuffer<typename TypeAdaptor::Type>(state, idxPosition), true, true, false));
+        }
+        return hasProperty(state, ObjectPropertyName(state, propertyName));
+    }
+
     virtual bool setIndexedProperty(ExecutionState& state, const Value& property, const Value& value) override
     {
         Value::ValueIndex index = property.tryToUseAsIndex(state);


### PR DESCRIPTION
* Revise hasProperty and apply it everywhere
* Add hasIndexedProperty for performance
* Change Object::nextIndex{Forward, Backward} double parameter types into int for performance
* in String.prototype.replace, Use test fast path correctly & use old method because newer method cannot support regexp correctly(old method is faster)

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>