### PR TITLE
Optimized and fixing executeEnumerateObject in ByteCodeInterpreter.cpp

### DIFF
--- a/tools/test/v8/v8.mjsunit.status
+++ b/tools/test/v8/v8.mjsunit.status
@@ -833,7 +833,6 @@
   'regress/regress-4255-2': [SKIP],
   'regress/regress-4255-3': [SKIP],
   'regress/regress-4665': [SKIP],
-  'regress/regress-4825': [SKIP],
   'regress/regress-crbug-100859': [SKIP],
   'regress/regress-crbug-352586': [SKIP],
   'regress/regress-crbug-422858': [SKIP],


### PR DESCRIPTION
Basically when we iterated an object's keys, it was not in ascending order.
Also when one of the keys enumerable was changed to false, it was still in the list.
Enabled one V8 test.

Signed-off-by: bence gabor kis <kisbg@inf.u-szeged.hu>