### PR TITLE
Fix bugs & Implement missed ES6 features

### DIFF
--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -86,7 +86,6 @@ struct ByteCodeGenerateContext {
         , m_isLeftBindingAffectedByRightExpression(false)
         , m_registerStack(new std::vector<ByteCodeRegisterIndex>())
         , m_lexicallyDeclaredNames(new std::vector<std::pair<size_t, AtomicString>>())
-        , m_offsetToBasePointer(0)
         , m_positionToContinue(0)
         , m_complexJumpBreakIgnoreCount(0)
         , m_complexJumpContinueIgnoreCount(0)
@@ -121,7 +120,6 @@ struct ByteCodeGenerateContext {
         , m_isLeftBindingAffectedByRightExpression(contextBefore.m_isLeftBindingAffectedByRightExpression)
         , m_registerStack(contextBefore.m_registerStack)
         , m_lexicallyDeclaredNames(contextBefore.m_lexicallyDeclaredNames)
-        , m_offsetToBasePointer(contextBefore.m_offsetToBasePointer)
         , m_positionToContinue(contextBefore.m_positionToContinue)
         , m_recursiveStatementStack(contextBefore.m_recursiveStatementStack)
         , m_complexJumpBreakIgnoreCount(contextBefore.m_complexJumpBreakIgnoreCount)
@@ -149,7 +147,6 @@ struct ByteCodeGenerateContext {
         ctx.m_labeledContinueStatmentPositions.insert(ctx.m_labeledContinueStatmentPositions.end(), m_labeledContinueStatmentPositions.begin(), m_labeledContinueStatmentPositions.end());
         ctx.m_complexCaseStatementPositions.insert(m_complexCaseStatementPositions.begin(), m_complexCaseStatementPositions.end());
         ctx.m_getObjectCodePositions.insert(ctx.m_getObjectCodePositions.end(), m_getObjectCodePositions.begin(), m_getObjectCodePositions.end());
-        ctx.m_offsetToBasePointer = m_offsetToBasePointer;
         ctx.m_positionToContinue = m_positionToContinue;
         ctx.m_lexicalBlockIndex = m_lexicalBlockIndex;
         ctx.m_classInfo = m_classInfo;
@@ -327,14 +324,13 @@ struct ByteCodeGenerateContext {
     std::vector<std::pair<String*, size_t>> m_labeledBreakStatmentPositions;
     std::vector<std::pair<String*, size_t>> m_labeledContinueStatmentPositions;
     std::vector<size_t> m_getObjectCodePositions;
-    // For For In Statement
-    size_t m_offsetToBasePointer;
     // For Label Statement
     size_t m_positionToContinue;
     // code position, special Statement count
     enum RecursiveStatementKind : size_t {
         Try,
         Catch,
+        Finally,
         With,
         Block
     };

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -65,6 +65,9 @@ class UnaryTypeof;
 class GetObject;
 class SetObjectOperation;
 class CheckIfKeyIsLast;
+class GetIterator;
+class IteratorStep;
+class IteratorClose;
 
 class ByteCodeInterpreter {
 public:
@@ -102,7 +105,7 @@ public:
     static void setGlobalVariableSlowCase(ExecutionState& state, Object* go, GlobalVariableAccessCacheItem* slot, const Value& value, ByteCodeBlock* block);
     static void initializeGlobalVariable(ExecutionState& state, InitializeGlobalVariable* code, const Value& value);
 
-    static size_t tryOperation(ExecutionState*& state, size_t programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
+    static Value tryOperation(ExecutionState*& state, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
 
     static void createFunctionOperation(ExecutionState& state, CreateFunction* createFunction, ByteCodeBlock* byteCodeBlock, Value* registerFile);
     static ArrayObject* createRestElementOperation(ExecutionState& state, ByteCodeBlock* byteCodeBlock);
@@ -141,6 +144,9 @@ public:
     static void unaryTypeof(ExecutionState& state, UnaryTypeof* code, Value* registerFile);
 
     static void checkIfKeyIsLast(ExecutionState& state, CheckIfKeyIsLast* code, char* codeBuffer, size_t& programCounter, Value* registerFile);
+    static void getIteratorOperation(ExecutionState& state, GetIterator* code, Value* registerFile);
+    static void iteratorStepOperation(ExecutionState& state, size_t& programCounter, Value* registerFile, char* codeBuffer);
+    static void iteratorCloseOperation(ExecutionState& state, IteratorClose* code, Value* registerFile);
 
     static void ensureArgumentsObjectOperation(ExecutionState& state, ByteCodeBlock* byteCodeBlock, Value* registerFile);
 };

--- a/src/parser/ast/ClassDeclarationNode.h
+++ b/src/parser/ast/ClassDeclarationNode.h
@@ -63,7 +63,7 @@ public:
         if (m_class.classBody()->hasConstructor()) {
             m_class.classBody()->constructor()->generateExpressionByteCode(codeBlock, context, classIndex);
         } else {
-            codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), classIndex, context->m_classInfo.m_prototypeIndex, context->m_classInfo.m_superIndex, context->m_classInfo.m_name, nullptr), context, this);
+            codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), classIndex, context->m_classInfo.m_prototypeIndex, context->m_classInfo.m_superIndex, nullptr), context, this);
         }
 
         m_class.classBody()->generateClassInitializer(codeBlock, context, classIndex);

--- a/src/parser/ast/ClassNode.h
+++ b/src/parser/ast/ClassNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 
 class ClassNode {
 public:
-    ClassNode(RefPtr<IdentifierNode>& id, RefPtr<Node> superClass, RefPtr<ClassBodyNode> classBody, LexicalBlockIndex classBodyLexicalBlockIndex)
+    ClassNode(RefPtr<IdentifierNode> id, RefPtr<Node> superClass, RefPtr<ClassBodyNode> classBody, LexicalBlockIndex classBodyLexicalBlockIndex)
         : m_classBodyLexicalBlockIndex(classBodyLexicalBlockIndex)
         , m_id(id)
         , m_superClass(superClass)
@@ -35,11 +35,10 @@ public:
     {
     }
 
-    virtual ASTNodeType type() { return ASTNodeType::Class; }
-    inline const RefPtr<IdentifierNode>& id() { return m_id; }
-    inline const RefPtr<Node> superClass() { return m_superClass; }
-    inline const RefPtr<ClassBodyNode> classBody() { return m_classBody; }
-    inline LexicalBlockIndex classBodyLexicalBlockIndex() { return m_classBodyLexicalBlockIndex; }
+    inline const RefPtr<IdentifierNode>& id() const { return m_id; }
+    inline const RefPtr<Node>& superClass() const { return m_superClass; }
+    inline const RefPtr<ClassBodyNode>& classBody() const { return m_classBody; }
+    inline LexicalBlockIndex classBodyLexicalBlockIndex() const { return m_classBodyLexicalBlockIndex; }
 private:
     LexicalBlockIndex m_classBodyLexicalBlockIndex;
     RefPtr<IdentifierNode> m_id; // Id

--- a/src/parser/ast/FunctionExpressionNode.h
+++ b/src/parser/ast/FunctionExpressionNode.h
@@ -38,7 +38,7 @@ public:
     {
         CodeBlock* blk = context->m_codeBlock->asInterpretedCodeBlock()->childBlocks()[m_subCodeBlockIndex];
         if (UNLIKELY(blk->isClassConstructor())) {
-            codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), dstIndex, context->m_classInfo.m_prototypeIndex, context->m_classInfo.m_superIndex, context->m_classInfo.m_name, blk), context, this);
+            codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), dstIndex, context->m_classInfo.m_prototypeIndex, context->m_classInfo.m_superIndex, blk), context, this);
         } else if (UNLIKELY(blk->isClassMethod() || blk->isClassStaticMethod())) {
             size_t homeObjectIndex = blk->isClassStaticMethod() ? context->m_classInfo.m_constructorIndex : context->m_classInfo.m_prototypeIndex;
             codeBlock->pushCode(CreateFunction(ByteCodeLOC(m_loc.index), dstIndex, homeObjectIndex, blk), context, this);

--- a/src/parser/ast/ProgramNode.h
+++ b/src/parser/ast/ProgramNode.h
@@ -52,7 +52,7 @@ public:
 
         codeBlock->finalizeLexicalBlock(context, blockContext);
 
-        codeBlock->pushCode(End(ByteCodeLOC(SIZE_MAX)), context, this);
+        codeBlock->pushCode(End(ByteCodeLOC(SIZE_MAX), 0), context, this);
     }
 
     virtual void iterateChildren(const std::function<void(Node* node)>& fn) override

--- a/src/parser/ast/YieldExpressionNode.h
+++ b/src/parser/ast/YieldExpressionNode.h
@@ -37,7 +37,7 @@ public:
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
         static_assert(sizeof(ByteCodeGenerateContext::RecursiveStatementKind) == sizeof(size_t), "");
-        size_t mostBigCode = std::max({ sizeof(WithOperation), sizeof(BlockOperation), (sizeof(TryOperation) + sizeof(TryCatchWithBlockBodyEnd) + sizeof(FinallyEnd)) });
+        size_t mostBigCode = std::max({ sizeof(WithOperation), sizeof(BlockOperation), (sizeof(TryOperation) + sizeof(TryCatchWithBlockBodyEnd) + sizeof(End)) });
         context->m_maxYieldStatementExtraDataLength = std::max(context->m_maxYieldStatementExtraDataLength,
                                                                (mostBigCode * context->m_recursiveStatementStack.size()) + sizeof(GeneratorResume) + sizeof(size_t) /* stack size */ + context->m_recursiveStatementStack.size() * sizeof(size_t) /* code start position data size */
                                                                );
@@ -45,6 +45,7 @@ public:
 
         if (m_argument == nullptr) {
             codeBlock->pushCode(Yield(ByteCodeLOC(m_loc.index), REGISTER_LIMIT, dstRegister, tailDataLength), context, this);
+            pushExtraData(codeBlock, context);
         } else {
             size_t argIdx = m_argument->getRegister(codeBlock, context);
             m_argument->generateExpressionByteCode(codeBlock, context, argIdx);
@@ -58,6 +59,8 @@ public:
                 codeBlock->pushCode(YieldDelegate(ByteCodeLOC(m_loc.index), iteratorIdx, valueIdx, dstRegister, tailDataLength), context, this);
                 size_t iterStepPos = codeBlock->lastCodePosition<YieldDelegate>();
 
+                pushExtraData(codeBlock, context);
+
                 context->giveUpRegister(); // for drop valueIdx
 
                 codeBlock->pushCode(Jump(ByteCodeLOC(m_loc.index), loopStart), context, this);
@@ -65,11 +68,15 @@ public:
                 context->giveUpRegister(); // for drop iteratorIdx
             } else {
                 codeBlock->pushCode(Yield(ByteCodeLOC(m_loc.index), argIdx, dstRegister, tailDataLength), context, this);
+                pushExtraData(codeBlock, context);
             }
 
             context->giveUpRegister(); // for drop argIdx
         }
+    }
 
+    void pushExtraData(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context)
+    {
         auto iter = context->m_recursiveStatementStack.begin();
         while (iter != context->m_recursiveStatementStack.end()) {
             size_t pos = codeBlock->m_code.size();

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -4312,6 +4312,10 @@ public:
                     lastPoppedScopeContext->m_hasImplictFunctionName = true;
                 }
             }
+
+            if (isParse && initNode->type() == ASTNodeType::ClassExpression && !((ClassExpressionNode*)initNode.get())->classNode().id()) {
+                ((ClassExpressionNode*)initNode.get())->setImplictName(name);
+            }
         } else if (!isIdentifier && !options.inFor) {
             this->expect(Substitution);
         }
@@ -5533,6 +5537,12 @@ public:
             }
             referNode = body->appendChild(this->statementListItem<ParseAs(StatementNode)>().get(), referNode);
         }
+
+        bool isEndedWithReturnNode = referNode && referNode->type() == ASTNodeType::ReturnStatement;
+        if (!isEndedWithReturnNode) {
+            referNode = body->appendChild(adoptRef(new ReturnStatmentNode(nullptr)));
+        }
+
         this->expect(RightBrace);
 
         return this->finalize(nodeStart, new BlockStatementNode(body.get(), 0));

--- a/src/runtime/ExecutionState.cpp
+++ b/src/runtime/ExecutionState.cpp
@@ -106,7 +106,7 @@ Value ExecutionState::makeSuperPropertyReference()
 
     // If env.HasSuperBinding() is false, throw a ReferenceError exception.
     if (!env->hasSuperBinding()) {
-        ErrorObject::throwBuiltinError(*this, ErrorObject::Code::TypeError, errorMessage_No_Super_Binding);
+        ErrorObject::throwBuiltinError(*this, ErrorObject::Code::ReferenceError, errorMessage_No_Super_Binding);
     }
 
     // Let actualThis be env.GetThisBinding().

--- a/src/runtime/IteratorOperations.cpp
+++ b/src/runtime/IteratorOperations.cpp
@@ -125,7 +125,7 @@ Value iteratorClose(ExecutionState& state, const Value& iterator, const Value& c
     }
     // If Type(innerResult.[[value]]) is not Object, throw a TypeError exception.
     if (!innerResult.isObject()) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "result is not an object");
+        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "Iterator close result is not an object");
     }
     // Return Completion(completion).
     return completionValue;

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -155,20 +155,6 @@
   <test id="S11.4.4_A6_T3"><reason>ALLOW_FAIL</reason></test>
   <test id="S11.4.5_A6_T3"><reason>ALLOW_FAIL</reason></test>
 
-  <test id="basics"><reason>TODO</reason></test>
-  <test id="body-dstr-assign-error"><reason>TODO</reason></test>
-  <test id="body-put-error"><reason>TODO</reason></test>
-  <test id="generator-close-via-break"><reason>TODO</reason></test>
-  <test id="generator-close-via-return"><reason>TODO</reason></test>
-  <test id="generator-close-via-throw"><reason>TODO</reason></test>
-  <test id="head-expr-to-obj"><reason>TODO</reason></test>
-  <test id="iterator-close-get-method-error"><reason>TODO</reason></test>
-  <test id="iterator-close-non-object"><reason>TODO</reason></test>
-  <test id="iterator-close-via-break"><reason>TODO</reason></test>
-  <test id="iterator-close-via-return"><reason>TODO</reason></test>
-  <test id="iterator-close-via-throw"><reason>TODO</reason></test>
-  <test id="yield-star-from-catch"><reason>TODO</reason></test>
-  <test id="yield-star-from-try"><reason>TODO</reason></test>
   <test id="let-closure-inside-condition"><reason>TODO</reason></test>
   <test id="let-closure-inside-initialization"><reason>TODO</reason></test>
   <test id="let-closure-inside-next-expression"><reason>TODO</reason></test>


### PR DESCRIPTION
* Reimplement finally block in try-statement.
* Replace `ReturnFunction`, `ReturnFunctionWithValue` bytecode with `End`.
* When for-of loop is exited by exception or break, we need to close iterator
* Don't add Return Statement in ByteCodeGenerator. We should add Return Statement in ScriptParser.
* Fix bug in yield expression.
* Implement add implicit class name on class expression.

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>