### PR TITLE
Add fast paths for hasProperty internal method

### DIFF
--- a/src/runtime/ArgumentsObject.cpp
+++ b/src/runtime/ArgumentsObject.cpp
@@ -155,6 +155,16 @@ ArgumentsObject::ArgumentsObject(ExecutionState& state, ScriptFunctionObject* so
     }
 }
 
+ObjectHasPropertyResult ArgumentsObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P)
+{
+    uint64_t index = P.tryToUseAsIndex();
+    if (LIKELY(!isModifiedArgument(index) && isMatchedArgument(index))) {
+        return ObjectHasPropertyResult(ObjectGetResult(getIndexedPropertyValueQuickly(state, index), true, true, true));
+    }
+
+    return Object::hasProperty(state, P);
+}
+
 ObjectGetResult ArgumentsObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     uint64_t index = P.tryToUseAsIndex();

--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -32,6 +32,7 @@ class ScriptFunctionObject;
 class ArgumentsObject : public Object {
 public:
     ArgumentsObject(ExecutionState& state, ScriptFunctionObject* sourceFunctionObject, size_t argc, Value* argv, FunctionEnvironmentRecord* environmentRecordWillArgumentsObjectBeLocatedIn, bool isMapped);
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) override;
     virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -55,6 +55,17 @@ ArrayObject::ArrayObject(ExecutionState& state, double length)
                                                                                                                           (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::NonEnumerablePresent | ObjectPropertyDescriptor::NonConfigurablePresent)));
 }
 
+ObjectHasPropertyResult ArrayObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+{
+    ObjectGetResult v = getFastModeValue(state, P);
+    if (LIKELY(v.hasValue())) {
+        return ObjectHasPropertyResult(v);
+    }
+
+    return Object::hasProperty(state, P);
+}
+
+
 ObjectGetResult ArrayObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
 {
     ObjectGetResult v = getFastModeValue(state, P);

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -50,6 +50,7 @@ public:
         return true;
     }
 
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     void defineOwnPropertyThrowsException(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc)

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -650,6 +650,7 @@ public:
         return false;
     }
 
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
 
     void* operator new(size_t size)

--- a/src/runtime/StringObject.cpp
+++ b/src/runtime/StringObject.cpp
@@ -48,6 +48,18 @@ void* StringObject::operator new(size_t size)
     return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
 }
 
+ObjectHasPropertyResult StringObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+{
+    Value::ValueIndex idx = P.tryToUseAsIndex();
+    if (idx != Value::InvalidIndexValue) {
+        size_t strLen = m_primitiveValue->length();
+        if (LIKELY(idx < strLen)) {
+            return ObjectHasPropertyResult(ObjectGetResult(Value(String::fromCharCode(m_primitiveValue->charAt(idx))), false, true, false));
+        }
+    }
+    return Object::hasProperty(state, P);
+}
+
 
 ObjectGetResult StringObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
 {

--- a/src/runtime/StringObject.h
+++ b/src/runtime/StringObject.h
@@ -44,6 +44,7 @@ public:
         m_primitiveValue = data;
     }
 
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -282,6 +282,19 @@ public:
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
     virtual const char* internalClassProperty() override;
 
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override
+    {
+        uint64_t index = P.tryToUseAsIndex();
+        if (LIKELY(Value::InvalidIndexValue != index)) {
+            if ((unsigned)index < arrayLength()) {
+                unsigned idxPosition = index * typedArrayElementSize;
+                return ObjectHasPropertyResult(ObjectGetResult(getValueFromBuffer<typename TypeAdaptor::Type>(state, idxPosition), true, true, false));
+            }
+            return ObjectHasPropertyResult();
+        }
+        return ArrayBufferView::hasProperty(state, P);
+    }
+
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override
     {
         uint64_t index = P.tryToUseAsIndex();


### PR DESCRIPTION
Also the Object.[[Get]] method is modified to follow the standard requirements without recursion.

Signed-off-by: Robert Fancsik <frobert@inf.u-szeged.hu>