### PR TITLE
Add a SuperGetObjectOperation

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -72,6 +72,7 @@ struct GlobalVariableAccessCacheItem;
     F(CreateRestElement, 0, 0)                              \
     F(SuperReference, 1, 0)                                 \
     F(SuperSetObjectOperation, 0, 2)                        \
+    F(SuperGetObjectOperation, 1, 2)                        \
     F(CallSuper, -1, 0)                                     \
     F(LoadThisBinding, 0, 0)                                \
     F(ObjectDefineOwnPropertyOperation, 0, 0)               \
@@ -505,22 +506,43 @@ public:
 
 class SuperSetObjectOperation : public ByteCode {
 public:
-    SuperSetObjectOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, PropertyName propertyName, const size_t loadRegisterIndex)
+    SuperSetObjectOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, const size_t propertyNameIndex, const size_t loadRegisterIndex)
         : ByteCode(Opcode::SuperSetObjectOperationOpcode, loc)
         , m_objectRegisterIndex(objectRegisterIndex)
         , m_loadRegisterIndex(loadRegisterIndex)
-        , m_propertyName(propertyName)
+        , m_propertyNameIndex(propertyNameIndex)
     {
     }
 
     ByteCodeRegisterIndex m_objectRegisterIndex;
     ByteCodeRegisterIndex m_loadRegisterIndex;
-    PropertyName m_propertyName;
+    ByteCodeRegisterIndex m_propertyNameIndex;
 
 #ifndef NDEBUG
     void dump(const char* byteCodeStart)
     {
-        printf("set object super(r%d).%s <- r%d", (int)m_objectRegisterIndex, m_propertyName.plainString()->toUTF8StringData().data(), (int)m_loadRegisterIndex);
+        printf("set object super(r%d).r%d <- r%d", (int)m_objectRegisterIndex, (int)m_propertyNameIndex, (int)m_loadRegisterIndex);
+    }
+#endif
+};
+
+class SuperGetObjectOperation : public ByteCode {
+public:
+    SuperGetObjectOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, const size_t storeRegisterIndex, const size_t propertyNameIndex)
+        : ByteCode(Opcode::SuperGetObjectOperationOpcode, loc)
+        , m_objectRegisterIndex(objectRegisterIndex)
+        , m_storeRegisterIndex(storeRegisterIndex)
+        , m_propertyNameIndex(propertyNameIndex)
+    {
+    }
+
+    ByteCodeRegisterIndex m_objectRegisterIndex;
+    ByteCodeRegisterIndex m_storeRegisterIndex;
+    ByteCodeRegisterIndex m_propertyNameIndex;
+#ifndef NDEBUG
+    void dump(const char* byteCodeStart)
+    {
+        printf("get object r%d <- super(r%d).r%d", (int)m_storeRegisterIndex, (int)m_objectRegisterIndex, (int)m_propertyNameIndex);
     }
 #endif
 };

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -572,7 +572,14 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
                 SuperSetObjectOperation* cd = (SuperSetObjectOperation*)currentCode;
                 assignStackIndexIfNeeded(cd->m_objectRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 assignStackIndexIfNeeded(cd->m_loadRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
+                assignStackIndexIfNeeded(cd->m_propertyNameIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
+            }
+            case SuperGetObjectOperationOpcode: {
+                SuperSetObjectOperation* cd = (SuperSetObjectOperation*)currentCode;
+                assignStackIndexIfNeeded(cd->m_objectRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
+                assignStackIndexIfNeeded(cd->m_loadRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
+                assignStackIndexIfNeeded(cd->m_propertyNameIndex, stackBase, stackBaseWillBe, stackVariableSize);
             }
             case CallSuperOpcode: {
                 CallSuper* cd = (CallSuper*)currentCode;

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -41,6 +41,7 @@ class CreateFunction;
 class CreateClass;
 class SuperReference;
 class SuperSetObjectOperation;
+class SuperGetObjectOperation;
 class CallSuper;
 class WithOperation;
 class BlockOperation;
@@ -109,6 +110,7 @@ public:
     static void classOperation(ExecutionState& state, CreateClass* code, Value* registerFile);
     static void superOperation(ExecutionState& state, SuperReference* code, Value* registerFile);
     static void superSetObjectOperation(ExecutionState& state, SuperSetObjectOperation* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
+    static Value superGetObjectOperation(ExecutionState& state, SuperGetObjectOperation* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void callSuperOperation(ExecutionState& state, CallSuper* code, Value* registerFile);
     static Value withOperation(ExecutionState*& state, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
     static Value blockOperation(ExecutionState*& state, BlockOperation* code, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);


### PR DESCRIPTION
* Also use SuperSetObjectOperation for super node when not a precomputed case in generateStoreByteCode in MemberExpressionNode
* Update vendor test submodule

Signed-off-by: Boram Bae <boram21.bae@samsung.com>