### PR TITLE
Add Proxy object support for several builtin operations

### DIFF
--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -53,6 +53,11 @@ public:
         return true;
     }
 
+    virtual bool isArray(ExecutionState& state) const override
+    {
+        return true;
+    }
+
     virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;

--- a/src/runtime/GlobalObjectBuiltinArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinArray.cpp
@@ -88,7 +88,7 @@ static Object* arraySpeciesCreate(ExecutionState& state, Object* originalArray, 
     Value C;
     // Let isArray be IsArray(originalArray).
     // If isArray is true, then
-    if (originalArray->isArrayObject()) {
+    if (originalArray->isArray(state)) {
         // Let C be Get(originalArray, "constructor").
         C = originalArrayConstructor;
 
@@ -117,12 +117,8 @@ static Object* arraySpeciesCreate(ExecutionState& state, Object* originalArray, 
 static Value builtinArrayIsArray(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
     ASSERT(argv != nullptr);
-    if (!argv[0].isObject())
-        return Value(false);
-    if (argv[0].asObject()->isArrayObject())
-        return Value(true);
-    else
-        return Value(false);
+
+    return Value(argv[0].isObject() && argv[0].asObject()->isArray(state));
 }
 
 // Array.from ( items [ , mapfn [ , thisArg ] ] )#

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -217,6 +217,8 @@ private:
     PropertyName toPropertyNameUintCase(ExecutionState& state) const;
 };
 
+typedef std::vector<ObjectPropertyName, GCUtil::gc_malloc_allocator<ObjectPropertyName>> ObjectPropertyNameVector;
+
 class JSGetterSetter : public PointerValue {
     friend class ObjectPropertyDescriptor;
     friend class Object;
@@ -723,6 +725,12 @@ public:
     virtual bool isExtensible(ExecutionState&)
     {
         return rareData() == nullptr ? true : rareData()->m_isExtensible;
+    }
+
+    // http://www.ecma-international.org/ecma-262/6.0/index.html#is-array
+    virtual bool isArray(ExecutionState& state) const
+    {
+        return false;
     }
 
     // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions

--- a/src/runtime/ProxyObject.h
+++ b/src/runtime/ProxyObject.h
@@ -108,6 +108,7 @@ public:
     virtual Value getPrototype(ExecutionState&) override;
     virtual Object* getPrototypeObject(ExecutionState&) override;
 
+    virtual bool isArray(ExecutionState&) const override;
     virtual bool isExtensible(ExecutionState&) override;
 
     virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) override;

--- a/tools/test/v8/v8.mjsunit.status
+++ b/tools/test/v8/v8.mjsunit.status
@@ -746,24 +746,17 @@
   'es6/proxies-global-reference' : [SKIP],
   'es6/proxies-integrity' : [SKIP],
   'es6/proxies' : [SKIP],
-  'es6/proxies-json' : [SKIP],
-  'es6/proxies-keys' : [SKIP],
-  'es6/proxies-object-assign' : [SKIP],
-  'es6/proxies-ownkeys' : [SKIP],
   'es6/proxies-prototype-handler-stackoverflow' : [SKIP],
   'es6/proxies-prototype-target-stackoverflow' : [SKIP],
   'es6/proxies-revocable' : [SKIP],
   'es6/proxies-set' : [SKIP],
-  'es6/proxies-set-prototype-of' : [SKIP],
   'es6/proxies-with' : [SKIP],
   'es6/proxies-with-unscopables' : [SKIP],
   'es6/reflect-construct' : [SKIP],
   'es6/reflect-define-property' : [SKIP],
   'es6/reflect-get-prototype-of' : [SKIP],
   'es6/reflect' : [SKIP],
-  'es6/reflect-own-keys' : [SKIP],
   'es6/reflect-prevent-extensions' : [SKIP],
-  'es6/reflect-set-prototype-of' : [SKIP],
   'es6/regexp-constructor' : [SKIP],
   'es6/regexp-sticky' : [SKIP],
   'es6/regexp-tolength' : [SKIP],
@@ -834,7 +827,6 @@
   'regress/regress-crbug-669540': [SKIP],
   # array
   'array-indexing': [SKIP],
-  'array-isarray': [SKIP], #Proxy
   'array-join': [SKIP], #Proxy
   'array-length': [SKIP], #arrow function
   # const


### PR DESCRIPTION
Related methods:
 - Array.isArray
 - JSON.stringify
 - JSON.parse
 - Object.prototype.toString

Also fixed some errors in the Promise builtin rotuines to enable more tests.

Signed-off-by: Robert Fancsik <frobert@inf.u-szeged.hu>