### PR TITLE
Fix class bugs

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -510,10 +510,22 @@ SymbolRef* VMInstanceRef::unscopablesSymbol()
     return toRef(toImpl(this)->globalSymbols().unscopables);
 }
 
-ValueRef* VMInstanceRef::drainJobQueue()
+VMInstanceRef::DrainJobQueueResult::DrainJobQueueResult()
+{
+    isThereRemainedJob = false;
+}
+
+VMInstanceRef::DrainJobQueueResult VMInstanceRef::drainJobQueue()
 {
     VMInstance* imp = toImpl(this);
-    return toRef(imp->drainJobQueue());
+    auto drainResult = imp->drainJobQueue();
+
+    VMInstanceRef::DrainJobQueueResult result;
+    result.isThereRemainedJob = drainResult.first;
+    if (drainResult.second) {
+        result.error = NullablePtr<ValueRef>(toRef(drainResult.second.value()));
+    }
+    return result;
 }
 
 void VMInstanceRef::setNewPromiseJobListener(NewPromiseJobListener l)
@@ -1563,6 +1575,11 @@ bool ValueRef::isNull() const
 bool ValueRef::isUndefined() const
 {
     return toImpl(this).isUndefined();
+}
+
+bool ValueRef::isEmpty() const
+{
+    return toImpl(this).isEmpty();
 }
 
 bool ValueRef::isString() const

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -256,9 +256,18 @@ public:
     SymbolRef* iteratorSymbol();
     SymbolRef* unscopablesSymbol();
 
-    // if there is an error, executing will be stopped and returns ErrorValue
-    // if thres is no job or no error, returns EmptyValue
-    ValueRef* drainJobQueue();
+    struct DrainJobQueueResult {
+        // test job queue ended without error
+        bool isSuccessful()
+        {
+            return !error.hasValue();
+        }
+        // is there any job after drain
+        bool isThereRemainedJob;
+        NullablePtr<ValueRef> error;
+        DrainJobQueueResult();
+    };
+    DrainJobQueueResult drainJobQueue();
 
     typedef void (*NewPromiseJobListener)(ExecutionStateRef* state, JobRef* job);
     void setNewPromiseJobListener(NewPromiseJobListener l);
@@ -341,6 +350,7 @@ public:
     bool isNumber() const;
     bool isNull() const;
     bool isUndefined() const;
+    bool isEmpty() const;
     bool isInt32() const;
     bool isUInt32() const;
     bool isDouble() const;

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -2999,13 +2999,22 @@ NEVER_INLINE void ByteCodeInterpreter::newTargetOperation(ExecutionState& state,
 
 NEVER_INLINE void ByteCodeInterpreter::defineObjectGetter(ExecutionState& state, ObjectDefineGetter* code, Value* registerFile)
 {
-    // FIXME: FunctionObject
     FunctionObject* fn = registerFile[code->m_objectPropertyValueRegisterIndex].asFunction();
-    String* pName = registerFile[code->m_objectPropertyNameRegisterIndex].toString(state);
-    StringBuilder builder;
-    builder.appendString("get ");
-    builder.appendString(pName);
-    fn->defineOwnProperty(state, state.context()->staticStrings().name, ObjectPropertyDescriptor(builder.finalize()));
+    Value pName = registerFile[code->m_objectPropertyNameRegisterIndex];
+    Value fnName = pName;
+    if (fnName.isSymbol()) {
+        StringBuilder builder;
+        builder.appendString("get [");
+        builder.appendString(fnName.asSymbol()->description());
+        builder.appendString("]");
+        fnName = builder.finalize(&state);
+    } else {
+        StringBuilder builder;
+        builder.appendString("get ");
+        builder.appendString(fnName.toString(state));
+        fnName = builder.finalize(&state);
+    }
+    fn->defineOwnProperty(state, state.context()->staticStrings().name, ObjectPropertyDescriptor(fnName));
     JSGetterSetter gs(registerFile[code->m_objectPropertyValueRegisterIndex].asFunction(), Value(Value::EmptyValue));
     ObjectPropertyDescriptor desc(gs, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent | ObjectPropertyDescriptor::EnumerablePresent));
     Object* object = registerFile[code->m_objectRegisterIndex].toObject(state);
@@ -3014,13 +3023,22 @@ NEVER_INLINE void ByteCodeInterpreter::defineObjectGetter(ExecutionState& state,
 
 NEVER_INLINE void ByteCodeInterpreter::defineObjectSetter(ExecutionState& state, ObjectDefineSetter* code, Value* registerFile)
 {
-    // FIXME: FunctionObject
     FunctionObject* fn = registerFile[code->m_objectPropertyValueRegisterIndex].asFunction();
-    String* pName = registerFile[code->m_objectPropertyNameRegisterIndex].toString(state);
-    StringBuilder builder;
-    builder.appendString("set ");
-    builder.appendString(pName);
-    fn->defineOwnProperty(state, state.context()->staticStrings().name, ObjectPropertyDescriptor(builder.finalize()));
+    Value pName = registerFile[code->m_objectPropertyNameRegisterIndex];
+    Value fnName = pName;
+    if (fnName.isSymbol()) {
+        StringBuilder builder;
+        builder.appendString("set [");
+        builder.appendString(fnName.asSymbol()->description());
+        builder.appendString("]");
+        fnName = builder.finalize(&state);
+    } else {
+        StringBuilder builder;
+        builder.appendString("set ");
+        builder.appendString(fnName.toString(state));
+        fnName = builder.finalize(&state);
+    }
+    fn->defineOwnProperty(state, state.context()->staticStrings().name, ObjectPropertyDescriptor(fnName));
     JSGetterSetter gs(Value(Value::EmptyValue), registerFile[code->m_objectPropertyValueRegisterIndex].asFunction());
     ObjectPropertyDescriptor desc(gs, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent | ObjectPropertyDescriptor::EnumerablePresent));
     Object* object = registerFile[code->m_objectRegisterIndex].toObject(state);

--- a/src/parser/ast/ClassDeclarationNode.h
+++ b/src/parser/ast/ClassDeclarationNode.h
@@ -68,6 +68,15 @@ public:
 
         m_class.classBody()->generateClassInitializer(codeBlock, context, classIndex);
 
+        size_t nameRegister = context->getRegister();
+        // we don't need to root class name string because it is AtomicString
+        codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), nameRegister, Value(context->m_classInfo.m_name.string())), context, this);
+        codeBlock->pushCode(ObjectDefineOwnPropertyWithNameOperation(ByteCodeLOC(m_loc.index), classIndex,
+                                                                     codeBlock->m_codeBlock->context()->staticStrings().name,
+                                                                     nameRegister, ObjectPropertyDescriptor::ConfigurablePresent),
+                            context, this);
+        context->giveUpRegister();
+
         if (m_class.classBodyLexicalBlockIndex() != LEXICAL_BLOCK_INDEX_MAX) {
             // Initialize class name
             context->m_isLexicallyDeclaredBindingInitialization = true;

--- a/src/parser/ast/ClassExpressionNode.h
+++ b/src/parser/ast/ClassExpressionNode.h
@@ -68,6 +68,15 @@ public:
 
         m_class.classBody()->generateClassInitializer(codeBlock, context, dstIndex);
 
+        size_t nameRegister = context->getRegister();
+        // we don't need to root class name string because it is AtomicString
+        codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), nameRegister, Value(context->m_classInfo.m_name.string())), context, this);
+        codeBlock->pushCode(ObjectDefineOwnPropertyWithNameOperation(ByteCodeLOC(m_loc.index), dstIndex,
+                                                                     codeBlock->m_codeBlock->context()->staticStrings().name,
+                                                                     nameRegister, ObjectPropertyDescriptor::ConfigurablePresent),
+                            context, this);
+        context->giveUpRegister();
+
         if (m_class.classBodyLexicalBlockIndex() != LEXICAL_BLOCK_INDEX_MAX) {
             ASSERT(classIdent);
             // Initialize class name

--- a/src/runtime/Context.cpp
+++ b/src/runtime/Context.cpp
@@ -63,6 +63,7 @@ Context::Context(VMInstance* instance)
     m_defaultStructureForBuiltinFunctionObject = m_instance->m_defaultStructureForBuiltinFunctionObject;
     m_defaultStructureForFunctionPrototypeObject = m_instance->m_defaultStructureForFunctionPrototypeObject;
     m_defaultStructureForBoundFunctionObject = m_instance->m_defaultStructureForBoundFunctionObject;
+    m_defaultStructureForClassConstructorFunctionObject = m_instance->m_defaultStructureForClassConstructorFunctionObject;
     m_defaultStructureForArrayObject = m_instance->m_defaultStructureForArrayObject;
     m_defaultStructureForStringObject = m_instance->m_defaultStructureForStringObject;
     m_defaultStructureForSymbolObject = m_instance->m_defaultStructureForSymbolObject;

--- a/src/runtime/Context.h
+++ b/src/runtime/Context.h
@@ -133,6 +133,11 @@ public:
         return m_defaultStructureForFunctionPrototypeObject;
     }
 
+    ObjectStructure* defaultStructureForClassConstructorFunctionObject()
+    {
+        return m_defaultStructureForClassConstructorFunctionObject;
+    }
+
     ObjectStructure* defaultStructureForArrayObject()
     {
         return m_defaultStructureForArrayObject;
@@ -243,6 +248,7 @@ private:
     ObjectStructure* m_defaultStructureForBuiltinFunctionObject;
     ObjectStructure* m_defaultStructureForFunctionPrototypeObject;
     ObjectStructure* m_defaultStructureForBoundFunctionObject;
+    ObjectStructure* m_defaultStructureForClassConstructorFunctionObject;
     ObjectStructure* m_defaultStructureForArrayObject;
     ObjectStructure* m_defaultStructureForStringObject;
     ObjectStructure* m_defaultStructureForSymbolObject;

--- a/src/runtime/ErrorObject.cpp
+++ b/src/runtime/ErrorObject.cpp
@@ -47,6 +47,7 @@ const char* errorMessage_Set_ToUndefined = "Cannot set property '%s' of undefine
 const char* errorMessage_Set_ToNull = "Cannot set property '%s' of null";
 const char* errorMessage_New_Target_Is_Undefined = "NewTarget is undefined";
 const char* errorMessage_Class_Prototype_Is_Not_Object_Nor_Null = "Class extends object prototype property is not object nor null";
+const char* errorMessage_Class_Prototype_Is_Not_Static_Generator = "Classes may not have a static property named 'prototype'";
 const char* errorMessage_Class_Extends_Value_Is_Not_Object_Nor_Null = "Class extends value is not object nor null";
 const char* errorMessage_Initialized_This_Binding = "Super constructor may only be called once";
 const char* errorMessage_UnInitialized_This_Binding = "Must call super constructor in derived class before accessing 'this' or returning from derived constructor";

--- a/src/runtime/ErrorObject.h
+++ b/src/runtime/ErrorObject.h
@@ -52,6 +52,7 @@ extern const char* errorMessage_Set_ToUndefined;
 extern const char* errorMessage_Set_ToNull;
 extern const char* errorMessage_New_Target_Is_Undefined;
 extern const char* errorMessage_Class_Prototype_Is_Not_Object_Nor_Null;
+extern const char* errorMessage_Class_Prototype_Is_Not_Static_Generator;
 extern const char* errorMessage_Class_Extends_Value_Is_Not_Object_Nor_Null;
 extern const char* errorMessage_Initialized_This_Binding;
 extern const char* errorMessage_UnInitialized_This_Binding;

--- a/src/runtime/FunctionObject.h
+++ b/src/runtime/FunctionObject.h
@@ -53,17 +53,18 @@ public:
     // getter of internal [[Prototype]]
     Value getFunctionPrototype(ExecutionState& state)
     {
-        if (LIKELY(isConstructor()))
-            return m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER];
-        else
+        if (LIKELY(isConstructor())) {
+            return m_values[functionPrototypeIndex()];
+        } else {
             return Value();
+        }
     }
 
     // setter of internal [[Prototype]]
     bool setFunctionPrototype(ExecutionState& state, const Value& v)
     {
         if (LIKELY(isConstructor())) {
-            m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER] = v;
+            m_values[functionPrototypeIndex()] = v;
             return true;
         } else {
             return false;
@@ -135,7 +136,7 @@ public:
 
     ConstructorKind constructorKind()
     {
-        return codeBlock()->isDerivedClassConstructor() == ConstructorKind::Derived ? ConstructorKind::Derived : ConstructorKind::Base;
+        return codeBlock()->isDerivedClassConstructor() ? ConstructorKind::Derived : ConstructorKind::Base;
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
@@ -162,17 +163,21 @@ protected:
     FunctionObject(ExecutionState& state, size_t defaultSpace); // function for derived classes. derived class MUST initlize member variable of FunctionObject.
 
     void initStructureAndValues(ExecutionState& state, bool isConstructor, bool isGenerator);
+    virtual size_t functionPrototypeIndex()
+    {
+        return ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER;
+    }
 
     Value getFunctionPrototypeKnownAsConstructor(ExecutionState& state)
     {
         ASSERT(isConstructor());
-        return m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER];
+        return m_values[functionPrototypeIndex()];
     }
 
     bool setFunctionPrototypeKnownAsConstructor(ExecutionState& state, const Value& v)
     {
         ASSERT(isConstructor());
-        m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER] = v;
+        m_values[functionPrototypeIndex()] = v;
         return true;
     }
     CodeBlock* m_codeBlock;

--- a/src/runtime/ScriptClassConstructorFunctionObject.cpp
+++ b/src/runtime/ScriptClassConstructorFunctionObject.cpp
@@ -25,6 +25,22 @@
 
 namespace Escargot {
 
+ScriptClassConstructorFunctionObject::ScriptClassConstructorFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, Object* homeObject)
+    : ScriptFunctionObject(state, codeBlock, outerEnvironment, 2)
+    , m_homeObject(homeObject)
+{
+    ASSERT(!codeBlock->isGenerator()); // Class constructor may not be a generator
+
+    m_structure = state.context()->defaultStructureForClassConstructorFunctionObject();
+
+    ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0 < m_structure->propertyCount());
+    ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1 < m_structure->propertyCount());
+    auto prototype = new Object(state);
+    prototype->setPrototype(state, state.context()->globalObject()->generatorPrototype());
+    m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = (Value(m_codeBlock->parameterCount()));
+    m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(Object::createFunctionPrototypeObject(state, this)));
+}
+
 Value ScriptClassConstructorFunctionObject::call(ExecutionState& state, const Value& thisValue, const size_t argc, NULLABLE Value* argv)
 {
     ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "Class constructor cannot be invoked without 'new'");

--- a/src/runtime/ScriptClassConstructorFunctionObject.h
+++ b/src/runtime/ScriptClassConstructorFunctionObject.h
@@ -26,11 +26,7 @@ namespace Escargot {
 
 class ScriptClassConstructorFunctionObject : public ScriptFunctionObject {
 public:
-    ScriptClassConstructorFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, Object* homeObject)
-        : ScriptFunctionObject(state, codeBlock, outerEnvironment, true, codeBlock->isGenerator())
-        , m_homeObject(homeObject)
-    {
-    }
+    ScriptClassConstructorFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, Object* homeObject);
 
     friend class FunctionObjectProcessCallGenerator;
     virtual Value call(ExecutionState& state, const Value& thisValue, const size_t argc, NULLABLE Value* argv) override;
@@ -47,6 +43,11 @@ public:
     }
 
 private:
+    virtual size_t functionPrototypeIndex() override
+    {
+        return ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1;
+    }
+
     Object* m_homeObject;
 };
 }

--- a/src/runtime/ScriptFunctionObject.h
+++ b/src/runtime/ScriptFunctionObject.h
@@ -32,6 +32,8 @@ public:
     ScriptFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, bool isConstructor, bool isGenerator);
 
 protected:
+    ScriptFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, size_t defaultPropertyCount);
+
     friend class FunctionObjectProcessCallGenerator;
     // https://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist
     virtual Value call(ExecutionState& state, const Value& thisValue, const size_t argc, NULLABLE Value* argv) override;

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -183,9 +183,8 @@ public:
         return m_jobQueue;
     }
 
-    // if there is an error, executing will be stopped and returns ErrorValue
-    // if thres is no job or no error, returns EmptyValue
-    Value drainJobQueue();
+    //   <is there any job after drain, thrown error value>
+    std::pair<bool, Optional<Value>> drainJobQueue();
 
     typedef void (*NewPromiseJobListener)(ExecutionState& state, Job* job);
     void setNewPromiseJobListener(NewPromiseJobListener l);
@@ -234,6 +233,7 @@ private:
     ObjectStructure* m_defaultStructureForBuiltinFunctionObject;
     ObjectStructure* m_defaultStructureForFunctionPrototypeObject;
     ObjectStructure* m_defaultStructureForBoundFunctionObject;
+    ObjectStructure* m_defaultStructureForClassConstructorFunctionObject;
     ObjectStructure* m_defaultStructureForArrayObject;
     ObjectStructure* m_defaultStructureForStringObject;
     ObjectStructure* m_defaultStructureForSymbolObject;

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -97,15 +97,8 @@
   <test id="13.2.1_5"><reason>TODO : Need to fix 'Number.prototype.toLocaleString' according to ECMAScript 6.0 spec</reason></test>
   <test id="13.3.0_6_1"><reason>TODO : Need to fix 'Date.prototype.toLocaleString' according to ECMAScript 6.0 spec</reason></test>
   <test id="13.3.0_7"><reason>TODO : Need to fix 'Date.prototype.toLocaleString' according to ECMAScript 6.0 spec</reason></test>
-  
+
   <test id="6.2.3"><reason>TODO</reason></test>
-  <test id="generator-prototype"><reason>TODO</reason></test>
-  <test id="getter-prototype"><reason>TODO</reason></test>
-  <test id="method-number"><reason>TODO</reason></test>
-  <test id="method-prototype"><reason>TODO</reason></test>
-  <test id="method-string"><reason>TODO</reason></test>
-  <test id="method-symbol"><reason>TODO</reason></test>
-  <test id="setter-prototype"><reason>TODO</reason></test>
   <test id="S11.13.1_A5_T1"><reason>TODO</reason></test>
   <test id="S11.13.1_A5_T2"><reason>TODO</reason></test>
   <test id="S11.13.1_A5_T3"><reason>TODO</reason></test>
@@ -262,9 +255,7 @@
   <test id="basics"><reason>TODO</reason></test>
   <test id="getters"><reason>TODO</reason></test>
   <test id="numeric-property-names"><reason>TODO</reason></test>
-  <test id="prototype-property"><reason>TODO</reason></test>
   <test id="setters"><reason>TODO</reason></test>
-  <test id="this-access-restriction"><reason>TODO</reason></test>
   <test id="body-dstr-assign-error"><reason>TODO</reason></test>
   <test id="body-put-error"><reason>TODO</reason></test>
   <test id="generator-close-via-break"><reason>TODO</reason></test>


### PR DESCRIPTION
* Fixup class parsing error check in esprima
* Class cannot have property named 'prototype'
* When define {getter, setter} in interpreter, property key can be symbol
* Reorder properties on class constructor
* Fixup public API

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>