### PR TITLE
Optimize script initialization performance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ def isPr() {
     env.CHANGE_ID != null
 }
 
-timeout(20) {
+timeout(30) {
     node {
         try {
             stage("Get source") {

--- a/build/config.cmake
+++ b/build/config.cmake
@@ -50,7 +50,6 @@ SET (ESCARGOT_CXXFLAGS
     -Wno-unused-parameter
     -Wno-type-limits -Wno-unused-result -Wno-unused-variable -Wno-invalid-offsetof
     -Wno-deprecated-declarations
-    -Wno-implicit-fallthrough
 )
 
 IF (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")

--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -1376,8 +1376,10 @@ static void markEvalToCodeblock(InterpretedCodeBlock* cb)
     cb->setHasEval();
     cb->computeVariables();
 
-    for (size_t i = 0; i < cb->childBlocks().size(); i++) {
-        markEvalToCodeblock(cb->childBlocks()[i]->asInterpretedCodeBlock());
+    InterpretedCodeBlock* child = cb->firstChild();
+    while (child) {
+        markEvalToCodeblock(child);
+        child = child->nextSibling();
     }
 }
 

--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -100,18 +100,20 @@ int getValidValueInInterpretedCodeBlock(void* ptr, GC_mark_custom_result* arr)
     arr[3].to = (GC_word*)current->m_parameterNames.data();
     arr[4].from = (GC_word*)&current->m_parentCodeBlock;
     arr[4].to = (GC_word*)current->m_parentCodeBlock;
-    arr[5].from = (GC_word*)&current->m_childBlocks;
-    arr[5].to = (GC_word*)current->m_childBlocks.data();
-    arr[6].from = (GC_word*)&current->m_byteCodeBlock;
-    arr[6].to = (GC_word*)current->m_byteCodeBlock;
-    arr[7].from = (GC_word*)&current->m_blockInfos;
-    arr[7].to = (GC_word*)current->m_blockInfos.data();
+    arr[5].from = (GC_word*)&current->m_nextSibling;
+    arr[5].to = (GC_word*)current->m_nextSibling;
+    arr[6].from = (GC_word*)&current->m_firstChild;
+    arr[6].to = (GC_word*)current->m_firstChild;
+    arr[7].from = (GC_word*)&current->m_byteCodeBlock;
+    arr[7].to = (GC_word*)current->m_byteCodeBlock;
+    arr[8].from = (GC_word*)&current->m_blockInfos;
+    arr[8].to = (GC_word*)current->m_blockInfos.data();
 #ifdef NDEBUG
-    arr[8].from = (GC_word*)&current->m_context;
-    arr[8].to = (GC_word*)nullptr;
+    arr[9].from = (GC_word*)&current->m_context;
+    arr[9].to = (GC_word*)nullptr;
 #else
-    arr[8].from = (GC_word*)&current->m_scopeContext;
-    arr[8].to = (GC_word*)current->m_scopeContext;
+    arr[9].from = (GC_word*)&current->m_scopeContext;
+    arr[9].to = (GC_word*)current->m_scopeContext;
 #endif
     return 0;
 }
@@ -147,7 +149,7 @@ void initializeCustomAllocators()
                                                                       TRUE);
 
     s_gcKinds[HeapObjectKind::InterpretedCodeBlockKind] = GC_new_kind_enumerable(GC_new_free_list(),
-                                                                                 GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 9>), 0),
+                                                                                 GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 10>), 0),
                                                                                  FALSE,
                                                                                  TRUE);
 }

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -60,7 +60,8 @@ void* InterpretedCodeBlock::operator new(size_t size)
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_blockInfos));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_parameterNames));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_parentCodeBlock));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_childBlocks));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_firstChild));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_nextSibling));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_byteCodeBlock));
 #ifndef NDEBUG
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_scopeContext));
@@ -114,6 +115,8 @@ CodeBlock::CodeBlock(Context* ctx, const NativeFunctionInfo& info)
     , m_hasImplictFunctionName(false)
     , m_hasArrowParameterPlaceHolder(false)
     , m_hasParameterOtherThanIdentifier(false)
+    , m_allowSuperCall(false)
+    , m_allowSuperProperty(false)
     , m_parameterCount(info.m_argumentCount)
     , m_functionName(info.m_name)
 {
@@ -152,6 +155,8 @@ CodeBlock::CodeBlock(Context* ctx, AtomicString name, size_t argc, bool isStrict
     , m_hasImplictFunctionName(false)
     , m_hasArrowParameterPlaceHolder(false)
     , m_hasParameterOtherThanIdentifier(false)
+    , m_allowSuperCall(false)
+    , m_allowSuperProperty(false)
     , m_parameterCount(argc)
     , m_functionName(name)
     , m_nativeFunctionData(info)
@@ -196,6 +201,8 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     , m_lexicalBlockStackAllocatedIdentifierMaximumDepth(0)
     , m_lexicalBlockIndexFunctionLocatedIn(0)
     , m_parentCodeBlock(nullptr)
+    , m_firstChild(nullptr)
+    , m_nextSibling(nullptr)
 #ifndef NDEBUG
     , m_bodyStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
     , m_bodyEndLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
@@ -270,6 +277,8 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     , m_lexicalBlockStackAllocatedIdentifierMaximumDepth(0)
     , m_lexicalBlockIndexFunctionLocatedIn(scopeCtx->m_lexicalBlockIndexFunctionLocatedIn)
     , m_parentCodeBlock(parentBlock)
+    , m_firstChild(nullptr)
+    , m_nextSibling(nullptr)
 #ifndef NDEBUG
     , m_bodyStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
     , m_bodyEndLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)

--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -169,8 +169,8 @@ struct ASTFunctionScopeContext : public gc {
     AtomicStringTightVector m_parameters;
     AtomicString m_functionName;
 
-    // TODO save these scopes as linked-list
-    Vector<ASTFunctionScopeContext *, GCUtil::gc_malloc_allocator<ASTFunctionScopeContext *>> m_childScopes;
+    ASTFunctionScopeContext *m_firstChild;
+    ASTFunctionScopeContext *m_nextSibling;
     ASTBlockScopeContextVector m_childBlockScopes;
 
     // we can use atomic allocator here because there is no pointer value on Vector<m_numeralLiteralData>
@@ -186,6 +186,30 @@ struct ASTFunctionScopeContext : public gc {
 
     void *operator new(size_t size);
     void *operator new[](size_t size) = delete;
+
+    void appendChild(ASTFunctionScopeContext *child)
+    {
+        ASSERT(child->m_nextSibling == nullptr);
+        if (m_firstChild == nullptr) {
+            m_firstChild = child;
+        } else {
+            ASTFunctionScopeContext *tail = firstChild();
+            while (tail->m_nextSibling != nullptr) {
+                tail = tail->m_nextSibling;
+            }
+            tail->m_nextSibling = child;
+        }
+    }
+
+    ASTFunctionScopeContext *firstChild()
+    {
+        return m_firstChild;
+    }
+
+    ASTFunctionScopeContext *nextSibling()
+    {
+        return m_nextSibling;
+    }
 
     bool hasVarName(AtomicString name)
     {
@@ -402,6 +426,8 @@ struct ASTFunctionScopeContext : public gc {
         , m_allowSuperProperty(false)
         , m_nodeType(ASTNodeType::Program)
         , m_lexicalBlockIndexFunctionLocatedIn(LEXICAL_BLOCK_INDEX_MAX)
+        , m_firstChild(nullptr)
+        , m_nextSibling(nullptr)
         , m_paramsStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
         , m_bodyStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
 #ifndef NDEBUG

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -64,7 +64,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::ArrowFunctionExpression; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstIndex) override
     {
-        CodeBlock* blk = context->m_codeBlock->asInterpretedCodeBlock()->childBlocks()[m_subCodeBlockIndex];
+        CodeBlock* blk = context->m_codeBlock->asInterpretedCodeBlock()->childBlockAt(m_subCodeBlockIndex);
         if (blk->usesArgumentsObject() && !codeBlock->m_codeBlock->isArrowFunctionExpression()) {
             codeBlock->pushCode(EnsureArgumentsObject(ByteCodeLOC(m_loc.index)), context, this);
         }

--- a/src/parser/ast/ForInOfStatementNode.h
+++ b/src/parser/ast/ForInOfStatementNode.h
@@ -149,10 +149,10 @@ public:
         size_t exit1Pos, exit2Pos, exit3Pos, continuePosition;
         // for-of only
         TryStatementNode::TryStatementByteCodeContext forOfTryStatmentContext;
-        ByteCodeRegisterIndex finishCheckRegisterIndex, iteratorDataRegisterIndex;
-        size_t forOfEndCheckRegisterHeadStartPosition;
-        size_t forOfEndCheckRegisterHeadEndPosition;
-        size_t forOfEndCheckRegisterBodyEndPosition;
+        ByteCodeRegisterIndex finishCheckRegisterIndex = REGISTER_LIMIT, iteratorDataRegisterIndex = REGISTER_LIMIT;
+        size_t forOfEndCheckRegisterHeadStartPosition = SIZE_MAX;
+        size_t forOfEndCheckRegisterHeadEndPosition = SIZE_MAX;
+        size_t forOfEndCheckRegisterBodyEndPosition = SIZE_MAX;
 
         if (m_forIn) {
             // for-in statement

--- a/src/parser/ast/FunctionExpressionNode.h
+++ b/src/parser/ast/FunctionExpressionNode.h
@@ -36,7 +36,7 @@ public:
     ASTFunctionScopeContext* scopeContext() { return m_scopeContext; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstIndex) override
     {
-        CodeBlock* blk = context->m_codeBlock->asInterpretedCodeBlock()->childBlocks()[m_subCodeBlockIndex];
+        CodeBlock* blk = context->m_codeBlock->asInterpretedCodeBlock()->childBlockAt(m_subCodeBlockIndex);
         if (UNLIKELY(blk->isClassConstructor())) {
             codeBlock->pushCode(CreateClass(ByteCodeLOC(m_loc.index), dstIndex, context->m_classInfo.m_prototypeIndex, context->m_classInfo.m_superIndex, blk, context->m_classInfo.m_src), context, this);
         } else if (UNLIKELY(blk->isClassMethod() || blk->isClassStaticMethod())) {

--- a/src/parser/ast/Node.cpp
+++ b/src/parser/ast/Node.cpp
@@ -76,7 +76,8 @@ void* ASTFunctionScopeContext::operator new(size_t size)
         GC_word obj_bitmap[GC_BITMAP_SIZE(ASTFunctionScopeContext)] = { 0 };
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_varNames));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_parameters));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_childScopes));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_firstChild));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_nextSibling));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_childBlockScopes));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_numeralLiteralData));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(ASTFunctionScopeContext));

--- a/src/parser/ast/StatementNode.h
+++ b/src/parser/ast/StatementNode.h
@@ -38,13 +38,13 @@ public:
         return true;
     }
 
-    StatementNode* nextSilbing()
+    StatementNode* nextSibling()
     {
-        return m_nextSilbing.get();
+        return m_nextSibling.get();
     }
 
 private:
-    RefPtr<StatementNode> m_nextSilbing;
+    RefPtr<StatementNode> m_nextSibling;
 };
 
 class StatementContainer : public RefCounted<StatementContainer> {
@@ -62,7 +62,7 @@ public:
         }
 
         do {
-            RefPtr<StatementNode> next = c->m_nextSilbing.release();
+            RefPtr<StatementNode> next = c->m_nextSibling.release();
             c.release();
             c = next;
         } while (c);
@@ -73,7 +73,7 @@ public:
         StatementNode* nd = firstChild();
         while (nd) {
             nd->generateStatementByteCode(codeBlock, context);
-            nd = nd->nextSilbing();
+            nd = nd->nextSibling();
         }
     }
 
@@ -82,7 +82,7 @@ public:
         StatementNode* nd = firstChild();
         while (nd) {
             nd->iterateChildren(fn);
-            nd = nd->nextSilbing();
+            nd = nd->nextSibling();
         }
     }
 
@@ -104,7 +104,7 @@ public:
             appendChild(child);
         } else {
             ASSERT(referNode->isStatement());
-            referNode->asStatement()->m_nextSilbing = child;
+            referNode->asStatement()->m_nextSibling = child;
         }
         return child;
     }
@@ -112,19 +112,19 @@ public:
     StatementNode* appendChild(Node* c)
     {
         ASSERT(c->isStatement());
-        ASSERT(c->asStatement()->nextSilbing() == nullptr);
+        ASSERT(c->asStatement()->nextSibling() == nullptr);
         StatementNode* child = c->asStatement();
         if (m_firstChild == nullptr) {
             m_firstChild = child;
         } else {
             StatementNode* tail = firstChild();
-            while (tail->m_nextSilbing != nullptr) {
-                tail = tail->m_nextSilbing.get();
+            while (tail->m_nextSibling != nullptr) {
+                tail = tail->m_nextSibling.get();
             }
-            tail->m_nextSilbing = child;
+            tail->m_nextSibling = child;
         }
         return child;
-    };
+    }
 
     StatementNode* firstChild()
     {

--- a/src/parser/ast/SwitchStatementNode.h
+++ b/src/parser/ast/SwitchStatementNode.h
@@ -65,7 +65,7 @@ public:
             codeBlock->pushCode(JumpIfTrue(ByteCodeLOC(m_loc.index), resultIndex), &newContext, this);
             newContext.giveUpRegister();
             newContext.giveUpRegister();
-            nd = nd->nextSilbing();
+            nd = nd->nextSibling();
         }
 
         ASSERT(rIndex0 == newContext.getLastRegisterIndex());
@@ -80,7 +80,7 @@ public:
             codeBlock->pushCode(JumpIfTrue(ByteCodeLOC(m_loc.index), resultIndex), &newContext, this);
             newContext.giveUpRegister();
             newContext.giveUpRegister();
-            nd = nd->nextSilbing();
+            nd = nd->nextSibling();
         }
 
         newContext.giveUpRegister();
@@ -95,7 +95,7 @@ public:
             SwitchCaseNode* caseNode = (SwitchCaseNode*)nd;
             codeBlock->peekCode<JumpIfTrue>(jumpCodePerCaseNodePosition[caseIdx++])->m_jumpPosition = codeBlock->currentCodeSize();
             caseNode->generateStatementByteCode(codeBlock, &newContext);
-            nd = nd->nextSilbing();
+            nd = nd->nextSibling();
         }
         if (m_default) {
             codeBlock->peekCode<Jump>(jmpToDefault)->m_jumpPosition = codeBlock->currentCodeSize();
@@ -106,7 +106,7 @@ public:
             SwitchCaseNode* caseNode = (SwitchCaseNode*)nd;
             codeBlock->peekCode<JumpIfTrue>(jumpCodePerCaseNodePosition[caseIdx++])->m_jumpPosition = codeBlock->currentCodeSize();
             caseNode->generateStatementByteCode(codeBlock, &newContext);
-            nd = nd->nextSilbing();
+            nd = nd->nextSibling();
         }
         size_t breakPos = codeBlock->currentCodeSize();
         newContext.consumeBreakPositions(codeBlock, breakPos, context->tryCatchWithBlockStatementCount());

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -142,7 +142,7 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
     String* scriptSource = src.finalize(&state);
 
     Script* script = parser.initializeScript(StringView(scriptSource, 0, scriptSource->length()), new ASCIIString("Function Constructor input"), false, nullptr, false, false, false, false, SIZE_MAX, false, allowSuperCall, false).scriptThrowsExceptionIfParseError(state);
-    InterpretedCodeBlock* cb = script->topCodeBlock()->childBlocks()[0];
+    InterpretedCodeBlock* cb = script->topCodeBlock()->firstChild();
     cb->updateSourceElementStart(3, 1);
     LexicalEnvironment* globalEnvironment = new LexicalEnvironment(new GlobalEnvironmentRecord(state, script->topCodeBlock(), state.context()->globalObject(), &state.context()->globalDeclarativeRecord(), &state.context()->globalDeclarativeStorage()), nullptr);
 

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -227,7 +227,6 @@ namespace Escargot {
     F(cosh)                       \
     F(codePointAt)                \
     F(create)                     \
-    F(dbgBreak)                   \
     F(decodeURI)                  \
     F(decodeURIComponent)         \
     F(defineProperties)           \

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -146,7 +146,7 @@ static OptionalRef<StringRef> builtinHelperFileRead(OptionalRef<ExecutionStateRe
         StringRef* src = StringRef::emptyString();
         std::string utf8Str;
         std::basic_string<unsigned char, std::char_traits<unsigned char>> str;
-        char buf[8];
+        char buf[512];
         bool hasNonLatin1Content = false;
         size_t readLen;
         while ((readLen = fread(buf, 1, sizeof buf, fp))) {


### PR DESCRIPTION
* Store child {ASTFunctionContext, InterpretedCodeBlock} as linked-list
* Reduce size of ScannerResult
* Remove Parser::scopeContexts
* Fix compile error in old system

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>