### PR TITLE
Pass more test262 testcases

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -71,6 +71,7 @@ struct GlobalVariableAccessCacheItem;
     F(CreateClass, 0, 0)                                    \
     F(CreateRestElement, 0, 0)                              \
     F(SuperReference, 1, 0)                                 \
+    F(SuperSetObjectOperation, 0, 2)                        \
     F(CallSuper, -1, 0)                                     \
     F(LoadThisBinding, 0, 0)                                \
     F(ObjectDefineOwnPropertyOperation, 0, 0)               \
@@ -498,6 +499,28 @@ public:
         } else {
             printf("super property -> r%d", (int)m_dstIndex);
         }
+    }
+#endif
+};
+
+class SuperSetObjectOperation : public ByteCode {
+public:
+    SuperSetObjectOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, PropertyName propertyName, const size_t loadRegisterIndex)
+        : ByteCode(Opcode::SuperSetObjectOperationOpcode, loc)
+        , m_objectRegisterIndex(objectRegisterIndex)
+        , m_loadRegisterIndex(loadRegisterIndex)
+        , m_propertyName(propertyName)
+    {
+    }
+
+    ByteCodeRegisterIndex m_objectRegisterIndex;
+    ByteCodeRegisterIndex m_loadRegisterIndex;
+    PropertyName m_propertyName;
+
+#ifndef NDEBUG
+    void dump(const char* byteCodeStart)
+    {
+        printf("set object super(r%d).%s <- r%d", (int)m_objectRegisterIndex, m_propertyName.plainString()->toUTF8StringData().data(), (int)m_loadRegisterIndex);
     }
 #endif
 };

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -568,6 +568,12 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
                 assignStackIndexIfNeeded(cd->m_dstIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
             }
+            case SuperSetObjectOperationOpcode: {
+                SuperSetObjectOperation* cd = (SuperSetObjectOperation*)currentCode;
+                assignStackIndexIfNeeded(cd->m_objectRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
+                assignStackIndexIfNeeded(cd->m_loadRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
+                break;
+            }
             case CallSuperOpcode: {
                 CallSuper* cd = (CallSuper*)currentCode;
                 assignStackIndexIfNeeded(cd->m_argumentsStartIndex, stackBase, stackBaseWillBe, stackVariableSize);

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -40,6 +40,7 @@ class CallEvalFunction;
 class CreateFunction;
 class CreateClass;
 class SuperReference;
+class SuperSetObjectOperation;
 class CallSuper;
 class WithOperation;
 class BlockOperation;
@@ -107,6 +108,7 @@ public:
     static void evalOperation(ExecutionState& state, CallEvalFunction* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void classOperation(ExecutionState& state, CreateClass* code, Value* registerFile);
     static void superOperation(ExecutionState& state, SuperReference* code, Value* registerFile);
+    static void superSetObjectOperation(ExecutionState& state, SuperSetObjectOperation* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void callSuperOperation(ExecutionState& state, CallSuper* code, Value* registerFile);
     static Value withOperation(ExecutionState*& state, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
     static Value blockOperation(ExecutionState*& state, BlockOperation* code, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
@@ -116,7 +118,7 @@ public:
 
     static void yieldOperation(ExecutionState& state, Value* registerFile, size_t programCounter, char* codeBuffer);
     static Value yieldDelegateOperation(ExecutionState& state, Value* registerFile, size_t& programCounter, char* codeBuffer);
-    static void yieldOperationImplementation(ExecutionState& state, Value returnValue, size_t tailDataPosition, size_t tailDataLength, size_t nextProgramCounter, ByteCodeRegisterIndex dstRegisterIndex);
+    static void yieldOperationImplementation(ExecutionState& state, Value returnValue, size_t tailDataPosition, size_t tailDataLength, size_t nextProgramCounter, ByteCodeRegisterIndex dstRegisterIndex, bool isDelegateOperation);
     static Value generatorResumeOperation(ExecutionState*& state, size_t& programCounter, ByteCodeBlock* byteCodeBlock);
 
     static void newTargetOperation(ExecutionState& state, NewTargetOperation* code, Value* registerFile);

--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -1468,18 +1468,26 @@ void Scanner::scanTemplate(Scanner::ScannerResult* token, bool head)
                 if (ch == '\r' && this->peekChar() == '\n') {
                     ++this->index;
                 }
-                raw += '\n';
+                if (ch == 0x2028 || ch == 0x2029) {
+                    raw += ch;
+                } else {
+                    raw += '\n';
+                }
                 this->lineStart = this->index;
             }
         } else if (isLineTerminator(ch)) {
             ++this->lineNumber;
-            raw += ch;
             if (ch == '\r' && this->peekChar() == '\n') {
-                raw += this->peekChar();
                 ++this->index;
             }
+            if (ch == 0x2028 || ch == 0x2029) {
+                raw += ch;
+                cooked += ch;
+            } else {
+                raw += '\n';
+                cooked += '\n';
+            }
             this->lineStart = this->index;
-            cooked += '\n';
         } else {
             cooked += ch;
             raw += ch;

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -1603,7 +1603,7 @@ public:
         this->expect(RightSquareBracket);
 
         if (isParse) {
-            return T(this->finalize(node, new ArrayExpressionNode(std::move(elements), AtomicString(), nullptr, hasSpreadElement)));
+            return T(this->finalize(node, new ArrayExpressionNode(std::move(elements), AtomicString(), nullptr, hasSpreadElement, false)));
         }
         return ScanExpressionResult(ASTNodeType::ArrayExpression);
     }
@@ -2691,7 +2691,7 @@ public:
             arrayExpressionForRaw = this->finalize(node, new ArrayExpressionNode(std::move(elements)));
         }
 
-        RefPtr<ArrayExpressionNode> quasiVector = this->finalize(node, new ArrayExpressionNode(std::move(elements), this->escargotContext->staticStrings().raw, arrayExpressionForRaw.get()));
+        RefPtr<ArrayExpressionNode> quasiVector = this->finalize(node, new ArrayExpressionNode(std::move(elements), this->escargotContext->staticStrings().raw, arrayExpressionForRaw.get(), false, true));
         args.push_back(quasiVector.get());
         for (size_t i = 0; i < templateLiteral->expressions().size(); i++) {
             args.push_back(templateLiteral->expressions()[i]);

--- a/src/runtime/GeneratorObject.h
+++ b/src/runtime/GeneratorObject.h
@@ -81,6 +81,7 @@ private:
     // yield is implemented throw this type of by this class
     // we cannot use normal return logic because we must not modify ExecutionState(some statements(block,with..) needs modifying control flow data for exit function)
     struct GeneratorExitValue : public gc {
+        bool m_isDelegateOperation;
         Value m_value;
 
         void* operator new(size_t size)
@@ -93,6 +94,7 @@ private:
     void releaseExecutionVariables()
     {
         m_executionState = nullptr;
+        m_registerFile = nullptr;
         m_byteCodeBlock = nullptr;
     }
 

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -54,6 +54,7 @@ public:
         , m_object(nullptr)
         , m_objectPrototypeToString(nullptr)
         , m_objectCreate(nullptr)
+        , m_objectFreeze(nullptr)
         , m_function(nullptr)
         , m_functionPrototype(nullptr)
         , m_iteratorPrototype(nullptr)
@@ -245,6 +246,10 @@ public:
     FunctionObject* objectCreate()
     {
         return m_objectCreate;
+    }
+    FunctionObject* objectFreeze()
+    {
+        return m_objectFreeze;
     }
 
     FunctionObject* function()
@@ -678,6 +683,7 @@ private:
     Object* m_objectPrototype;
     FunctionObject* m_objectPrototypeToString;
     FunctionObject* m_objectCreate;
+    FunctionObject* m_objectFreeze;
 
     FunctionObject* m_function;
     FunctionObject* m_functionPrototype;

--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -605,8 +605,9 @@ void GlobalObject::installObject(ExecutionState& state)
                                                          (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     // 19.1.2.5 Object.freeze ( O )
+    m_objectFreeze = new NativeFunctionObject(state, NativeFunctionInfo(strings.freeze, builtinObjectFreeze, 1, NativeFunctionInfo::Strict));
     m_object->defineOwnProperty(state, ObjectPropertyName(strings.freeze),
-                                ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings.freeze, builtinObjectFreeze, 1, NativeFunctionInfo::Strict)),
+                                ObjectPropertyDescriptor(m_objectFreeze,
                                                          (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     // 19.1.2.6 Object.getOwnPropertyDescriptor ( O, P )

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -93,6 +93,12 @@
   <test id="prototype-value"><reason>Test is wrong. Generator is not constructor</reason></test>
   <test id="generator-invoke-ctor"><reason>Test is wrong. Generator is not constructor</reason></test>
   <test id="S11.2.1_A4_T5"><reason>Test is wrong. String.prototype.length is not undefined</reason></test>
+  <test id="cache-differing-expressions-eval"><reason>Test is wrong. TC contents is wrong and fixed newer version</reason></test>
+  <test id="cache-differing-expressions-new-function"><reason>Test is wrong. TC contents is wrong and fixed newer version</reason></test>
+  <test id="cache-differing-expressions"><reason>Test is wrong. TC contents is wrong and fixed newer version</reason></test>
+  <test id="cache-identical-source-eval"><reason>Test is wrong. TC contents is wrong and fixed newer version</reason></test>
+  <test id="cache-identical-source-new-function"><reason>Test is wrong. TC contents is wrong and fixed newer version</reason></test>
+  <test id="cache-identical-source"><reason>Test is wrong. TC contents is wrong and fixed newer version</reason></test>
 
   <!-- Assigment expression should get left-reference first test cases. TC are right, but every major engine don't pass these cases -->
   <test id="S11.13.1_A5_T5"><reason>ALLOW_FAIL</reason></test>
@@ -149,31 +155,13 @@
   <test id="S11.4.4_A6_T3"><reason>ALLOW_FAIL</reason></test>
   <test id="S11.4.5_A6_T3"><reason>ALLOW_FAIL</reason></test>
 
-  <test id="10.6-13-a-2"><reason>TODO: Need to set caller of arguments's callee correctly(not 'null' or 'undefined')</reason></test>
-  <test id="10.6-13-a-3"><reason>TODO: Need to set caller of arguments's callee correctly(not 'null' or 'undefined')</reason></test>
-
   <test id="obj-id-identifier-yield-ident-valid"><reason>TODO</reason></test>
-  <test id="cache-differing-expressions-eval"><reason>TODO</reason></test>
-  <test id="cache-differing-expressions-new-function"><reason>TODO</reason></test>
-  <test id="cache-differing-expressions"><reason>TODO</reason></test>
-  <test id="cache-identical-source-eval"><reason>TODO</reason></test>
-  <test id="cache-identical-source-new-function"><reason>TODO</reason></test>
-  <test id="cache-identical-source"><reason>TODO</reason></test>
-  <test id="template-object-frozen-non-strict"><reason>TODO</reason></test>
-  <test id="template-object-frozen-strict"><reason>TODO</reason></test>
-  <test id="template-object"><reason>TODO</reason></test>
-  <test id="tv-line-continuation"><reason>TODO</reason></test>
-  <test id="tv-line-terminator-sequence"><reason>TODO</reason></test>
-  <test id="tv-null-character-escape-sequence"><reason>TODO</reason></test>
-  <test id="star-iterable"><reason>TODO</reason></test>
   <test id="yield-as-label-in-sloppy"><reason>TODO</reason></test>
   <test id="let-non-strict-access"><reason>TODO</reason></test>
   <test id="let-non-strict-syntax"><reason>TODO</reason></test>
-  <test id="setter"><reason>TODO</reason></test>
   <test id="yield-non-strict-access"><reason>TODO</reason></test>
   <test id="yield-non-strict-syntax"><reason>TODO</reason></test>
   <test id="basics"><reason>TODO</reason></test>
-  <test id="setters"><reason>TODO</reason></test>
   <test id="body-dstr-assign-error"><reason>TODO</reason></test>
   <test id="body-put-error"><reason>TODO</reason></test>
   <test id="generator-close-via-break"><reason>TODO</reason></test>


### PR DESCRIPTION
* Process 0x2028, 0x2029 char on template literal correctly
* Object are created by TaggedTemplateLiteral are should frozen
* When eval `super.foo = 1`, use `this` as receiver
* Implement Function.protoype.caller
* Fix processing '\0' char bug in builtinFileReadHelper
* When eval `yield delegate` repect it's result.

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>