### PR TITLE
Fix Object.getOwnPropertySymbols

### DIFF
--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -386,9 +386,6 @@ static Value builtinObjectGetOwnPropertyNames(ExecutionState& state, Value thisV
 static Value builtinObjectGetOwnPropertySymbols(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
     // https://www.ecma-international.org/ecma-262/6.0/#sec-object.getownpropertysymbols
-    if (!argv[0].isObject()) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Object.string(), false, state.context()->staticStrings().getOwnPropertySymbols.string(), errorMessage_GlobalObject_FirstArgumentNotObject);
-    }
     Object* O = argv[0].toObject(state);
     return getOwnPropertyKeys(state, O, GetOwnPropertyKeysType::Symbol);
 }


### PR DESCRIPTION
This argument must be coerced to object according to the standard.

Signed-off-by: Robert Fancsik <frobert@inf.u-szeged.hu>