### PR TITLE
Revise parser: specify parser/scanner with two ASTBuilders

### DIFF
--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -1,0 +1,669 @@
+/*
+ * Copyright (c) 2019-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#ifndef __EscargotASTBuilder__
+#define __EscargotASTBuilder__
+
+namespace Escargot {
+
+#define FOR_EACH_TARGET_NODE(F)               \
+    F(FunctionExpression)                     \
+    F(ArrowFunctionExpression)                \
+    F(ArrowParameterPlaceHolder)              \
+    F(FunctionDeclaration)                    \
+    F(Property)                               \
+    F(Empty)                                  \
+    F(EmptyStatement)                         \
+    F(BlockStatement)                         \
+    F(BreakStatement)                         \
+    F(BreakLabelStatement)                    \
+    F(ContinueStatement)                      \
+    F(ContinueLabelStatement)                 \
+    F(ReturnStatement)                        \
+    F(IfStatement)                            \
+    F(ForStatement)                           \
+    F(WhileStatement)                         \
+    F(DoWhileStatement)                       \
+    F(SpreadElement)                          \
+    F(RestElement)                            \
+    F(SwitchStatement)                        \
+    F(SwitchCase)                             \
+    F(WithStatement)                          \
+    F(ThisExpression)                         \
+    F(ExpressionStatement)                    \
+    F(UnaryExpressionBitwiseNot)              \
+    F(UnaryExpressionDelete)                  \
+    F(UnaryExpressionLogicalNot)              \
+    F(UnaryExpressionMinus)                   \
+    F(UnaryExpressionPlus)                    \
+    F(UnaryExpressionTypeOf)                  \
+    F(UnaryExpressionVoid)                    \
+    F(AssignmentExpressionBitwiseAnd)         \
+    F(AssignmentExpressionBitwiseOr)          \
+    F(AssignmentExpressionBitwiseXor)         \
+    F(AssignmentExpressionDivision)           \
+    F(AssignmentExpressionLeftShift)          \
+    F(AssignmentExpressionMinus)              \
+    F(AssignmentExpressionMod)                \
+    F(AssignmentExpressionMultiply)           \
+    F(AssignmentExpressionPlus)               \
+    F(AssignmentExpressionSignedRightShift)   \
+    F(AssignmentExpressionUnsignedRightShift) \
+    F(AssignmentExpressionSimple)             \
+    F(BinaryExpressionBitwiseAnd)             \
+    F(BinaryExpressionBitwiseOr)              \
+    F(BinaryExpressionBitwiseXor)             \
+    F(BinaryExpressionDivision)               \
+    F(BinaryExpressionEqual)                  \
+    F(BinaryExpressionNotEqual)               \
+    F(BinaryExpressionStrictEqual)            \
+    F(BinaryExpressionNotStrictEqual)         \
+    F(BinaryExpressionGreaterThan)            \
+    F(BinaryExpressionGreaterThanOrEqual)     \
+    F(BinaryExpressionLessThan)               \
+    F(BinaryExpressionLessThanOrEqual)        \
+    F(BinaryExpressionIn)                     \
+    F(BinaryExpressionInstanceOf)             \
+    F(BinaryExpressionLeftShift)              \
+    F(BinaryExpressionLogicalAnd)             \
+    F(BinaryExpressionLogicalOr)              \
+    F(BinaryExpressionMinus)                  \
+    F(BinaryExpressionMod)                    \
+    F(BinaryExpressionMultiply)               \
+    F(BinaryExpressionPlus)                   \
+    F(BinaryExpressionSignedRightShift)       \
+    F(BinaryExpressionUnsignedRightShift)     \
+    F(UpdateExpressionDecrementPostfix)       \
+    F(UpdateExpressionDecrementPrefix)        \
+    F(UpdateExpressionIncrementPostfix)       \
+    F(UpdateExpressionIncrementPrefix)        \
+    F(MemberExpression)                       \
+    F(MetaProperty)                           \
+    F(YieldExpression)                        \
+    F(ConditionalExpression)                  \
+    F(VariableDeclarator)                     \
+    F(InitializeParameterExpression)          \
+    F(LabeledStatement)                       \
+    F(Literal)                                \
+    F(TaggedTemplateExpression)               \
+    F(Directive)                              \
+    F(RegExpLiteral)                          \
+    F(CatchClause)                            \
+    F(TryStatement)                           \
+    F(ThrowStatement)                         \
+    F(ClassElement)                           \
+    F(SuperExpression)                        \
+    F(AssignmentPattern)                      \
+    F(RegisterReference)                      \
+    F(ExportDefaultDeclaration)               \
+    F(ExportAllDeclaration)                   \
+    F(ImportNamespaceSpecifier)               \
+    F(ImportDefaultSpecifier)                 \
+    F(ImportSpecifier)                        \
+    F(ExportSpecifier)                        \
+    F(DebuggerStatement)
+
+class SyntaxNode {
+public:
+    MAKE_STACK_ALLOCATED();
+
+    SyntaxNode()
+        : m_nodeType(ASTNodeTypeError)
+        , m_string(AtomicString())
+    {
+    }
+
+    SyntaxNode(ASTNodeType nodeType)
+        : m_nodeType(nodeType)
+        , m_string(AtomicString())
+    {
+    }
+
+    SyntaxNode(ASTNodeType nodeType, const AtomicString& string)
+        : m_nodeType(nodeType)
+        , m_string(string)
+    {
+        ASSERT(m_nodeType == Identifier);
+    }
+
+    SyntaxNode(std::nullptr_t ptr)
+        : m_nodeType(ASTNodeTypeError)
+        , m_string(AtomicString())
+    {
+    }
+
+    SyntaxNode(SyntaxNode* node)
+        : m_nodeType(node->m_nodeType)
+        , m_string(node->m_string)
+    {
+        ASSERT(node != nullptr);
+    }
+
+    ASTNodeType type() { return m_nodeType; }
+    AtomicString& name()
+    {
+        ASSERT(m_nodeType == Identifier);
+        return m_string;
+    }
+
+    void setNodeType(ASTNodeType type)
+    {
+        m_nodeType = type;
+    }
+
+    ALWAYS_INLINE bool isAssignmentOperation()
+    {
+        return m_nodeType >= ASTNodeType::AssignmentExpression && m_nodeType <= ASTNodeType::AssignmentExpressionSimple;
+    }
+
+    ALWAYS_INLINE bool isIdentifier()
+    {
+        return m_nodeType == ASTNodeType::Identifier;
+    }
+
+    ALWAYS_INLINE bool isLiteral()
+    {
+        return m_nodeType == ASTNodeType::Literal;
+    }
+
+    ALWAYS_INLINE SyntaxNode* asIdentifier()
+    {
+        ASSERT(m_nodeType == Identifier);
+        return this;
+    }
+
+    ALWAYS_INLINE SyntaxNode* asClassExpression()
+    {
+        ASSERT(m_nodeType == ClassExpression);
+        return this;
+    }
+
+    ALWAYS_INLINE SyntaxNode* asClassDeclaration()
+    {
+        ASSERT(m_nodeType == ClassDeclaration);
+        return this;
+    }
+
+    ALWAYS_INLINE SyntaxNode* asSequenceExpression()
+    {
+        ASSERT(m_nodeType == SequenceExpression);
+        return this;
+    }
+
+    ALWAYS_INLINE SyntaxNode* asFunctionDeclaration()
+    {
+        ASSERT(m_nodeType == FunctionDeclaration);
+        return this;
+    }
+
+    ALWAYS_INLINE SyntaxNode* asLiteral()
+    {
+        ASSERT(m_nodeType == Literal);
+        return this;
+    }
+
+    ALWAYS_INLINE SyntaxNode* asImportSpecifier()
+    {
+        ASSERT(m_nodeType == ImportSpecifier);
+        return this;
+    }
+
+    ALWAYS_INLINE SyntaxNode* asExportSpecifier()
+    {
+        ASSERT(m_nodeType == ExportSpecifier);
+        return this;
+    }
+
+    ALWAYS_INLINE SyntaxNode* appendChild(SyntaxNode* c)
+    {
+        ASSERT(m_nodeType == ASTStatementContainer);
+        return nullptr;
+    }
+
+    ALWAYS_INLINE SyntaxNode* appendChild(SyntaxNode* c, SyntaxNode* referNode)
+    {
+        ASSERT(m_nodeType == ASTStatementContainer);
+        return nullptr;
+    }
+
+    void tryToSetImplicitName(AtomicString s)
+    {
+        // dummy function for tryToSetImplicitName() of ClassExpressionNode
+        ASSERT(m_nodeType == ClassExpression);
+        return;
+    }
+
+    std::vector<SyntaxNode>& expressions()
+    {
+        // dummy function for expressions() of SequenceExpressionNode
+        // this function should never be invocked
+        RELEASE_ASSERT_NOT_REACHED();
+        std::vector<SyntaxNode>* tempVector = new std::vector<SyntaxNode>();
+        return *tempVector;
+    }
+
+    ASTFunctionScopeContext* scopeContext()
+    {
+        // dummy function for scopeContext() of FunctionDeclarationNode
+        // this function should never be invocked
+        RELEASE_ASSERT_NOT_REACHED();
+        return new ASTFunctionScopeContext();
+    }
+
+    ClassNode& classNode()
+    {
+        // dummy function for classNode() of ClassDeclarationNode
+        // this function should never be invocked
+        RELEASE_ASSERT_NOT_REACHED();
+        ClassNode* tempClassNode = new ClassNode();
+        return *tempClassNode;
+    }
+
+    Value value()
+    {
+        // dummy function for value() of LiteralNode
+        // this function should never be invocked
+        RELEASE_ASSERT_NOT_REACHED();
+        return Value();
+    }
+
+    IdentifierNode* imported()
+    {
+        // dummy function for imported() of ImportSpecifierNode
+        // this function should never be invocked
+        RELEASE_ASSERT_NOT_REACHED();
+        return new IdentifierNode();
+    }
+
+    IdentifierNode* exported()
+    {
+        // dummy function for imported() of ExportSpecifierNode
+        // this function should never be invocked
+        RELEASE_ASSERT_NOT_REACHED();
+        return new IdentifierNode();
+    }
+
+    IdentifierNode* local()
+    {
+        // dummy function for local() of Import/ExportSpecifierNode
+        // this function should never be invocked
+        RELEASE_ASSERT_NOT_REACHED();
+        return new IdentifierNode();
+    }
+
+    ALWAYS_INLINE operator bool()
+    {
+        return m_nodeType != ASTNodeTypeError;
+    }
+
+    ALWAYS_INLINE SyntaxNode* operator->() { return this; }
+    ALWAYS_INLINE SyntaxNode* get() { return this; }
+    ALWAYS_INLINE SyntaxNode release() { return *this; }
+private:
+    ASTNodeType m_nodeType;
+    AtomicString m_string;
+};
+
+class SyntaxChecker {
+public:
+    MAKE_STACK_ALLOCATED();
+
+    SyntaxChecker() {}
+    typedef SyntaxNode ASTNode;
+    typedef SyntaxNode ASTPassNode;
+    typedef SyntaxNode ASTNodePtr;
+    typedef SyntaxNode ASTIdentifierNode;
+    typedef SyntaxNode ASTStatementContainer;
+    typedef SyntaxNode* ASTStatementNodePtr;
+    typedef std::vector<SyntaxNode> ASTNodeVector;
+
+    bool isNodeGenerator() { return false; }
+    SyntaxNode createIdentifierNode(const AtomicString& name)
+    {
+        return SyntaxNode(ASTNodeType::Identifier, name);
+    }
+
+    template <class ClassType>
+    SyntaxNode createClass(SyntaxNode id, SyntaxNode superClass, SyntaxNode classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
+    {
+        ClassType* tempClass = new ClassType();
+        tempClass->relaxAdoptionRequirement();
+        ASTNodeType type = tempClass->type();
+        tempClass->deref();
+        return SyntaxNode(type);
+    }
+
+    SyntaxNode createForInOfStatementNode(SyntaxNode* left, SyntaxNode* right, SyntaxNode* body, bool forIn, bool hasLexicalDeclarationOnInit, LexicalBlockIndex headLexicalBlockIndex, LexicalBlockIndex iterationLexicalBlockIndex)
+    {
+        if (forIn) {
+            return SyntaxNode(ASTNodeType::ForInStatement);
+        } else {
+            return SyntaxNode(ASTNodeType::ForOfStatement);
+        }
+    }
+
+    ALWAYS_INLINE SyntaxNode createSequenceExpressionNode(ASTNodeVector&& expressions)
+    {
+        return SyntaxNode(ASTNodeType::SequenceExpression);
+    }
+
+    ALWAYS_INLINE SyntaxNode createVariableDeclarationNode(ASTNodeVector&& decl, EscargotLexer::KeywordKind kind)
+    {
+        return SyntaxNode(ASTNodeType::VariableDeclaration);
+    }
+
+    ALWAYS_INLINE SyntaxNode createArrayPatternNode(ASTNodeVector&& elements)
+    {
+        return SyntaxNode(ASTNodeType::ArrayPattern);
+    }
+
+    ALWAYS_INLINE SyntaxNode createObjectPatternNode(ASTNodeVector&& properties)
+    {
+        return SyntaxNode(ASTNodeType::ObjectPattern);
+    }
+
+    ALWAYS_INLINE SyntaxNode createCallExpressionNode(SyntaxNode* callee, ASTNodeVector&& arguments)
+    {
+        return SyntaxNode(ASTNodeType::CallExpression);
+    }
+
+    ALWAYS_INLINE SyntaxNode createClassBodyNode(ASTNodeVector&& elementList, ASTNode constructor)
+    {
+        return SyntaxNode(ASTNodeType::ClassBody);
+    }
+
+    ALWAYS_INLINE SyntaxNode createNewExpressionNode(SyntaxNode* callee, ASTNodeVector&& arguments)
+    {
+        return SyntaxNode(ASTNodeType::NewExpression);
+    }
+
+    ALWAYS_INLINE SyntaxNode createTemplateLiteralNode(TemplateElementVector* vector, ASTNodeVector&& expressions)
+    {
+        return SyntaxNode(ASTNodeType::TemplateLiteral);
+    }
+
+    ALWAYS_INLINE SyntaxNode createArrowParameterPlaceHolderNode(ASTNodeVector&& params)
+    {
+        return SyntaxNode(ASTNodeType::ArrowParameterPlaceHolder);
+    }
+
+    ALWAYS_INLINE SyntaxNode createArrayExpressionNode(ASTNodeVector&& elements, AtomicString additionalPropertyName, SyntaxNode* additionalPropertyExpression, bool hasSpreadElement, bool isTaggedTemplateExpression)
+    {
+        return SyntaxNode(ASTNodeType::ArrayExpression);
+    }
+
+    ALWAYS_INLINE SyntaxNode createObjectExpressionNode(ASTNodeVector&& properties)
+    {
+        return SyntaxNode(ASTNodeType::ObjectExpression);
+    }
+
+    ALWAYS_INLINE SyntaxNode createExportNamedDeclarationNode(ASTNode declaration, ASTNodeVector&& specifiers, ASTNode source)
+    {
+        return SyntaxNode(ASTNodeType::ExportNamedDeclaration);
+    }
+
+    ALWAYS_INLINE SyntaxNode createImportDeclarationNode(ASTNodeVector&& specifiers, ASTNode src)
+    {
+        return SyntaxNode(ASTNodeType::ImportDeclaration);
+    }
+
+    ALWAYS_INLINE SyntaxNode createStatementContainer()
+    {
+        return SyntaxNode(ASTNodeType::ASTStatementContainer);
+    }
+
+#define DECLARE_CREATE_FUNCTION(name)                         \
+    template <typename... Args>                               \
+    ALWAYS_INLINE SyntaxNode create##name##Node(Args... args) \
+    {                                                         \
+        return SyntaxNode(name);                              \
+    }
+    FOR_EACH_TARGET_NODE(DECLARE_CREATE_FUNCTION)
+#undef DECLARE_CREATE_FUNCTION
+
+    SyntaxNode reinterpretExpressionAsPattern(SyntaxNode* expr)
+    {
+        SyntaxNode result = *expr;
+        switch (expr->type()) {
+        case Identifier:
+        case MemberExpression:
+        case RestElement:
+        case AssignmentPattern:
+            break;
+        case SpreadElement:
+            result.setNodeType(ASTNodeType::RestElement);
+            break;
+        case ArrayExpression:
+            result.setNodeType(ASTNodeType::ArrayPattern);
+            break;
+        case ObjectExpression:
+            result.setNodeType(ASTNodeType::ObjectPattern);
+            break;
+        case AssignmentExpressionSimple:
+            result.setNodeType(ASTNodeType::AssignmentPattern);
+            break;
+        default:
+            break;
+        }
+
+        return result;
+    }
+
+    SyntaxNode convertTaggedTemplateExpressionToCallExpression(SyntaxNode taggedTemplateExpression, ASTFunctionScopeContext* scopeContext, AtomicString raw)
+    {
+        return SyntaxNode(CallExpression);
+    }
+};
+
+class NodeGenerator {
+public:
+    MAKE_STACK_ALLOCATED();
+
+    NodeGenerator() {}
+    typedef RefPtr<Node> ASTNode;
+    typedef PassRefPtr<Node> ASTPassNode;
+    typedef Node* ASTNodePtr;
+    typedef IdentifierNode* ASTIdentifierNode;
+    typedef RefPtr<StatementContainer> ASTStatementContainer;
+    typedef StatementNode* ASTStatementNodePtr;
+    typedef std::vector<RefPtr<Node>> ASTNodeVector;
+
+    bool isNodeGenerator() { return true; }
+    IdentifierNode* createIdentifierNode(const AtomicString& name)
+    {
+        return new IdentifierNode(name);
+    }
+
+    template <class ClassType>
+    ClassType* createClass(RefPtr<Node> id, RefPtr<Node> superClass, RefPtr<Node> classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
+    {
+        return new ClassType(id, superClass, classBody, classBodyLexicalBlockIndex, classSrc);
+    }
+
+    ForInOfStatementNode* createForInOfStatementNode(Node* left, Node* right, Node* body, bool forIn, bool hasLexicalDeclarationOnInit, LexicalBlockIndex headLexicalBlockIndex, LexicalBlockIndex iterationLexicalBlockIndex)
+    {
+        return new ForInOfStatementNode(left, right, body, forIn, hasLexicalDeclarationOnInit, headLexicalBlockIndex, iterationLexicalBlockIndex);
+    }
+
+    SequenceExpressionNode* createSequenceExpressionNode(ASTNodeVector&& expressions)
+    {
+        return new SequenceExpressionNode(std::forward<ASTNodeVector>(expressions));
+    }
+
+    VariableDeclarationNode* createVariableDeclarationNode(ASTNodeVector&& decl, EscargotLexer::KeywordKind kind)
+    {
+        return new VariableDeclarationNode(std::forward<ASTNodeVector>(decl), kind);
+    }
+
+    ArrayPatternNode* createArrayPatternNode(ASTNodeVector&& elements)
+    {
+        return new ArrayPatternNode(std::forward<ASTNodeVector>(elements));
+    }
+
+    ObjectPatternNode* createObjectPatternNode(ASTNodeVector&& properties)
+    {
+        return new ObjectPatternNode(std::forward<ASTNodeVector>(properties));
+    }
+
+    CallExpressionNode* createCallExpressionNode(Node* callee, ASTNodeVector&& arguments)
+    {
+        return new CallExpressionNode(callee, std::forward<ASTNodeVector>(arguments));
+    }
+
+    ClassBodyNode* createClassBodyNode(ASTNodeVector&& elementList, ASTNode constructor)
+    {
+        return new ClassBodyNode(std::forward<ASTNodeVector>(elementList), constructor);
+    }
+
+    NewExpressionNode* createNewExpressionNode(Node* callee, ASTNodeVector&& arguments)
+    {
+        return new NewExpressionNode(callee, std::forward<ASTNodeVector>(arguments));
+    }
+
+    TemplateLiteralNode* createTemplateLiteralNode(TemplateElementVector* vector, ASTNodeVector&& expressions)
+    {
+        return new TemplateLiteralNode(vector, std::forward<ASTNodeVector>(expressions));
+    }
+
+    ArrowParameterPlaceHolderNode* createArrowParameterPlaceHolderNode(ASTNodeVector&& params)
+    {
+        return new ArrowParameterPlaceHolderNode(std::forward<ASTNodeVector>(params));
+    }
+
+    ArrayExpressionNode* createArrayExpressionNode(ASTNodeVector&& elements, AtomicString additionalPropertyName, Node* additionalPropertyExpression, bool hasSpreadElement, bool isTaggedTemplateExpression)
+    {
+        return new ArrayExpressionNode(std::forward<ASTNodeVector>(elements), additionalPropertyName, additionalPropertyExpression, hasSpreadElement, isTaggedTemplateExpression);
+    }
+
+    ObjectExpressionNode* createObjectExpressionNode(ASTNodeVector&& properties)
+    {
+        return new ObjectExpressionNode(std::forward<ASTNodeVector>(properties));
+    }
+
+    ExportNamedDeclarationNode* createExportNamedDeclarationNode(RefPtr<Node> declaration, ASTNodeVector&& specifiers, RefPtr<Node> source)
+    {
+        return new ExportNamedDeclarationNode(declaration, std::forward<ASTNodeVector>(specifiers), source);
+    }
+
+    ImportDeclarationNode* createImportDeclarationNode(ASTNodeVector&& specifiers, RefPtr<Node> src)
+    {
+        return new ImportDeclarationNode(std::forward<ASTNodeVector>(specifiers), src);
+    }
+
+    RefPtr<StatementContainer> createStatementContainer()
+    {
+        return StatementContainer::create();
+    }
+
+#define DECLARE_CREATE_FUNCTION(name)                          \
+    template <typename... Args>                                \
+    ALWAYS_INLINE name##Node* create##name##Node(Args... args) \
+    {                                                          \
+        return new name##Node(args...);                        \
+    }
+    FOR_EACH_TARGET_NODE(DECLARE_CREATE_FUNCTION)
+#undef DECLARE_CREATE_FUNCTION
+
+    RefPtr<Node> reinterpretExpressionAsPattern(Node* expr)
+    {
+        RefPtr<Node> result = expr;
+        switch (expr->type()) {
+        case Identifier:
+        case MemberExpression:
+        case RestElement:
+        case AssignmentPattern:
+            break;
+        case SpreadElement: {
+            SpreadElementNode* spread = (SpreadElementNode*)expr;
+            RefPtr<Node> arg = this->reinterpretExpressionAsPattern(spread->argument());
+            result = adoptRef(new RestElementNode(arg.get(), spread->m_loc));
+            break;
+        }
+        case ArrayExpression: {
+            ArrayExpressionNode* array = expr->asArrayExpression();
+            ExpressionNodeVector& elements = array->elements();
+            for (size_t i = 0; i < elements.size(); i++) {
+                if (elements[i] != nullptr) {
+                    elements[i] = this->reinterpretExpressionAsPattern(elements[i].get());
+                }
+            }
+            result = adoptRef(new ArrayPatternNode(std::move(elements), array->m_loc));
+            break;
+        }
+        case ObjectExpression: {
+            ObjectExpressionNode* object = expr->asObjectExpression();
+            PropertiesNodeVector& properties = object->properties();
+            for (size_t i = 0; i < properties.size(); i++) {
+                ASSERT(properties[i]->type() == Property);
+                RefPtr<Node> value = this->reinterpretExpressionAsPattern(properties[i]->asProperty()->value());
+                properties[i]->asProperty()->setValue(value.get());
+            }
+            result = adoptRef(new ObjectPatternNode(std::move(properties), object->m_loc));
+            break;
+        }
+        case AssignmentExpressionSimple: {
+            AssignmentExpressionSimpleNode* assign = expr->asAssignmentExpressionSimple();
+            RefPtr<Node> left = this->reinterpretExpressionAsPattern(assign->left());
+            result = adoptRef(new AssignmentPatternNode(left.get(), assign->right(), assign->m_loc));
+            break;
+        }
+        default:
+            break;
+        }
+        return result;
+    }
+
+    // FIXME MetaNode
+    PassRefPtr<Node> convertTaggedTemplateExpressionToCallExpression(RefPtr<TaggedTemplateExpressionNode> taggedTemplateExpression, ASTFunctionScopeContext* scopeContext, AtomicString raw)
+    {
+        TemplateLiteralNode* templateLiteral = (TemplateLiteralNode*)taggedTemplateExpression->quasi();
+        ArgumentVector args;
+        ExpressionNodeVector elements;
+        for (size_t i = 0; i < templateLiteral->quasis()->size(); i++) {
+            UTF16StringData& sd = (*templateLiteral->quasis())[i]->value;
+            String* str = new UTF16String(std::move(sd));
+            elements.push_back(adoptRef(new LiteralNode(Value(str))));
+        }
+
+        RefPtr<ArrayExpressionNode> arrayExpressionForRaw;
+        {
+            ExpressionNodeVector elements;
+            for (size_t i = 0; i < templateLiteral->quasis()->size(); i++) {
+                UTF16StringData& sd = (*templateLiteral->quasis())[i]->valueRaw;
+                String* str = new UTF16String(std::move(sd));
+                elements.push_back(adoptRef(new LiteralNode(Value(str))));
+            }
+            arrayExpressionForRaw = adoptRef(new ArrayExpressionNode(std::move(elements)));
+        }
+
+        RefPtr<ArrayExpressionNode> quasiVector = adoptRef(new ArrayExpressionNode(std::move(elements), raw, arrayExpressionForRaw.get(), false, true));
+        args.push_back(quasiVector.get());
+        for (size_t i = 0; i < templateLiteral->expressions().size(); i++) {
+            args.push_back(templateLiteral->expressions()[i]);
+        }
+
+        if (taggedTemplateExpression->expr()->isIdentifier() && taggedTemplateExpression->expr()->asIdentifier()->name() == "eval") {
+            scopeContext->m_hasEval = true;
+        }
+        return adoptRef(new CallExpressionNode(taggedTemplateExpression->expr(), std::move(args)));
+    }
+};
+} // Escargot
+
+#endif

--- a/src/parser/ast/AST.h
+++ b/src/parser/ast/AST.h
@@ -108,7 +108,7 @@
 #include "RegExpLiteralNode.h"
 #include "RegisterReferenceNode.h"
 #include "RestElementNode.h"
-#include "ReturnStatmentNode.h"
+#include "ReturnStatementNode.h"
 #include "SequenceExpressionNode.h"
 #include "SpreadElementNode.h"
 #include "StatementNode.h"

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -59,9 +59,6 @@ public:
     ArrowFunctionExpressionNode(ASTFunctionScopeContext* scopeContext, size_t subCodeBlockIndex)
         : m_subCodeBlockIndex(subCodeBlockIndex - 1)
     {
-        scopeContext->m_isArrowFunctionExpression = true;
-        scopeContext->m_nodeType = this->type();
-        scopeContext->m_isGenerator = false;
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::ArrowFunctionExpression; }

--- a/src/parser/ast/AssignmentExpressionUnsignedRightShiftNode.h
+++ b/src/parser/ast/AssignmentExpressionUnsignedRightShiftNode.h
@@ -27,17 +27,17 @@
 namespace Escargot {
 
 // An assignment operator expression.
-class AssignmentExpressionUnsignedShiftNode : public ExpressionNode {
+class AssignmentExpressionUnsignedRightShiftNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    AssignmentExpressionUnsignedShiftNode(Node* left, Node* right)
+    AssignmentExpressionUnsignedRightShiftNode(Node* left, Node* right)
         : ExpressionNode()
         , m_left(left)
         , m_right(right)
     {
     }
 
-    virtual ~AssignmentExpressionUnsignedShiftNode()
+    virtual ~AssignmentExpressionUnsignedRightShiftNode()
     {
     }
 

--- a/src/parser/ast/BinaryExpressionDivisionNode.h
+++ b/src/parser/ast/BinaryExpressionDivisionNode.h
@@ -38,7 +38,7 @@ public:
     virtual ~BinaryExpressionDivisionNode()
     {
     }
-    virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionDivison; }
+    virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionDivision; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
         bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());

--- a/src/parser/ast/CallExpressionNode.h
+++ b/src/parser/ast/CallExpressionNode.h
@@ -169,7 +169,7 @@ public:
         }
 
         bool isCalleeHasReceiver = false;
-        bool isSuperCall = m_callee->isSuperNode() && ((SuperExpressionNode*)m_callee.get())->isCall();
+        bool isSuperCall = m_callee->isSuperExpression() && ((SuperExpressionNode*)m_callee.get())->isCall();
 
         if (m_callee->isMemberExpression()) {
             isCalleeHasReceiver = true;
@@ -187,7 +187,7 @@ public:
         if (isCalleeHasReceiver) {
             receiverIndex = context->getLastRegisterIndex();
             Node* object = ((MemberExpressionNode*)(m_callee.get()))->object();
-            if (object->isSuperNode()) {
+            if (object->isSuperExpression()) {
                 ThisExpressionNode* nd = new (alloca(sizeof(ThisExpressionNode))) ThisExpressionNode();
                 nd->generateExpressionByteCode(codeBlock, context, receiverIndex);
             }

--- a/src/parser/ast/CatchClauseNode.h
+++ b/src/parser/ast/CatchClauseNode.h
@@ -68,8 +68,6 @@ private:
     RefPtr<BlockStatementNode> m_body;
     LexicalBlockIndex m_paramLexicalBlockIndex;
 };
-
-typedef std::vector<RefPtr<Node>> CatchClauseNodeVector;
 }
 
 #endif

--- a/src/parser/ast/ClassBodyNode.h
+++ b/src/parser/ast/ClassBodyNode.h
@@ -27,12 +27,11 @@
 
 namespace Escargot {
 
-typedef std::vector<RefPtr<ClassElementNode>> ClassElementNodeVector;
 
 class ClassBodyNode : public Node {
 public:
     friend class ScriptParser;
-    ClassBodyNode(ClassElementNodeVector&& elementList, RefPtr<FunctionExpressionNode> constructor)
+    ClassBodyNode(ExpressionNodeVector&& elementList, RefPtr<Node> constructor)
         : Node()
         , m_elementList(elementList)
         , m_constructor(constructor)
@@ -54,7 +53,7 @@ public:
         size_t objIndex = context->m_classInfo.m_prototypeIndex;
 
         for (unsigned i = 0; i < m_elementList.size(); i++) {
-            ClassElementNode* p = m_elementList[i].get();
+            ClassElementNode* p = m_elementList[i]->asClassElement();
 
             size_t destIndex = p->isStatic() ? classIndex : objIndex;
 
@@ -128,14 +127,14 @@ public:
         }
 
         for (unsigned i = 0; i < m_elementList.size(); i++) {
-            ClassElementNode* p = m_elementList[i].get();
+            ClassElementNode* p = m_elementList[i]->asClassElement();
             p->iterateChildren(fn);
         }
     }
 
 private:
-    ClassElementNodeVector m_elementList;
-    RefPtr<FunctionExpressionNode> m_constructor;
+    ExpressionNodeVector m_elementList;
+    RefPtr<Node> m_constructor;
 };
 }
 

--- a/src/parser/ast/ClassElementNode.h
+++ b/src/parser/ast/ClassElementNode.h
@@ -70,7 +70,7 @@ public:
         return m_isStatic;
     }
 
-    virtual ASTNodeType type() override { return ASTNodeType::ClassBody; }
+    virtual ASTNodeType type() override { return ASTNodeType::ClassElement; }
     virtual void iterateChildren(const std::function<void(Node* node)>& fn) override
     {
         fn(this);

--- a/src/parser/ast/ClassNode.h
+++ b/src/parser/ast/ClassNode.h
@@ -27,7 +27,16 @@ namespace Escargot {
 
 class ClassNode {
 public:
-    ClassNode(RefPtr<IdentifierNode> id, RefPtr<Node> superClass, RefPtr<ClassBodyNode> classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
+    ClassNode()
+        : m_classBodyLexicalBlockIndex(0)
+        , m_id()
+        , m_superClass()
+        , m_classBody()
+        , m_classSrc()
+    {
+    }
+
+    ClassNode(RefPtr<Node> id, RefPtr<Node> superClass, RefPtr<ClassBodyNode> classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
         : m_classBodyLexicalBlockIndex(classBodyLexicalBlockIndex)
         , m_id(id)
         , m_superClass(superClass)
@@ -36,14 +45,14 @@ public:
     {
     }
 
-    inline const RefPtr<IdentifierNode>& id() const { return m_id; }
+    inline const RefPtr<Node>& id() const { return m_id; }
     inline const RefPtr<Node>& superClass() const { return m_superClass; }
     inline const RefPtr<ClassBodyNode>& classBody() const { return m_classBody; }
     inline LexicalBlockIndex classBodyLexicalBlockIndex() const { return m_classBodyLexicalBlockIndex; }
     inline const StringView& classSrc() const { return m_classSrc; }
 private:
     LexicalBlockIndex m_classBodyLexicalBlockIndex;
-    RefPtr<IdentifierNode> m_id; // Id
+    RefPtr<Node> m_id; // Id
     RefPtr<Node> m_superClass;
     RefPtr<ClassBodyNode> m_classBody;
     StringView m_classSrc;

--- a/src/parser/ast/DirectiveNode.h
+++ b/src/parser/ast/DirectiveNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 
 class DirectiveNode : public StatementNode {
 public:
-    DirectiveNode(ExpressionNode* expr, StringView value)
+    DirectiveNode(Node* expr, StringView value)
         : StatementNode()
         , m_expr(expr)
         , m_value(value)
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_expr;
+    RefPtr<Node> m_expr;
     StringView m_value;
 };
 }

--- a/src/parser/ast/ExportAllDeclarationNode.h
+++ b/src/parser/ast/ExportAllDeclarationNode.h
@@ -28,9 +28,10 @@ namespace Escargot {
 class ExportAllDeclarationNode : public ExportDeclarationNode {
 public:
     friend class ScriptParser;
-    ExportAllDeclarationNode(RefPtr<LiteralNode> src)
+    ExportAllDeclarationNode(RefPtr<Node> src)
         : m_src(src)
     {
+        ASSERT(src->isLiteral());
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::ExportAllDeclaration; }
@@ -42,7 +43,7 @@ public:
     }
 
 private:
-    RefPtr<LiteralNode> m_src;
+    RefPtr<Node> m_src;
 };
 }
 

--- a/src/parser/ast/ExportNamedDeclarationNode.h
+++ b/src/parser/ast/ExportNamedDeclarationNode.h
@@ -29,7 +29,7 @@ namespace Escargot {
 class ExportNamedDeclarationNode : public ExportDeclarationNode {
 public:
     friend class ScriptParser;
-    ExportNamedDeclarationNode(RefPtr<StatementNode> declaration, ExportSpecifierNodeVector&& specifiers, RefPtr<LiteralNode> source)
+    ExportNamedDeclarationNode(RefPtr<Node> declaration, NodeVector&& specifiers, RefPtr<Node> source)
         : m_declaration(declaration)
         , m_specifiers(std::move(specifiers))
         , m_source(source)
@@ -63,9 +63,9 @@ public:
 
 
 private:
-    RefPtr<StatementNode> m_declaration;
-    ExportSpecifierNodeVector m_specifiers;
-    RefPtr<LiteralNode> m_source;
+    RefPtr<Node> m_declaration;
+    NodeVector m_specifiers;
+    RefPtr<Node> m_source;
 };
 }
 

--- a/src/parser/ast/ExportSpecifierNode.h
+++ b/src/parser/ast/ExportSpecifierNode.h
@@ -27,10 +27,11 @@ namespace Escargot {
 class ExportSpecifierNode : public Node {
 public:
     friend class ScriptParser;
-    ExportSpecifierNode(RefPtr<IdentifierNode> local, RefPtr<IdentifierNode> exported)
+    ExportSpecifierNode(RefPtr<Node> local, RefPtr<Node> exported)
         : m_local(local)
         , m_exported(exported)
     {
+        ASSERT(local->isIdentifier() && exported->isIdentifier());
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::ExportSpecifier; }
@@ -47,22 +48,20 @@ public:
         return m_local != m_exported;
     }
 
-    RefPtr<IdentifierNode> local()
+    IdentifierNode* local()
     {
-        return m_local;
+        return m_local->asIdentifier();
     }
 
-    RefPtr<IdentifierNode> exported()
+    IdentifierNode* exported()
     {
-        return m_exported;
+        return m_exported->asIdentifier();
     }
 
 private:
-    RefPtr<IdentifierNode> m_local;
-    RefPtr<IdentifierNode> m_exported;
+    RefPtr<Node> m_local;
+    RefPtr<Node> m_exported;
 };
-
-typedef std::vector<RefPtr<ExportSpecifierNode>> ExportSpecifierNodeVector;
 }
 
 #endif

--- a/src/parser/ast/ExpressionNode.h
+++ b/src/parser/ast/ExpressionNode.h
@@ -34,7 +34,7 @@ public:
     {
     }
 
-    virtual bool isExpressionNode() override
+    virtual bool isExpression() override
     {
         return true;
     }

--- a/src/parser/ast/FunctionDeclarationNode.h
+++ b/src/parser/ast/FunctionDeclarationNode.h
@@ -29,8 +29,6 @@ public:
         : m_isGenerator(isGenerator)
         , m_scopeContext(scopeContext)
     {
-        scopeContext->m_nodeType = this->type();
-        scopeContext->m_isGenerator = isGenerator;
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::FunctionDeclaration; }

--- a/src/parser/ast/FunctionExpressionNode.h
+++ b/src/parser/ast/FunctionExpressionNode.h
@@ -29,8 +29,6 @@ public:
         : m_isGenerator(isGenerator)
         , m_subCodeBlockIndex(subCodeBlockIndex - 1)
     {
-        scopeContext->m_nodeType = this->type();
-        scopeContext->m_isGenerator = isGenerator;
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::FunctionExpression; }

--- a/src/parser/ast/IdentifierNode.h
+++ b/src/parser/ast/IdentifierNode.h
@@ -31,6 +31,13 @@ namespace Escargot {
 class IdentifierNode : public Node {
 public:
     friend class ScriptParser;
+
+    IdentifierNode()
+        : Node()
+        , m_name()
+    {
+    }
+
     explicit IdentifierNode(const AtomicString& name)
         : Node()
         , m_name(name)

--- a/src/parser/ast/ImportDeclarationNode.h
+++ b/src/parser/ast/ImportDeclarationNode.h
@@ -28,7 +28,7 @@ namespace Escargot {
 class ImportDeclarationNode : public StatementNode {
 public:
     friend class ScriptParser;
-    ImportDeclarationNode(ImportSpecifierNodeVector&& specifiers, RefPtr<LiteralNode> src)
+    ImportDeclarationNode(ImportSpecifierNodeVector&& specifiers, RefPtr<Node> src)
         : m_specifiers(specifiers)
         , m_src(src)
     {
@@ -51,7 +51,7 @@ public:
 
 private:
     ImportSpecifierNodeVector m_specifiers;
-    RefPtr<LiteralNode> m_src;
+    RefPtr<Node> m_src;
 };
 }
 

--- a/src/parser/ast/ImportDefaultSpecifierNode.h
+++ b/src/parser/ast/ImportDefaultSpecifierNode.h
@@ -27,9 +27,10 @@ namespace Escargot {
 class ImportDefaultSpecifierNode : public Node {
 public:
     friend class ScriptParser;
-    ImportDefaultSpecifierNode(RefPtr<IdentifierNode> local)
+    ImportDefaultSpecifierNode(RefPtr<Node> local)
         : m_local(local)
     {
+        ASSERT(local->isIdentifier());
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::ImportDefaultSpecifier; }
@@ -40,13 +41,13 @@ public:
         m_local->iterateChildren(fn);
     }
 
-    RefPtr<IdentifierNode> local()
+    IdentifierNode* local()
     {
-        return m_local;
+        return m_local->asIdentifier();
     }
 
 private:
-    RefPtr<IdentifierNode> m_local;
+    RefPtr<Node> m_local;
 };
 }
 

--- a/src/parser/ast/ImportNamespaceSpecifierNode.h
+++ b/src/parser/ast/ImportNamespaceSpecifierNode.h
@@ -27,9 +27,10 @@ namespace Escargot {
 class ImportNamespaceSpecifierNode : public Node {
 public:
     friend class ScriptParser;
-    ImportNamespaceSpecifierNode(RefPtr<IdentifierNode> local)
+    ImportNamespaceSpecifierNode(RefPtr<Node> local)
         : m_local(local)
     {
+        ASSERT(local->isIdentifier());
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::ImportNamespaceSpecifier; }
@@ -40,13 +41,13 @@ public:
         m_local->iterateChildren(fn);
     }
 
-    RefPtr<IdentifierNode> local()
+    IdentifierNode* local()
     {
-        return m_local;
+        return m_local->asIdentifier();
     }
 
 private:
-    RefPtr<IdentifierNode> m_local;
+    RefPtr<Node> m_local;
 };
 }
 

--- a/src/parser/ast/ImportSpecifierNode.h
+++ b/src/parser/ast/ImportSpecifierNode.h
@@ -27,10 +27,11 @@ namespace Escargot {
 class ImportSpecifierNode : public Node {
 public:
     friend class ScriptParser;
-    ImportSpecifierNode(RefPtr<IdentifierNode> local, RefPtr<IdentifierNode> imported)
+    ImportSpecifierNode(RefPtr<Node> local, RefPtr<Node> imported)
         : m_local(local)
         , m_imported(imported)
     {
+        ASSERT(local->isIdentifier() && imported->asIdentifier());
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::ImportSpecifier; }
@@ -42,19 +43,19 @@ public:
         m_imported->iterateChildren(fn);
     }
 
-    RefPtr<IdentifierNode> local()
+    IdentifierNode* local()
     {
-        return m_local;
+        return m_local->asIdentifier();
     }
 
-    RefPtr<IdentifierNode> imported()
+    IdentifierNode* imported()
     {
-        return m_imported;
+        return m_imported->asIdentifier();
     }
 
 private:
-    RefPtr<IdentifierNode> m_local;
-    RefPtr<IdentifierNode> m_imported;
+    RefPtr<Node> m_local;
+    RefPtr<Node> m_imported;
 };
 
 typedef std::vector<RefPtr<Node>> ImportSpecifierNodeVector;

--- a/src/parser/ast/LabeledStatementNode.h
+++ b/src/parser/ast/LabeledStatementNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class LabeledStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    LabeledStatementNode(StatementNode* statementNode, String* label)
+    LabeledStatementNode(Node* statementNode, String* label)
         : StatementNode()
         , m_statementNode(statementNode)
         , m_label(label)
@@ -57,7 +57,7 @@ public:
     }
 
 private:
-    RefPtr<StatementNode> m_statementNode;
+    RefPtr<Node> m_statementNode;
     String* m_label;
 };
 }

--- a/src/parser/ast/MemberExpressionNode.h
+++ b/src/parser/ast/MemberExpressionNode.h
@@ -85,7 +85,7 @@ public:
 
         if (isPreComputedCase()) {
             ASSERT(m_property->isIdentifier());
-            if (m_object->isSuperNode()) {
+            if (m_object->isSuperExpression()) {
                 size_t propertyIndex = m_property->getRegister(codeBlock, context);
                 codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_property->asIdentifier()->m_loc.index), propertyIndex, m_property->asIdentifier()->name().string()), context, m_property.get());
                 codeBlock->pushCode(SuperGetObjectOperation(ByteCodeLOC(m_loc.index), objectIndex, dstIndex, propertyIndex), context, this);
@@ -98,7 +98,7 @@ public:
         } else {
             size_t propertyIndex = m_property->getRegister(codeBlock, context);
             m_property->generateExpressionByteCode(codeBlock, context, propertyIndex);
-            if (m_object->isSuperNode()) {
+            if (m_object->isSuperExpression()) {
                 codeBlock->pushCode(SuperGetObjectOperation(ByteCodeLOC(m_loc.index), objectIndex, dstIndex, propertyIndex), context, this);
             } else {
                 codeBlock->pushCode(GetObject(ByteCodeLOC(m_loc.index), objectIndex, propertyIndex, dstIndex), context, this);
@@ -125,7 +125,7 @@ public:
                 objectIndex = context->getLastRegisterIndex();
             }
 
-            if (m_object->isSuperNode()) {
+            if (m_object->isSuperExpression()) {
                 size_t propertyIndex = m_property->getRegister(codeBlock, context);
                 codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_property->asIdentifier()->m_loc.index), propertyIndex, m_property->asIdentifier()->name().string()), context, m_property.get());
                 codeBlock->pushCode(SuperSetObjectOperation(ByteCodeLOC(m_loc.index), objectIndex, propertyIndex, valueIndex), context, this);
@@ -153,7 +153,7 @@ public:
                 propertyIndex = context->getLastRegisterIndex();
                 objectIndex = context->getLastRegisterIndex(1);
             }
-            if (m_object->isSuperNode()) {
+            if (m_object->isSuperExpression()) {
                 codeBlock->pushCode(SuperSetObjectOperation(ByteCodeLOC(m_loc.index), objectIndex, propertyIndex, valueIndex), context, this);
             } else {
                 codeBlock->pushCode(SetObjectOperation(ByteCodeLOC(m_loc.index), objectIndex, propertyIndex, valueIndex), context, this);

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -92,7 +92,7 @@ enum ASTNodeType {
     BinaryExpressionBitwiseAnd,
     BinaryExpressionBitwiseOr,
     BinaryExpressionBitwiseXor,
-    BinaryExpressionDivison,
+    BinaryExpressionDivision,
     /* Note: These 8 types must be in this order */
     BinaryExpressionEqual,
     BinaryExpressionNotEqual,
@@ -114,7 +114,6 @@ enum ASTNodeType {
     BinaryExpressionPlus,
     BinaryExpressionSignedRightShift,
     BinaryExpressionUnsignedRightShift,
-    LogicalExpression,
     UpdateExpressionDecrementPostfix,
     UpdateExpressionDecrementPrefix,
     UpdateExpressionIncrementPostfix,
@@ -136,7 +135,6 @@ enum ASTNodeType {
     TaggedTemplateExpression,
     Directive,
     RegExpLiteral,
-    NativeFunction,
     TryStatement,
     CatchClause,
     ThrowStatement,
@@ -145,7 +143,6 @@ enum ASTNodeType {
     Class,
     ClassBody,
     ClassElement,
-    ClassMethod,
     SuperExpression,
     ImportSpecifier,
     ImportDefaultSpecifier,
@@ -160,7 +157,8 @@ enum ASTNodeType {
     ArrayPattern,
     ObjectPattern,
     RegisterReference,
-    ASTNodeTypeError,
+    ASTStatementContainer, // used only for SyntaxNode
+    ASTNodeTypeError, // used only for SyntaxNode
 };
 
 COMPILE_ASSERT((int)Program == 0, "");
@@ -229,6 +227,15 @@ class PropertyNode;
 class MemberExpressionNode;
 class ObjectExpressionNode;
 class StatementNode;
+class ClassBodyNode;
+class ClassElementNode;
+class ClassExpressionNode;
+class ClassDeclarationNode;
+class SequenceExpressionNode;
+class VariableDeclaratorNode;
+class FunctionDeclarationNode;
+class ImportSpecifierNode;
+class ExportSpecifierNode;
 
 class Node : public RefCounted<Node> {
 protected:
@@ -279,10 +286,16 @@ public:
         return type() == ASTNodeType::Identifier;
     }
 
-    IdentifierNode *asIdentifier()
+    ALWAYS_INLINE IdentifierNode *asIdentifier()
     {
         ASSERT(isIdentifier());
         return (IdentifierNode *)this;
+    }
+
+    ALWAYS_INLINE ClassExpressionNode *asClassExpression()
+    {
+        ASSERT(type() == ASTNodeType::ClassExpression);
+        return (ClassExpressionNode *)this;
     }
 
     bool isAssignmentPattern()
@@ -290,7 +303,7 @@ public:
         return type() == ASTNodeType::AssignmentPattern;
     }
 
-    AssignmentPatternNode *asAssignmentPattern()
+    ALWAYS_INLINE AssignmentPatternNode *asAssignmentPattern()
     {
         ASSERT(isAssignmentPattern());
         return (AssignmentPatternNode *)this;
@@ -301,7 +314,7 @@ public:
         return type() == ASTNodeType::ArrayExpression;
     }
 
-    ArrayExpressionNode *asArrayExpression()
+    ALWAYS_INLINE ArrayExpressionNode *asArrayExpression()
     {
         ASSERT(isArrayExpression());
         return (ArrayExpressionNode *)this;
@@ -312,7 +325,7 @@ public:
         return type() == ASTNodeType::ObjectExpression;
     }
 
-    ObjectExpressionNode *asObjectExpression()
+    ALWAYS_INLINE ObjectExpressionNode *asObjectExpression()
     {
         ASSERT(isObjectExpression());
         return (ObjectExpressionNode *)this;
@@ -323,7 +336,7 @@ public:
         return type() == ASTNodeType::Property;
     }
 
-    PropertyNode *asProperty()
+    ALWAYS_INLINE PropertyNode *asProperty()
     {
         ASSERT(isProperty());
         return (PropertyNode *)this;
@@ -334,28 +347,76 @@ public:
         return type() == ASTNodeType::AssignmentExpressionSimple;
     }
 
-    AssignmentExpressionSimpleNode *asAssignmentExpressionSimple()
+    ALWAYS_INLINE AssignmentExpressionSimpleNode *asAssignmentExpressionSimple()
     {
         ASSERT(isAssignmentExpressionSimple());
         return (AssignmentExpressionSimpleNode *)this;
     }
 
-    MemberExpressionNode *asMemberExpression()
+    ALWAYS_INLINE MemberExpressionNode *asMemberExpression()
     {
         ASSERT(isMemberExpression());
         return (MemberExpressionNode *)this;
     }
 
-    LiteralNode *asLiteral()
+    ALWAYS_INLINE LiteralNode *asLiteral()
     {
         ASSERT(isLiteral());
         return (LiteralNode *)this;
     }
 
-    StatementNode *asStatementNode()
+    ALWAYS_INLINE StatementNode *asStatement()
     {
-        ASSERT(isStatementNode());
+        ASSERT(isStatement());
         return (StatementNode *)this;
+    }
+
+    ALWAYS_INLINE SequenceExpressionNode *asSequenceExpression()
+    {
+        ASSERT(type() == ASTNodeType::SequenceExpression);
+        return (SequenceExpressionNode *)this;
+    }
+
+    ALWAYS_INLINE ClassBodyNode *asClassBody()
+    {
+        ASSERT(type() == ASTNodeType::ClassBody);
+        return (ClassBodyNode *)this;
+    }
+
+    ALWAYS_INLINE ClassElementNode *asClassElement()
+    {
+        ASSERT(type() == ASTNodeType::ClassElement);
+        return (ClassElementNode *)this;
+    }
+
+    ALWAYS_INLINE ClassDeclarationNode *asClassDeclaration()
+    {
+        ASSERT(type() == ASTNodeType::ClassDeclaration);
+        return (ClassDeclarationNode *)this;
+    }
+
+    ALWAYS_INLINE VariableDeclaratorNode *asVariableDeclarator()
+    {
+        ASSERT(type() == ASTNodeType::VariableDeclarator);
+        return (VariableDeclaratorNode *)this;
+    }
+
+    ALWAYS_INLINE FunctionDeclarationNode *asFunctionDeclaration()
+    {
+        ASSERT(type() == ASTNodeType::FunctionDeclaration);
+        return (FunctionDeclarationNode *)this;
+    }
+
+    ALWAYS_INLINE ImportSpecifierNode *asImportSpecifier()
+    {
+        ASSERT(type() == ASTNodeType::ImportSpecifier);
+        return (ImportSpecifierNode *)this;
+    }
+
+    ALWAYS_INLINE ExportSpecifierNode *asExportSpecifier()
+    {
+        ASSERT(type() == ASTNodeType::ExportSpecifier);
+        return (ExportSpecifierNode *)this;
     }
 
     bool isLiteral()
@@ -368,17 +429,17 @@ public:
         return type() == ASTNodeType::MemberExpression;
     }
 
-    bool isSuperNode()
+    bool isSuperExpression()
     {
         return type() == ASTNodeType::SuperExpression;
     }
 
-    virtual bool isExpressionNode()
+    virtual bool isExpression()
     {
         return false;
     }
 
-    virtual bool isStatementNode()
+    virtual bool isStatement()
     {
         return false;
     }
@@ -432,7 +493,7 @@ typedef std::vector<RefPtr<Node>> PatternNodeVector;
 class PropertyNode;
 typedef std::vector<RefPtr<Node>> PropertiesNodeVector;
 class VariableDeclaratorNode;
-typedef std::vector<RefPtr<VariableDeclaratorNode>> VariableDeclaratorVector;
+typedef std::vector<RefPtr<Node>> VariableDeclaratorVector;
 }
 
 #endif

--- a/src/parser/ast/ReturnStatementNode.h
+++ b/src/parser/ast/ReturnStatementNode.h
@@ -17,23 +17,23 @@
  *  USA
  */
 
-#ifndef ReturnStatmentNode_h
-#define ReturnStatmentNode_h
+#ifndef ReturnStatementNode_h
+#define ReturnStatementNode_h
 
 #include "StatementNode.h"
 
 namespace Escargot {
 
-class ReturnStatmentNode : public StatementNode {
+class ReturnStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    explicit ReturnStatmentNode(Node* argument)
+    explicit ReturnStatementNode(Node* argument)
         : StatementNode()
         , m_argument(argument)
     {
     }
 
-    virtual ~ReturnStatmentNode()
+    virtual ~ReturnStatementNode()
     {
     }
 

--- a/src/parser/ast/StatementNode.h
+++ b/src/parser/ast/StatementNode.h
@@ -33,7 +33,7 @@ public:
     {
     }
 
-    virtual bool isStatementNode()
+    virtual bool isStatement()
     {
         return true;
     }
@@ -70,7 +70,7 @@ public:
 
     void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context)
     {
-        StatementNode* nd = m_firstChild.get();
+        StatementNode* nd = firstChild();
         while (nd) {
             nd->generateStatementByteCode(codeBlock, context);
             nd = nd->nextSilbing();
@@ -79,46 +79,51 @@ public:
 
     void iterateChildren(const std::function<void(Node* node)>& fn)
     {
-        StatementNode* nd = m_firstChild.get();
+        StatementNode* nd = firstChild();
         while (nd) {
             nd->iterateChildren(fn);
             nd = nd->nextSilbing();
         }
     }
 
-    StatementNode* appendChild(RefPtr<StatementNode> c)
+    StatementNode* appendChild(RefPtr<Node> c)
     {
         return appendChild(c.get());
     }
 
-    StatementNode* appendChild(RefPtr<StatementNode> c, RefPtr<StatementNode> referNode)
+    StatementNode* appendChild(RefPtr<Node> c, RefPtr<Node> referNode)
     {
         return appendChild(c.get(), referNode.get());
     }
 
-    StatementNode* appendChild(StatementNode* c, StatementNode* referNode)
+    StatementNode* appendChild(Node* c, Node* referNode)
     {
+        ASSERT(c->isStatement());
+        StatementNode* child = c->asStatement();
         if (referNode == nullptr) {
-            appendChild(c);
+            appendChild(child);
         } else {
-            referNode->m_nextSilbing = c;
+            ASSERT(referNode->isStatement());
+            referNode->asStatement()->m_nextSilbing = child;
         }
-        return c;
+        return child;
     }
 
-    StatementNode* appendChild(StatementNode* c)
+    StatementNode* appendChild(Node* c)
     {
-        ASSERT(c->nextSilbing() == nullptr);
+        ASSERT(c->isStatement());
+        ASSERT(c->asStatement()->nextSilbing() == nullptr);
+        StatementNode* child = c->asStatement();
         if (m_firstChild == nullptr) {
-            m_firstChild = c;
+            m_firstChild = child;
         } else {
-            StatementNode* tail = m_firstChild.get();
+            StatementNode* tail = firstChild();
             while (tail->m_nextSilbing != nullptr) {
                 tail = tail->m_nextSilbing.get();
             }
-            tail->m_nextSilbing = c;
+            tail->m_nextSilbing = child;
         }
-        return c;
+        return child;
     };
 
     StatementNode* firstChild()

--- a/src/parser/ast/TryStatementNode.h
+++ b/src/parser/ast/TryStatementNode.h
@@ -29,11 +29,10 @@ namespace Escargot {
 class TryStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    TryStatementNode(Node *block, Node *handler, CatchClauseNodeVector &&guardedHandlers, Node *finalizer)
+    TryStatementNode(Node *block, Node *handler, Node *finalizer)
         : StatementNode()
         , m_block((BlockStatementNode *)block)
         , m_handler((CatchClauseNode *)handler)
-        , m_guardedHandlers(std::move(guardedHandlers))
         , m_finalizer((BlockStatementNode *)finalizer)
     {
     }
@@ -178,7 +177,6 @@ public:
 private:
     RefPtr<BlockStatementNode> m_block;
     RefPtr<CatchClauseNode> m_handler;
-    CatchClauseNodeVector m_guardedHandlers;
     RefPtr<BlockStatementNode> m_finalizer;
 };
 }

--- a/src/parser/ast/VariableDeclarationNode.h
+++ b/src/parser/ast/VariableDeclarationNode.h
@@ -45,7 +45,7 @@ public:
     {
         return m_kind;
     }
-    VariableDeclaratorVector& declarations() { return m_declarations; }
+
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
         size_t len = m_declarations.size();
@@ -57,7 +57,7 @@ public:
     virtual void generateStoreByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex src, bool needToReferenceSelf) override
     {
         ASSERT(m_declarations.size() == 1);
-        m_declarations[0]->id()->generateStoreByteCode(codeBlock, context, src, true);
+        m_declarations[0]->asVariableDeclarator()->id()->generateStoreByteCode(codeBlock, context, src, true);
     }
 
     virtual void generateReferenceResolvedAddressByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
@@ -76,8 +76,8 @@ public:
 
         size_t len = m_declarations.size();
         for (size_t i = 0; i < len; i++) {
-            m_declarations[i]->id()->iterateChildren(fn);
-            m_declarations[i]->init()->iterateChildren(fn);
+            m_declarations[i]->asVariableDeclarator()->id()->iterateChildren(fn);
+            m_declarations[i]->asVariableDeclarator()->init()->iterateChildren(fn);
         }
     }
 

--- a/src/parser/ast/WithStatementNode.h
+++ b/src/parser/ast/WithStatementNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class WithStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    WithStatementNode(RefPtr<Node> object, RefPtr<StatementNode> body)
+    WithStatementNode(RefPtr<Node> object, RefPtr<Node> body)
         : StatementNode()
         , m_object(object)
         , m_body(body)
@@ -67,7 +67,7 @@ public:
 
 private:
     RefPtr<Node> m_object;
-    RefPtr<StatementNode> m_body; // body: [ Statement ];
+    RefPtr<Node> m_body; // body: [ Statement ];
 };
 }
 

--- a/src/parser/esprima_cpp/Messages.h
+++ b/src/parser/esprima_cpp/Messages.h
@@ -1,0 +1,100 @@
+/*
+  Copyright JS Foundation and other contributors, https://js.foundation/
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/*
+ * Copyright (c) 2019-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#ifndef __EscargotMessages__
+#define __EscargotMessages__
+
+namespace Escargot {
+namespace esprima {
+namespace Messages {
+const char* UnexpectedToken = "Unexpected token %s";
+const char* UnexpectedNumber = "Unexpected number";
+const char* UnexpectedString = "Unexpected string";
+const char* UnexpectedIdentifier = "Unexpected identifier";
+const char* UnexpectedReserved = "Unexpected reserved word";
+const char* UnexpectedTemplate = "Unexpected quasi %s";
+const char* UnexpectedEOS = "Unexpected end of input";
+const char* NewlineAfterThrow = "Illegal newline after throw";
+const char* InvalidRegExp = "Invalid regular expression";
+const char* InvalidLHSInAssignment = "Invalid left-hand side in assignment";
+const char* InvalidLHSInForIn = "Invalid left-hand side in for-in";
+const char* InvalidLHSInForLoop = "Invalid left-hand side in for-loop";
+const char* MultipleDefaultsInSwitch = "More than one default clause in switch statement";
+const char* NoCatchOrFinally = "Missing catch or finally after try";
+const char* UnknownLabel = "Undefined label \'%s\'";
+const char* Redeclaration = "%s \'%s\' has already been declared";
+const char* IllegalContinue = "Illegal continue statement";
+const char* IllegalBreak = "Illegal break statement";
+const char* IllegalReturn = "Illegal return statement";
+const char* StrictModeWith = "Strict mode code may not include a with statement";
+const char* StrictCatchVariable = "Catch variable may not be eval or arguments in strict mode";
+const char* StrictVarName = "Variable name may not be eval or arguments in strict mode";
+const char* StrictParamName = "Parameter name eval or arguments is not allowed in strict mode";
+const char* StrictParamDupe = "Strict mode function may not have duplicate parameter names";
+const char* StrictFunctionName = "Function name may not be eval or arguments in strict mode";
+const char* StrictOctalLiteral = "Octal literals are not allowed in strict mode.";
+const char* StrictLeadingZeroLiteral = "Decimals with leading zeros are not allowed in strict mode.";
+const char* StrictDelete = "Delete of an unqualified identifier in strict mode.";
+const char* StrictLHSAssignment = "Assignment to eval or arguments is not allowed in strict mode";
+const char* StrictLHSPostfix = "Postfix increment/decrement may not have eval or arguments operand in strict mode";
+const char* StrictLHSPrefix = "Prefix increment/decrement may not have eval or arguments operand in strict mode";
+const char* StrictReservedWord = "Use of future reserved word in strict mode";
+const char* ParameterAfterRestParameter = "Rest parameter must be last formal parameter";
+const char* DefaultRestParameter = "Unexpected token =";
+const char* ObjectPatternAsRestParameter = "Unexpected token {";
+const char* DuplicateProtoProperty = "Duplicate __proto__ fields are not allowed in object literals";
+const char* ConstructorSpecialMethod = "Class constructor may not be an accessor";
+const char* ConstructorGenerator = "Class constructor may not be a generator";
+const char* DuplicateConstructor = "A class may only have one constructor";
+const char* StaticPrototype = "Classes may not have static property named prototype";
+const char* MissingFromClause = "Unexpected token";
+const char* NoAsAfterImportNamespace = "Unexpected token";
+const char* InvalidModuleSpecifier = "Unexpected token";
+const char* IllegalImportDeclaration = "Unexpected token";
+const char* IllegalExportDeclaration = "Unexpected token";
+const char* DuplicateBinding = "Duplicate binding %s";
+const char* ForInOfLoopInitializer = "%s loop variable declaration may not have an initializer";
+const char* BadGetterArity = "Getter must not have any formal parameters";
+const char* BadSetterArity = "Setter must have exactly one formal parameter";
+const char* BadSetterRestParameter = "Setter function argument must not be a rest parameter";
+} // namespace Messages
+} // namespace esprima
+} // namespace Escargot
+
+#endif

--- a/src/parser/esprima_cpp/esprima.h
+++ b/src/parser/esprima_cpp/esprima.h
@@ -32,7 +32,8 @@ class ProgramNode;
 class FunctionNode;
 class CodeBlock;
 
-// NOTE I converted esprima (3.1.1, cd59092) to cpp
+// Based on the latest esprima version 4.0.1
+
 namespace esprima {
 
 typedef std::function<void(::Escargot::Node*, NodeLOC start, NodeLOC end)> ParserASTNodeHandler;


### PR DESCRIPTION
* all parser and scanner methods share common parsing codes, but part of creating a new Node is implemented by two ASTBuilders which are passed as argument
* SyntaxChecker only checks any syntax error
* NodeGenerator checks any syntax error and also creates a new Node
* remove unused Node methods and fix some typo in Node
* esprima::Messages is divided into another header file

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>