### PR TITLE
Fix  in GlobalObjectBuiltinMath

### DIFF
--- a/tools/test/v8/v8.mjsunit.status
+++ b/tools/test/v8/v8.mjsunit.status
@@ -746,7 +746,6 @@
   'regress/regress-324028': [SKIP],
   'regress/regress-95920': [SKIP],
   'regress/regress-crbug-109362': [SKIP],
-  'to_number_order': [SKIP],
   'regress/regress-r3391': [SKIP],
   'regress/regress-crbug-627934': [SKIP],
   'third_party/object-keys/object-keys': [SKIP],


### PR DESCRIPTION
Few Math functions needed a minor fix (min,max,hypot).
Basily if the first agrument was NaN or infinity, then don't convert the other arguments toNumber.

Also enabled one V8 test.

Signed-off-by: bence gabor kis <kisbg@inf.u-szeged.hu>