### PR TITLE
Add conversion between ExpressionNode and PatternNode

### DIFF
--- a/src/parser/ast/ArrayExpressionNode.h
+++ b/src/parser/ast/ArrayExpressionNode.h
@@ -89,35 +89,6 @@ public:
         }
     }
 
-    virtual void generateStoreByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex srcRegister, bool needToReferenceSelf)
-    {
-        // store each element by iterator
-        ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
-
-        size_t iteratorIndex = context->getRegister();
-        size_t iteratorValueIndex = context->getRegister();
-
-        codeBlock->pushCode(GetIterator(ByteCodeLOC(m_loc.index), srcRegister, iteratorIndex), context, this);
-
-        for (size_t i = 0; i < m_elements.size(); i++) {
-            if (m_elements[i]) {
-                if (LIKELY(m_elements[i]->type() != SpreadElement)) {
-                    codeBlock->pushCode(IteratorStep(ByteCodeLOC(m_loc.index), iteratorValueIndex, iteratorIndex), context, this);
-                    m_elements[i]->generateResolveAddressByteCode(codeBlock, context);
-                    m_elements[i]->generateStoreByteCode(codeBlock, context, iteratorValueIndex, false);
-                } else {
-                    ASSERT(i == m_elements.size() - 1);
-                    m_elements[i]->generateStoreByteCode(codeBlock, context, iteratorIndex, false);
-                }
-            } else {
-                codeBlock->pushCode(IteratorStep(ByteCodeLOC(m_loc.index), iteratorValueIndex, iteratorIndex), context, this);
-            }
-        }
-
-        context->giveUpRegister(); // for drop iteratorValueIndex
-        context->giveUpRegister(); // for drop iteratorIndex
-    }
-
     virtual void iterateChildrenIdentifier(const std::function<void(AtomicString name, bool isAssignment)>& fn)
     {
         for (size_t i = 0; i < m_elements.size(); i++) {

--- a/src/parser/ast/ArrayPatternNode.h
+++ b/src/parser/ast/ArrayPatternNode.h
@@ -33,6 +33,12 @@ public:
     {
     }
 
+    ArrayPatternNode(ExpressionNodeVector&& elements, NodeLOC& loc)
+        : m_elements(elements)
+    {
+        m_loc = loc;
+    }
+
     virtual ASTNodeType type() { return ASTNodeType::ArrayPattern; }
     virtual void generateStoreByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex srcRegister, bool needToReferenceSelf)
     {

--- a/src/parser/ast/AssignmentExpressionSimpleNode.h
+++ b/src/parser/ast/AssignmentExpressionSimpleNode.h
@@ -168,36 +168,6 @@ public:
         generateResultNotRequiredAssignmentByteCode(this, m_left.get(), m_right.get(), codeBlock, context);
     }
 
-    virtual void generateStoreByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex srcRegister, bool needToReferenceSelf)
-    {
-        LiteralNode* undefinedNode = new (alloca(sizeof(LiteralNode))) LiteralNode(Value());
-        size_t undefinedIndex = undefinedNode->getRegister(codeBlock, context);
-        undefinedNode->generateExpressionByteCode(codeBlock, context, undefinedIndex);
-
-        size_t cmpIndex = context->getRegister();
-        codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), srcRegister, undefinedIndex, cmpIndex), context, this);
-
-        context->giveUpRegister(); // for drop undefinedIndex
-
-        codeBlock->pushCode<JumpIfTrue>(JumpIfTrue(ByteCodeLOC(m_loc.index), cmpIndex), context, this);
-        size_t pos1 = codeBlock->lastCodePosition<JumpIfTrue>();
-        context->giveUpRegister(); // for drop cmpIndex
-
-        // not undefined case, set srcRegister
-        m_left->generateStoreByteCode(codeBlock, context, srcRegister, needToReferenceSelf);
-        codeBlock->pushCode<Jump>(Jump(ByteCodeLOC(m_loc.index)), context, this);
-        size_t pos2 = codeBlock->lastCodePosition<Jump>();
-
-        // undefined case, set default node
-        codeBlock->peekCode<JumpIfTrue>(pos1)->m_jumpPosition = codeBlock->currentCodeSize();
-        size_t rightIndex = m_right->getRegister(codeBlock, context);
-        m_right->generateExpressionByteCode(codeBlock, context, rightIndex);
-        m_left->generateStoreByteCode(codeBlock, context, rightIndex, needToReferenceSelf);
-        context->giveUpRegister(); // for drop rightIndex
-
-        codeBlock->peekCode<Jump>(pos2)->m_jumpPosition = codeBlock->currentCodeSize();
-    }
-
     virtual void iterateChildrenIdentifier(const std::function<void(AtomicString name, bool isAssignment)>& fn)
     {
         m_left->iterateChildrenIdentifierAssigmentCase(fn);

--- a/src/parser/ast/InitializeParameterExpressionNode.h
+++ b/src/parser/ast/InitializeParameterExpressionNode.h
@@ -59,7 +59,7 @@ public:
                 context->giveUpRegister();
             }
         } else {
-            // pattern or default paremter cases
+            // pattern or default parameter cases
             size_t rightRegister = context->getRegister();
             m_left->generateResolveAddressByteCode(codeBlock, context);
             codeBlock->pushCode(GetParameter(ByteCodeLOC(m_loc.index), rightRegister, m_paramIndex), context, this);

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -363,11 +363,6 @@ public:
         return type() == ASTNodeType::SuperExpression;
     }
 
-    bool isValidAssignmentTarget()
-    {
-        return isIdentifier() || isMemberExpression();
-    }
-
     virtual bool isExpressionNode()
     {
         return false;
@@ -811,7 +806,7 @@ typedef std::vector<RefPtr<Node>> ArgumentVector;
 typedef std::vector<RefPtr<Node>> ExpressionNodeVector;
 typedef std::vector<RefPtr<Node>> PatternNodeVector;
 class PropertyNode;
-typedef std::vector<RefPtr<PropertyNode>> PropertiesNodeVector;
+typedef std::vector<RefPtr<Node>> PropertiesNodeVector;
 class VariableDeclaratorNode;
 typedef std::vector<RefPtr<VariableDeclaratorNode>> VariableDeclaratorVector;
 }

--- a/src/parser/ast/ObjectExpressionNode.h
+++ b/src/parser/ast/ObjectExpressionNode.h
@@ -51,7 +51,7 @@ public:
         codeBlock->pushCode(CreateObject(ByteCodeLOC(m_loc.index), dstRegister), context, this);
         size_t objIndex = dstRegister;
         for (unsigned i = 0; i < m_properties.size(); i++) {
-            PropertyNode* p = m_properties[i].get();
+            PropertyNode* p = m_properties[i].get()->asProperty();
             AtomicString propertyAtomicName;
             bool hasKey = false;
             size_t propertyIndex = SIZE_MAX;
@@ -106,44 +106,10 @@ public:
         }
     }
 
-    virtual void generateStoreByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex srcRegister, bool needToReferenceSelf)
-    {
-        if (m_properties.size() > 0) {
-            for (size_t i = 0; i < m_properties.size(); i++) {
-                m_properties[i]->generateStoreByteCode(codeBlock, context, srcRegister, needToReferenceSelf);
-            }
-        } else {
-            // ObjectAssignmentPattern without AssignmentPropertyList requires object-coercible
-            // check if srcRegister is undefined or null
-            size_t cmpIndex = context->getRegister();
-
-            LiteralNode* undefinedNode = new (alloca(sizeof(LiteralNode))) LiteralNode(Value());
-            size_t undefinedIndex = undefinedNode->getRegister(codeBlock, context);
-            undefinedNode->generateExpressionByteCode(codeBlock, context, undefinedIndex);
-            codeBlock->pushCode(BinaryEqual(ByteCodeLOC(m_loc.index), srcRegister, undefinedIndex, cmpIndex), context, this);
-            codeBlock->pushCode<JumpIfTrue>(JumpIfTrue(ByteCodeLOC(m_loc.index), cmpIndex), context, this);
-            size_t pos1 = codeBlock->lastCodePosition<JumpIfTrue>();
-            context->giveUpRegister(); // for drop undefinedIndex
-
-            LiteralNode* nullNode = new (alloca(sizeof(LiteralNode))) LiteralNode(Value(Value::Null));
-            size_t nullIndex = nullNode->getRegister(codeBlock, context);
-            nullNode->generateExpressionByteCode(codeBlock, context, nullIndex);
-            codeBlock->pushCode(BinaryEqual(ByteCodeLOC(m_loc.index), srcRegister, nullIndex, cmpIndex), context, this);
-            codeBlock->pushCode<JumpIfFalse>(JumpIfFalse(ByteCodeLOC(m_loc.index), cmpIndex), context, this);
-            size_t pos2 = codeBlock->lastCodePosition<JumpIfFalse>();
-            context->giveUpRegister(); // for drop nullIndex
-            context->giveUpRegister(); // for drop cmpIndex
-
-            codeBlock->peekCode<JumpIfTrue>(pos1)->m_jumpPosition = codeBlock->currentCodeSize();
-            codeBlock->pushCode(ThrowStaticErrorOperation(ByteCodeLOC(m_loc.index), ErrorObject::TypeError, errorMessage_Can_Not_Be_Destructed), context, this);
-            codeBlock->peekCode<JumpIfTrue>(pos2)->m_jumpPosition = codeBlock->currentCodeSize();
-        }
-    }
-
     virtual void iterateChildrenIdentifier(const std::function<void(AtomicString name, bool isAssignment)>& fn)
     {
         for (size_t i = 0; i < m_properties.size(); i++) {
-            PropertyNode* p = m_properties[i].get();
+            PropertyNode* p = m_properties[i].get()->asProperty();
             if (!(p->key()->isIdentifier() && !p->computed())) {
                 p->key()->iterateChildrenIdentifier(fn);
             }

--- a/src/parser/ast/ObjectPatternNode.h
+++ b/src/parser/ast/ObjectPatternNode.h
@@ -31,6 +31,22 @@ public:
     ObjectPatternNode(PropertiesNodeVector&& properties)
         : m_properties(properties)
     {
+#ifndef NDEBUG
+        for (size_t i = 0; i < m_properties.size(); i++) {
+            ASSERT(m_properties[i]->isProperty());
+        }
+#endif
+    }
+
+    ObjectPatternNode(PropertiesNodeVector&& properties, NodeLOC& loc)
+        : m_properties(properties)
+    {
+        m_loc = loc;
+#ifndef NDEBUG
+        for (size_t i = 0; i < m_properties.size(); i++) {
+            ASSERT(m_properties[i]->isProperty());
+        }
+#endif
     }
 
     virtual ASTNodeType type() { return ASTNodeType::ObjectPattern; }
@@ -75,7 +91,7 @@ public:
     virtual void iterateChildrenIdentifier(const std::function<void(AtomicString name, bool isAssignment)>& fn)
     {
         for (size_t i = 0; i < m_properties.size(); i++) {
-            PropertyNode* p = m_properties[i].get();
+            PropertyNode* p = m_properties[i].get()->asProperty();
             if (!(p->key()->isIdentifier() && !p->computed())) {
                 p->key()->iterateChildrenIdentifier(fn);
             }

--- a/src/parser/ast/PropertyNode.h
+++ b/src/parser/ast/PropertyNode.h
@@ -59,6 +59,11 @@ public:
         return m_value.get();
     }
 
+    void setValue(Node* value)
+    {
+        m_value = value;
+    }
+
     Kind kind()
     {
         return m_kind;

--- a/src/parser/ast/RestElementNode.h
+++ b/src/parser/ast/RestElementNode.h
@@ -27,10 +27,17 @@ namespace Escargot {
 
 class RestElementNode : public ExpressionNode {
 public:
-    RestElementNode(IdentifierNode* argument)
+    RestElementNode(Node* argument)
         : ExpressionNode()
+        , m_argument(argument)
     {
-        m_argument = argument;
+    }
+
+    RestElementNode(Node* argument, NodeLOC& loc)
+        : ExpressionNode()
+        , m_argument(argument)
+    {
+        m_loc = loc;
     }
 
     virtual ~RestElementNode()
@@ -38,7 +45,7 @@ public:
     }
 
     virtual ASTNodeType type() { return ASTNodeType::RestElement; }
-    IdentifierNode* argument()
+    Node* argument()
     {
         return m_argument.get();
     }
@@ -48,6 +55,7 @@ public:
         // srcRegister indicates iteratorRegister
         size_t restElementRegister = m_argument->getRegister(codeBlock, context);
         codeBlock->pushCode(BindingRestElement(ByteCodeLOC(m_loc.index), srcRegister, restElementRegister), context, this);
+        m_argument->generateResolveAddressByteCode(codeBlock, context);
         m_argument->generateStoreByteCode(codeBlock, context, restElementRegister, needToReferenceSelf);
         context->giveUpRegister();
     }
@@ -62,7 +70,7 @@ public:
     }
 
 protected:
-    RefPtr<IdentifierNode> m_argument;
+    RefPtr<Node> m_argument;
 };
 }
 

--- a/src/parser/ast/SequenceExpressionNode.h
+++ b/src/parser/ast/SequenceExpressionNode.h
@@ -59,7 +59,7 @@ public:
     }
 
     virtual ASTNodeType type() { return ASTNodeType::SequenceExpression; }
-    const ExpressionNodeVector& expressions() { return m_expressions; }
+    ExpressionNodeVector& expressions() { return m_expressions; }
 private:
     ExpressionNodeVector m_expressions; // expression: Expression;
 };

--- a/src/parser/ast/SpreadElementNode.h
+++ b/src/parser/ast/SpreadElementNode.h
@@ -36,9 +36,10 @@ public:
     {
     }
 
-    virtual ASTNodeType type()
+    virtual ASTNodeType type() { return SpreadElement; }
+    Node* argument()
     {
-        return SpreadElement;
+        return m_argument.get();
     }
 
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister)
@@ -46,16 +47,6 @@ public:
         size_t spreadIndex = m_argument->getRegister(codeBlock, context);
         m_argument->generateExpressionByteCode(codeBlock, context, spreadIndex);
         codeBlock->pushCode(CreateSpreadObject(ByteCodeLOC(m_loc.index), dstRegister, spreadIndex), context, this);
-        context->giveUpRegister();
-    }
-
-    virtual void generateStoreByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex srcRegister, bool needToReferenceSelf)
-    {
-        // srcRegister indicates iteratorRegister
-        size_t restElementRegister = m_argument->getRegister(codeBlock, context);
-        codeBlock->pushCode(BindingRestElement(ByteCodeLOC(m_loc.index), srcRegister, restElementRegister), context, this);
-        m_argument->generateResolveAddressByteCode(codeBlock, context);
-        m_argument->generateStoreByteCode(codeBlock, context, restElementRegister, needToReferenceSelf);
         context->giveUpRegister();
     }
 


### PR DESCRIPTION
* implement reinterpretExpressionAsPattern parsing method for conversion between ExpressionNode and PatternNode
* remove redundant modules in Patterns

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>