### PR TITLE
Fix syntax check of parameters for arrow function

### DIFF
--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -269,9 +269,6 @@
   <test id="attempt-to-redeclare-function-declaration-with-function-declaration"><reason>TODO</reason></test>
   <test id="attempt-to-redeclare-function-declaration-with-var"><reason>TODO</reason></test>
   <test id="attempt-to-redeclare-var-with-function-declaration"><reason>TODO</reason></test>
-  <test id="arrowparameters-bindingidentifier-no-arguments"><reason>TODO</reason></test>
-  <test id="arrowparameters-bindingidentifier-no-eval"><reason>TODO</reason></test>
-  <test id="arrowparameters-cover-no-duplicates"><reason>TODO</reason></test>
   <test id="array-elem-init-simple-strict"><reason>TODO</reason></test>
   <test id="array-elem-nested-array-invalid"><reason>TODO</reason></test>
   <test id="array-elem-nested-obj-invalid"><reason>TODO</reason></test>


### PR DESCRIPTION
* add syntax check for single parameter in arrow function
* use of parsePropertyMethod is fixed upto the latest esprima version

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>