### PR TITLE
Fix a bug of variable declarations within patterns

### DIFF
--- a/src/parser/ast/ObjectPatternNode.h
+++ b/src/parser/ast/ObjectPatternNode.h
@@ -36,9 +36,12 @@ public:
     virtual ASTNodeType type() { return ASTNodeType::ObjectPattern; }
     virtual void generateStoreByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex srcRegister, bool needToReferenceSelf)
     {
+        bool isLexicallyDeclaredBindingInitialization = context->m_isLexicallyDeclaredBindingInitialization;
         for (size_t i = 0; i < m_properties.size(); i++) {
+            context->m_isLexicallyDeclaredBindingInitialization = isLexicallyDeclaredBindingInitialization;
             m_properties[i]->generateStoreByteCode(codeBlock, context, srcRegister, needToReferenceSelf);
         }
+        ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
     }
 
     // FIXME implement iterateChildrenIdentifier in PropertyNode itself

--- a/src/parser/ast/VariableDeclaratorNode.h
+++ b/src/parser/ast/VariableDeclaratorNode.h
@@ -57,13 +57,12 @@ public:
 
         if (m_init) {
             context->getRegister();
+            context->m_isLexicallyDeclaredBindingInitialization = m_kind != EscargotLexer::KeywordKind::VarKeyword;
             if (m_id->isIdentifier() && !m_id->asIdentifier()->name().string()->equals("arguments")) {
                 // check canUseIndexedVariableStorage for give right value to generateStoreByteCode(isInit..) with eval
                 RefPtr<AssignmentExpressionSimpleNode> assign = adoptRef(new (alloca(sizeof(AssignmentExpressionSimpleNode))) AssignmentExpressionSimpleNode(m_id.get(), m_init.get()));
                 assign->m_loc = m_loc;
-                context->m_isLexicallyDeclaredBindingInitialization = m_kind != EscargotLexer::KeywordKind::VarKeyword;
                 assign->generateResultNotRequiredExpressionByteCode(codeBlock, context);
-                ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
                 assign->giveupChildren();
                 assign.release().leakRef(); // leak reference for prevent calling operator delete by ~RefPtr
             } else {
@@ -72,6 +71,7 @@ public:
                 m_id->generateStoreByteCode(codeBlock, context, r, false);
                 context->giveUpRegister();
             }
+            ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
             context->giveUpRegister();
         }
 

--- a/src/runtime/EnvironmentRecord.h
+++ b/src/runtime/EnvironmentRecord.h
@@ -434,6 +434,7 @@ public:
 
     virtual void setMutableBindingByBindingSlot(ExecutionState& state, const BindingSlot& slot, const AtomicString& name, const Value& v) override
     {
+        // TDZ check only (every indexed const variables are checked on bytecode generation time)
         if (UNLIKELY(m_heapStorage[slot.m_index].isEmpty())) {
             throwReferenceError(state, slot.m_index);
         }


### PR DESCRIPTION
* declarations of block scoped variables are correctly handled
* const variable check is added to GlobalEnvironmentRecord::setMutableBindingByBindingSlot

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>