### PR TITLE
Fix some bugs related to Propertydescriptor and Array

### DIFF
--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -345,8 +345,12 @@ Object* ObjectPropertyDescriptor::fromObjectPropertyDescriptor(ExecutionState& s
         // 4.a Perform CreateDataProperty(obj, "value", Desc.[[Value]]).
         // 5. If Desc has a [[Writable]] field, then
         // 5.a Perform CreateDataProperty(obj, "writable", Desc.[[Writable]]).
-        obj->defineOwnProperty(state, ObjectPropertyName(state, strings->value.string()), ObjectPropertyDescriptor(desc.isValuePresent() ? desc.value() : Value(), ObjectPropertyDescriptor::AllPresent));
-        obj->defineOwnProperty(state, ObjectPropertyName(state, strings->writable.string()), ObjectPropertyDescriptor(Value(desc.isWritable()), ObjectPropertyDescriptor::AllPresent));
+        if (desc.isValuePresent()) {
+            obj->defineOwnProperty(state, ObjectPropertyName(state, strings->value.string()), ObjectPropertyDescriptor(desc.value(), ObjectPropertyDescriptor::AllPresent));
+        }
+        if (desc.isWritablePresent()) {
+            obj->defineOwnProperty(state, ObjectPropertyName(state, strings->writable.string()), ObjectPropertyDescriptor(Value(desc.isWritable()), ObjectPropertyDescriptor::AllPresent));
+        }
     } else {
         ASSERT(desc.hasJSGetter() || desc.hasJSSetter());
         // 6. If Desc has a [[Get]] field, then
@@ -362,10 +366,14 @@ Object* ObjectPropertyDescriptor::fromObjectPropertyDescriptor(ExecutionState& s
     }
     // 8. If Desc has an [[Enumerable]] field, then
     // 8.a. Perform CreateDataProperty(obj, "enumerable", Desc.[[Enumerable]]).
-    obj->defineOwnProperty(state, ObjectPropertyName(state, strings->enumerable.string()), ObjectPropertyDescriptor(Value(desc.isEnumerable()), ObjectPropertyDescriptor::AllPresent));
+    if (desc.isEnumerablePresent()) {
+        obj->defineOwnProperty(state, ObjectPropertyName(state, strings->enumerable.string()), ObjectPropertyDescriptor(Value(desc.isEnumerable()), ObjectPropertyDescriptor::AllPresent));
+    }
     // 9. If Desc has a [[Configurable]] field, then
     // 9.a. Perform CreateDataProperty(obj , "configurable", Desc.[[Configurable]]).
-    obj->defineOwnProperty(state, ObjectPropertyName(state, strings->configurable.string()), ObjectPropertyDescriptor(Value(desc.isConfigurable()), ObjectPropertyDescriptor::AllPresent));
+    if (desc.isConfigurablePresent()) {
+        obj->defineOwnProperty(state, ObjectPropertyName(state, strings->configurable.string()), ObjectPropertyDescriptor(Value(desc.isConfigurable()), ObjectPropertyDescriptor::AllPresent));
+    }
     // 10. Assert: all of the above CreateDataProperty operations return true.
     // 11. Return obj.
     return obj;

--- a/src/runtime/PointerValue.h
+++ b/src/runtime/PointerValue.h
@@ -259,6 +259,11 @@ public:
         return false;
     }
 
+    virtual bool isArrayIteratorPrototypeObject() const
+    {
+        return false;
+    }
+
     virtual bool isStringIteratorObject() const
     {
         return false;

--- a/tools/test/spidermonkey/excludelist.txt
+++ b/tools/test/spidermonkey/excludelist.txt
@@ -9,10 +9,9 @@ non262/module/await-restricted-nested.js
 non262/Array/from-iterator-close.js
 non262/Array/from_primitive.js
 non262/Array/generics.js
+non262/Array/iterator_edge_cases.js
 
 # TODO
-non262/Array/iterator_edge_cases.js
-non262/Array/pop-no-has-trap.js
 non262/Array/regress-304828.js
 non262/Array/regress-313153.js
 non262/Array/regress-387501.js
@@ -43,7 +42,6 @@ non262/class/newTargetDVG.js
 non262/class/newTargetEval.js
 non262/class/newTargetGenerators.js
 non262/class/outerBinding.js
-non262/class/parenExprToString.js
 non262/class/strictExecution.js
 non262/class/superCallBaseInvoked.js
 non262/class/superElemDelete.js
@@ -421,7 +419,6 @@ non262/lexical-environment/unscopables-const.js
 non262/lexical-environment/unscopables-delete.js
 non262/lexical-environment/unscopables-mutation.js
 non262/lexical-environment/unscopables-proto.js
-non262/lexical-environment/unscopables-proxy.js
 non262/lexical-environment/unscopables-strict.js
 non262/lexical-environment/var-in-catch-body-annex-b-eval-destructuring.js
 non262/lexical-environment/var-in-catch-body-annex-b-eval-for-of.js
@@ -443,8 +440,6 @@ non262/object/destructuring-shorthand-defaults.js
 non262/object/entries.js
 non262/object/freeze-global-eval-const.js
 non262/object/freeze-proxy.js
-non262/object/property-descriptor-order.js
-non262/object/propertyIsEnumerable-proxy.js
 non262/object/regress-444787.js
 non262/object/seal-proxy.js
 non262/object/setPrototypeOf-cycle.js
@@ -496,7 +491,6 @@ non262/reflect-parse/stackOverflow.js
 non262/reflect-parse/statements.js
 non262/reflect-parse/templateStrings.js
 non262/Reflect/set.js
-non262/Reflect/setPrototypeOf.js
 non262/RegExp/character-class-escape-s.js
 non262/RegExp/character-escape-class-s-mongolian-vowel-separator.js
 non262/RegExp/compile-lastIndex.js


### PR DESCRIPTION
* Create a property only when each field of desc presents at fromObjectPropertyDescriptor
* Add a ArrayIteratorPrototypeObject
* Call iteratorClose correctly at Array.from

Signed-off-by: Boram Bae <boram21.bae@samsung.com>