### PR TITLE
Optmize escargot

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,26 +85,26 @@ timeout(20) {
             stage('Running test') {
             parallel (
                 'release-32bit-jetstream-1' : {
-                    sh 'tools/run-tests.py --arch=x86 --engine="${WORKSPACE}/build/out_linux_release/escargot" jetstream-only-simple-parallel-1'
+                    sh 'GC_FREE_SPACE_DIVISOR=1 tools/run-tests.py --arch=x86 --engine="${WORKSPACE}/build/out_linux_release/escargot" jetstream-only-simple-parallel-1'
                 },
                 'release-32bit-jetstream-2' : {
-                    sh 'tools/run-tests.py --arch=x86 --engine="${WORKSPACE}/build/out_linux_release/escargot" jetstream-only-simple-parallel-2'
+                    sh 'GC_FREE_SPACE_DIVISOR=1 tools/run-tests.py --arch=x86 --engine="${WORKSPACE}/build/out_linux_release/escargot" jetstream-only-simple-parallel-2'
                 },
                 'release-32bit-jetstream-3' : {
-                    sh 'tools/run-tests.py --arch=x86 --engine="${WORKSPACE}/build/out_linux_release/escargot" jetstream-only-simple-parallel-3'
+                    sh 'GC_FREE_SPACE_DIVISOR=1 tools/run-tests.py --arch=x86 --engine="${WORKSPACE}/build/out_linux_release/escargot" jetstream-only-simple-parallel-3'
                 },
                 'release-64bit-jetstream-1' : {
-                    sh 'tools/run-tests.py --arch=x86_64 --engine="${WORKSPACE}/build/out_linux64_release/escargot" jetstream-only-simple-parallel-1'
+                    sh 'GC_FREE_SPACE_DIVISOR=1 tools/run-tests.py --arch=x86_64 --engine="${WORKSPACE}/build/out_linux64_release/escargot" jetstream-only-simple-parallel-1'
                 },
                 'release-64bit-jetstream-2' : {
-                    sh 'tools/run-tests.py --arch=x86_64 --engine="${WORKSPACE}/build/out_linux64_release/escargot" jetstream-only-simple-parallel-2'
+                    sh 'GC_FREE_SPACE_DIVISOR=1 tools/run-tests.py --arch=x86_64 --engine="${WORKSPACE}/build/out_linux64_release/escargot" jetstream-only-simple-parallel-2'
                 },
                 'release-64bit-jetstream-3' : {
-                    sh 'tools/run-tests.py --arch=x86_64 --engine="${WORKSPACE}/build/out_linux64_release/escargot" jetstream-only-simple-parallel-3'
+                    sh 'GC_FREE_SPACE_DIVISOR=1 tools/run-tests.py --arch=x86_64 --engine="${WORKSPACE}/build/out_linux64_release/escargot" jetstream-only-simple-parallel-3'
                 },
                 'release-octane' : {
-                    sh 'tools/run-tests.py --arch=x86 --engine="${WORKSPACE}/build/out_linux_release/escargot" octane'
-                    sh 'tools/run-tests.py --arch=x86_64 --engine="${WORKSPACE}/build/out_linux64_release/escargot" octane'
+                    sh 'GC_FREE_SPACE_DIVISOR=1 tools/run-tests.py --arch=x86 --engine="${WORKSPACE}/build/out_linux_release/escargot" octane'
+                    sh 'GC_FREE_SPACE_DIVISOR=1 tools/run-tests.py --arch=x86_64 --engine="${WORKSPACE}/build/out_linux64_release/escargot" octane'
                 },
                 'release-chakracore' : {
                     sh 'tools/run-tests.py --arch=x86 --engine="${WORKSPACE}/build/out_linux_release/escargot" chakracore'

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -448,8 +448,11 @@ Value Script::executeModule(ExecutionState& state, Optional<Script*> referrer)
 Value Script::execute(ExecutionState& state, bool isExecuteOnEvalFunction, bool inStrictMode)
 {
     if (UNLIKELY(isExecuted())) {
-        ESCARGOT_LOG_ERROR("You cannot re-execute Script object...");
-        RELEASE_ASSERT_NOT_REACHED();
+        if (!m_canExecuteAgain) {
+            ESCARGOT_LOG_ERROR("You cannot re-execute is type of Script object");
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        m_topCodeBlock = state.context()->scriptParser().initializeScript(m_sourceCode, m_src, m_moduleData).script->m_topCodeBlock;
     }
 
     if (isModule()) {

--- a/src/parser/Script.h
+++ b/src/parser/Script.h
@@ -117,8 +117,9 @@ public:
     bool isExecuted();
 
 private:
-    Script(String* src, String* sourceCode, ModuleData* moduleData)
-        : m_src(src)
+    Script(String* src, String* sourceCode, ModuleData* moduleData, bool canExecuteAgain)
+        : m_canExecuteAgain(canExecuteAgain && !moduleData)
+        , m_src(src)
         , m_sourceCode(sourceCode)
         , m_topCodeBlock(nullptr)
         , m_moduleData(moduleData)
@@ -159,6 +160,7 @@ private:
     }
     // http://www.ecma-international.org/ecma-262/6.0/#sec-getexportednames
     AtomicStringVector exportedNames(ExecutionState& state, std::vector<Script*>& exportStarSet);
+    bool m_canExecuteAgain;
     String* m_src;
     String* m_sourceCode;
     InterpretedCodeBlock* m_topCodeBlock;

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -206,11 +206,10 @@ ScriptParser::InitializeScriptResult ScriptParser::initializeScript(StringView s
 
     // Parsing
     try {
-        m_context->vmInstance()->m_parsedSourceCodes.push_back(scriptSource.string());
         InterpretedCodeBlock* topCodeBlock = nullptr;
         RefPtr<ProgramNode> programNode = esprima::parseProgram(m_context, scriptSource, isModule, strictFromOutside, inWith, stackSizeRemain, allowSC, allowSP);
 
-        Script* script = new Script(fileName, new StringView(scriptSource), programNode->moduleData());
+        Script* script = new Script(fileName, new StringView(scriptSource), programNode->moduleData(), !parentCodeBlock);
         if (parentCodeBlock) {
             programNode->scopeContext()->m_hasEval = parentCodeBlock->hasEval();
             programNode->scopeContext()->m_hasWith = parentCodeBlock->hasWith();
@@ -249,7 +248,6 @@ ScriptParser::InitializeScriptResult ScriptParser::initializeScript(StringView s
         return result;
 
     } catch (esprima::Error& orgError) {
-        m_context->vmInstance()->m_parsedSourceCodes.pop_back();
         GC_enable();
 
         ScriptParser::InitializeScriptResult result;

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -62,7 +62,6 @@ public:
     AtomicString(Context* c, const char16_t* src, size_t len);
     AtomicString(Context* c, const char* src, size_t len);
     AtomicString(Context* c, const StringView& sv);
-    AtomicString(Context* c, const SourceStringView& sv);
     AtomicString(Context* c, String* name);
 
     inline String* string() const

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -112,7 +112,6 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
     try {
         srcToTest.appendString(") { }");
         String* cur = srcToTest.finalize(&state);
-        state.context()->vmInstance()->parsedSourceCodes().push_back(cur);
         esprima::parseProgram(state.context(), StringView(cur, 0, cur->length()), false, false, false, SIZE_MAX, false, false);
     } catch (esprima::Error& orgError) {
         ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "there is a script parse error in parameter name");

--- a/src/runtime/GlobalObject.cpp
+++ b/src/runtime/GlobalObject.cpp
@@ -74,12 +74,6 @@ static Value builtinIsBlockAllocatedOnStack(ExecutionState& state, Value thisVal
 
     return Value(result);
 }
-
-static Value builtinGc(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
-{
-    GC_gcollect_and_unmap();
-    return Value();
-}
 #endif
 
 class EvalFunctionObject : public NativeFunctionObject {
@@ -1071,11 +1065,6 @@ void GlobalObject::installOthers(ExecutionState& state)
     defineOwnProperty(state, ObjectPropertyName(isBlockAllocatedOnStackFunctionName),
                       ObjectPropertyDescriptor(new NativeFunctionObject(state,
                                                                         NativeFunctionInfo(strings->run, builtinIsBlockAllocatedOnStack, 2, NativeFunctionInfo::Strict)),
-                                               (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::AllPresent)));
-
-    defineOwnProperty(state, ObjectPropertyName(strings->gc),
-                      ObjectPropertyDescriptor(new NativeFunctionObject(state,
-                                                                        NativeFunctionInfo(strings->gc, builtinGc, 0, NativeFunctionInfo::Strict)),
                                                (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::AllPresent)));
 #endif
 

--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -25,6 +25,7 @@
 #include "runtime/BoundFunctionObject.h"
 #include "runtime/ScriptFunctionObject.h"
 #include "runtime/ScriptClassConstructorFunctionObject.h"
+#include "parser/Lexer.h"
 
 namespace Escargot {
 
@@ -72,7 +73,7 @@ static Value builtinFunctionToString(ExecutionState& state, Value thisValue, siz
 
             if (fn->codeBlock()->isInterpretedCodeBlock() && fn->codeBlock()->asInterpretedCodeBlock()->script() != nullptr) {
                 StringView src = fn->codeBlock()->asInterpretedCodeBlock()->src();
-                while (src[src.length() - 1] != '}') {
+                while (src.length() && EscargotLexer::isWhiteSpaceOrLineTerminator(src[src.length() - 1])) {
                     src = StringView(src, 0, src.length() - 1);
                 }
                 builder.appendString(new StringView(src));

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -75,10 +75,16 @@ class RopeString;
 class StringView;
 
 struct StringBufferAccessData {
-    bool has8BitContent;
-    bool hasSpecialImpl;
-    size_t length;
+    bool has8BitContent : 1;
+    bool hasSpecialImpl : 1;
+#if defined(ESCARGOT_32)
+    size_t length : 30;
+#else
+    size_t length : 62;
+#endif
     const void* buffer;
+
+    COMPILE_ASSERT(STRING_MAXIMUM_LENGTH < (std::numeric_limits<size_t>::max() >> 2), "");
 
     char16_t uncheckedCharAtFor8Bit(size_t idx) const
     {

--- a/src/runtime/StringView.cpp
+++ b/src/runtime/StringView.cpp
@@ -34,16 +34,4 @@ void* StringView::operator new(size_t size)
     }
     return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
 }
-
-void* SourceStringView::operator new(size_t size)
-{
-    static bool typeInited = false;
-    static GC_descr descr;
-    if (!typeInited) {
-        GC_word obj_bitmap[GC_BITMAP_SIZE(SourceStringView)] = { 0 };
-        descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(SourceStringView));
-        typeInited = true;
-    }
-    return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
-}
 }

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -185,11 +185,6 @@ public:
     bool hasPendingPromiseJob();
     SandBox::SandBoxResult executePendingPromiseJob();
 
-    Vector<String*, GCUtil::gc_malloc_allocator<String*>>& parsedSourceCodes()
-    {
-        return m_parsedSourceCodes;
-    }
-
     Vector<CodeBlock*, GCUtil::gc_malloc_allocator<CodeBlock*>>& compiledCodeBlocks()
     {
         return m_compiledCodeBlocks;

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -19,6 +19,7 @@
 
 #include <string.h>
 #include <vector>
+
 #include "api/EscargotPublic.h"
 
 #if defined(ESCARGOT_ENABLE_TEST)
@@ -230,6 +231,12 @@ static ValueRef* builtinRun(ExecutionStateRef* state, ValueRef* thisValue, size_
     }
 }
 
+static ValueRef* builtinGc(ExecutionStateRef* state, ValueRef* thisValue, size_t argc, ValueRef** argv, bool isConstructCall)
+{
+    Memory::gc();
+    return ValueRef::createUndefined();
+}
+
 #if defined(ESCARGOT_ENABLE_TEST)
 static ValueRef* builtinUneval(ExecutionStateRef* state, ValueRef* thisValue, size_t argc, ValueRef** argv, bool isConstructCall)
 {
@@ -299,6 +306,12 @@ PersistentRefHolder<ContextRef> createEscargotContext(VMInstanceRef* instance)
             FunctionObjectRef::NativeFunctionInfo nativeFunctionInfo(AtomicStringRef::create(context, "run"), builtinRun, 1, true, false);
             FunctionObjectRef* buildFunctionObjectRef = FunctionObjectRef::create(state, nativeFunctionInfo);
             context->globalObject()->defineDataProperty(state, StringRef::createFromASCII("run"), buildFunctionObjectRef, true, true, true);
+        }
+
+        {
+            FunctionObjectRef::NativeFunctionInfo nativeFunctionInfo(AtomicStringRef::create(context, "gc"), builtinGc, 0, true, false);
+            FunctionObjectRef* buildFunctionObjectRef = FunctionObjectRef::create(state, nativeFunctionInfo);
+            context->globalObject()->defineDataProperty(state, StringRef::createFromASCII("gc"), buildFunctionObjectRef, true, true, true);
         }
 
 #if defined(ESCARGOT_ENABLE_TEST)
@@ -435,6 +448,7 @@ static bool evalScript(ContextRef* context, StringRef* str, StringRef* fileName,
     if (stringEndsWith(fileName->toStdUTF8String(), "mjs")) {
         isModule = isModule || true;
     }
+
     auto scriptInitializeResult = context->scriptParser()->initializeScript(str, fileName, isModule);
     if (!scriptInitializeResult.script) {
         printf("Script parsing error: ");


### PR DESCRIPTION
* Don't allocate new StringView on parser if possible
* Store esprima::Context::firstCoverInitializedNameError as pointer. it can reduce copy cost on esprima::*CoverGrammar
* Make Script as reexcutable if possible
* Don't save parsed source codes
  - Remove SourceStringView
  - When create AtomicString from StringView, we should make new string data instead of reference StringView
* Reduce size of StringBufferAccessData

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>