### PR TITLE
Optimize script initialization performance

### DIFF
--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -289,6 +289,18 @@ typedef int32_t UChar32;
 #define UNUSED_PARAMETER(variable) (void)variable
 #endif
 
+#if !defined(FALLTHROUGH) && defined(COMPILER_GCC)
+#if __GNUC__ >= 7
+#define FALLTHROUGH __attribute__((fallthrough))
+#else
+#define FALLTHROUGH ((void)0)
+#endif
+#elif !defined(FALLTHROUGH) && defined(COMPILER_CLANG)
+#define FALLTHROUGH /* fall through */
+#else
+#define FALLTHROUGH
+#endif
+
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER == __LITTLE_ENDIAN || defined(__LITTLE_ENDIAN__) || defined(__i386) || defined(_M_IX86) || defined(__ia64) || defined(__ia64__) || defined(_M_IA64) || defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__) || defined(ANDROID)
 #define ESCARGOT_LITTLE_ENDIAN
 // #pragma message "little endian"

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -122,7 +122,13 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
     }
     ParserContextInformation info(isEvalMode, isGlobalScope, codeBlock->isStrict(), inWithFromRuntime || codeBlock->inWith());
 
-    Vector<Value, GCUtil::gc_malloc_atomic_allocator<Value>>* nData = &scopeCtx->m_numeralLiteralData;
+    NumeralLiteralVector* nData = nullptr;
+
+    if (ast->type() == ASTNodeType::Program) {
+        nData = &((ProgramNode*)ast)->numeralLiteralVector();
+    } else {
+        nData = &((FunctionNode*)ast)->numeralLiteralVector();
+    }
 
     if (nData->size() == 0) {
         nData = nullptr;

--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -70,7 +70,7 @@ struct ByteCodeGenerateError {
 };
 
 struct ByteCodeGenerateContext {
-    ByteCodeGenerateContext(CodeBlock* codeBlock, ByteCodeBlock* byteCodeBlock, ParserContextInformation& parserContextInformation, Vector<Value, GCUtil::gc_malloc_atomic_allocator<Value>>* numeralLiteralData)
+    ByteCodeGenerateContext(CodeBlock* codeBlock, ByteCodeBlock* byteCodeBlock, ParserContextInformation& parserContextInformation, NumeralLiteralVector* numeralLiteralData)
         : m_baseRegisterCount(0)
         , m_codeBlock(codeBlock)
         , m_byteCodeBlock(byteCodeBlock)
@@ -344,7 +344,7 @@ struct ByteCodeGenerateContext {
     ClassContextInformation m_classInfo;
     std::map<size_t, size_t> m_complexCaseStatementPositions;
     size_t m_maxYieldStatementExtraDataLength;
-    Vector<Value, GCUtil::gc_malloc_atomic_allocator<Value>>* m_numeralLiteralData;
+    NumeralLiteralVector* m_numeralLiteralData;
 };
 
 class ByteCodeGenerator {

--- a/src/parser/Lexer.h
+++ b/src/parser/Lexer.h
@@ -243,6 +243,7 @@ public:
             , startWithZero(false)
             , octal(false)
             , hasAllocatedString(false)
+            , hasNonComputedNumberLiteral(false)
             , hasKeywordButUseString(false)
             , prec(0)
             , lineNumber(0)
@@ -260,6 +261,7 @@ public:
         bool startWithZero : 1;
         bool octal : 1;
         bool hasAllocatedString : 1;
+        bool hasNonComputedNumberLiteral : 1;
         bool hasKeywordButUseString : 1;
         unsigned char prec : 8; // max prec is 11
         // we don't needs init prec.
@@ -282,6 +284,7 @@ public:
         StringView relatedSource(const StringView& source);
         StringView valueStringLiteral(Scanner* scannerInstance);
         Value valueStringLiteralForAST(Scanner* scannerInstance);
+        double valueNumberLiteral(Scanner* scannerInstance);
 
         inline operator bool() const
         {
@@ -299,6 +302,7 @@ public:
             this->startWithZero = false;
             this->octal = false;
             this->hasAllocatedString = false;
+            this->hasNonComputedNumberLiteral = false;
             this->hasKeywordButUseString = false;
             this->lineNumber = lineNumber;
             this->lineStart = lineStart;
@@ -307,12 +311,43 @@ public:
             this->valueNumber = 0;
         }
 
-        void setResult(Token type, String* s, size_t lineNumber, size_t lineStart, size_t start, size_t end)
+        void setPunctuatorResult(size_t lineNumber, size_t lineStart, size_t start, size_t end, PunctuatorKind p)
+        {
+            this->type = Token::PunctuatorToken;
+            this->startWithZero = false;
+            this->octal = false;
+            this->hasAllocatedString = false;
+            this->hasNonComputedNumberLiteral = false;
+            this->hasKeywordButUseString = false;
+            this->lineNumber = lineNumber;
+            this->lineStart = lineStart;
+            this->start = start;
+            this->end = end;
+            this->valuePunctuatorKind = p;
+        }
+
+        void setKeywordResult(size_t lineNumber, size_t lineStart, size_t start, size_t end, KeywordKind p)
+        {
+            this->type = Token::KeywordToken;
+            this->startWithZero = false;
+            this->octal = false;
+            this->hasAllocatedString = false;
+            this->hasNonComputedNumberLiteral = false;
+            this->hasKeywordButUseString = false;
+            this->lineNumber = lineNumber;
+            this->lineStart = lineStart;
+            this->start = start;
+            this->end = end;
+            this->valueKeywordKind = p;
+        }
+
+        void setResult(Token type, String* s, size_t lineNumber, size_t lineStart, size_t start, size_t end, bool octal = false)
         {
             this->type = type;
             this->startWithZero = false;
-            this->octal = false;
+            this->octal = octal;
             this->hasKeywordButUseString = true;
+            this->hasNonComputedNumberLiteral = false;
             this->lineNumber = lineNumber;
             this->lineStart = lineStart;
             this->start = start;
@@ -322,12 +357,13 @@ public:
             this->valueStringLiteralData.m_stringIfNewlyAllocated = s;
         }
 
-        void setResult(Token type, size_t stringStart, size_t stringEnd, size_t lineNumber, size_t lineStart, size_t start, size_t end)
+        void setResult(Token type, size_t stringStart, size_t stringEnd, size_t lineNumber, size_t lineStart, size_t start, size_t end, bool octal = false)
         {
             this->type = type;
             this->startWithZero = false;
-            this->octal = false;
+            this->octal = octal;
             this->hasKeywordButUseString = true;
+            this->hasNonComputedNumberLiteral = false;
             this->lineNumber = lineNumber;
             this->lineStart = lineStart;
             this->start = start;
@@ -339,13 +375,14 @@ public:
             ASSERT(this->valueStringLiteralData.m_start <= this->valueStringLiteralData.m_end);
         }
 
-        void setResult(Token type, double value, size_t lineNumber, size_t lineStart, size_t start, size_t end)
+        void setNumericLiteralResult(double value, size_t lineNumber, size_t lineStart, size_t start, size_t end, bool hasNonComputedNumberLiteral)
         {
-            this->type = type;
+            this->type = Token::NumericLiteralToken;
             this->startWithZero = false;
             this->octal = false;
             this->hasAllocatedString = false;
             this->hasKeywordButUseString = true;
+            this->hasNonComputedNumberLiteral = hasNonComputedNumberLiteral;
             this->lineNumber = lineNumber;
             this->lineStart = lineStart;
             this->start = start;
@@ -353,13 +390,14 @@ public:
             this->valueNumber = value;
         }
 
-        void setResult(Token type, ScanTemplateResult* value, size_t lineNumber, size_t lineStart, size_t start, size_t end)
+        void setTemplateTokenResult(ScanTemplateResult* value, size_t lineNumber, size_t lineStart, size_t start, size_t end)
         {
-            this->type = type;
+            this->type = Token::TemplateToken;
             this->startWithZero = false;
             this->octal = false;
             this->hasAllocatedString = false;
             this->hasKeywordButUseString = true;
+            this->hasNonComputedNumberLiteral = false;
             this->lineNumber = lineNumber;
             this->lineStart = lineStart;
             this->start = start;

--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -156,7 +156,6 @@ struct ASTFunctionScopeContext : public gc {
     bool m_isClassStaticMethod : 1;
     bool m_isGenerator : 1;
     bool m_hasSuperOrNewTarget : 1;
-    bool m_hasManyNumeralLiteral : 1;
     bool m_hasArrowParameterPlaceHolder : 1;
     bool m_hasParameterOtherThanIdentifier : 1;
     bool m_needsToComputeLexicalBlockStuffs : 1;
@@ -172,9 +171,6 @@ struct ASTFunctionScopeContext : public gc {
     ASTFunctionScopeContext *m_firstChild;
     ASTFunctionScopeContext *m_nextSibling;
     ASTBlockScopeContextVector m_childBlockScopes;
-
-    // we can use atomic allocator here because there is no pointer value on Vector<m_numeralLiteralData>
-    Vector<Value, GCUtil::gc_malloc_atomic_allocator<Value>> m_numeralLiteralData;
 
     ExtendedNodeLOC m_paramsStartLOC;
     ExtendedNodeLOC m_bodyStartLOC;
@@ -293,22 +289,6 @@ struct ASTFunctionScopeContext : public gc {
         }
     }
 
-    void insertNumeralLiteral(Value v)
-    {
-        ASSERT(!v.isPointerValue());
-        if (m_hasManyNumeralLiteral) {
-            return;
-        }
-        if (VectorUtil::findInVector(m_numeralLiteralData, v) == VectorUtil::invalidIndex) {
-            if (m_numeralLiteralData.size() < KEEP_NUMERAL_LITERDATA_IN_REGISTERFILE_LIMIT)
-                m_numeralLiteralData.push_back(v);
-            else {
-                m_numeralLiteralData.clear();
-                m_hasManyNumeralLiteral = true;
-            }
-        }
-    }
-
     void insertBlockScope(LexicalBlockIndex blockIndex, LexicalBlockIndex parentBlockIndex, ExtendedNodeLOC loc)
     {
 #ifndef NDEBUG
@@ -417,7 +397,6 @@ struct ASTFunctionScopeContext : public gc {
         , m_isClassStaticMethod(false)
         , m_isGenerator(false)
         , m_hasSuperOrNewTarget(false)
-        , m_hasManyNumeralLiteral(false)
         , m_hasArrowParameterPlaceHolder(false)
         , m_hasParameterOtherThanIdentifier(false)
         , m_needsToComputeLexicalBlockStuffs(false)

--- a/src/parser/ast/FunctionNode.h
+++ b/src/parser/ast/FunctionNode.h
@@ -28,10 +28,11 @@ namespace Escargot {
 
 class FunctionNode : public StatementNode {
 public:
-    FunctionNode(StatementContainer* params, BlockStatementNode* body)
+    FunctionNode(StatementContainer* params, BlockStatementNode* body, NumeralLiteralVector&& numeralLiteralVector)
         : StatementNode()
         , m_params(params)
         , m_body(body)
+        , m_numeralLiteralVector(std::move(numeralLiteralVector))
     {
     }
 
@@ -39,6 +40,7 @@ public:
     {
     }
 
+    NumeralLiteralVector& numeralLiteralVector() { return m_numeralLiteralVector; }
     virtual ASTNodeType type() override { return ASTNodeType::Function; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
@@ -55,6 +57,7 @@ public:
 private:
     RefPtr<StatementContainer> m_params;
     RefPtr<BlockStatementNode> m_body;
+    NumeralLiteralVector m_numeralLiteralVector;
 };
 }
 

--- a/src/parser/ast/Node.cpp
+++ b/src/parser/ast/Node.cpp
@@ -79,7 +79,6 @@ void* ASTFunctionScopeContext::operator new(size_t size)
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_firstChild));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_nextSibling));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_childBlockScopes));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_numeralLiteralData));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(ASTFunctionScopeContext));
         typeInited = true;
     }

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -487,6 +487,8 @@ public:
 };
 
 typedef std::vector<RefPtr<Node>> NodeVector;
+// we can use atomic allocator here because there is no pointer value on Vector
+typedef VectorWithInlineStorage<KEEP_NUMERAL_LITERDATA_IN_REGISTERFILE_LIMIT, Value, GCUtil::gc_malloc_atomic_allocator<Value>> NumeralLiteralVector;
 }
 
 #endif

--- a/src/parser/ast/ProgramNode.h
+++ b/src/parser/ast/ProgramNode.h
@@ -30,11 +30,12 @@ namespace Escargot {
 class ProgramNode : public StatementNode {
 public:
     friend class ScriptParser;
-    ProgramNode(StatementContainer* body, ASTFunctionScopeContext* scopeContext, Script::ModuleData* moduleData)
+    ProgramNode(StatementContainer* body, ASTFunctionScopeContext* scopeContext, Script::ModuleData* moduleData, NumeralLiteralVector&& numeralLiteralVector)
         : StatementNode()
         , m_container(body)
         , m_scopeContext(scopeContext)
         , m_moduleData(moduleData)
+        , m_numeralLiteralVector(std::move(numeralLiteralVector))
     {
     }
 
@@ -46,6 +47,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::Program; }
     ASTFunctionScopeContext* scopeContext() { return m_scopeContext; }
     Script::ModuleData* moduleData() { return m_moduleData; }
+    NumeralLiteralVector& numeralLiteralVector() { return m_numeralLiteralVector; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
         InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(0);
@@ -70,6 +72,7 @@ private:
     RefPtr<StatementContainer> m_container;
     ASTFunctionScopeContext* m_scopeContext;
     Script::ModuleData* m_moduleData;
+    NumeralLiteralVector m_numeralLiteralVector;
 };
 }
 

--- a/src/runtime/AtomicString.cpp
+++ b/src/runtime/AtomicString.cpp
@@ -109,6 +109,7 @@ void AtomicString::init(AtomicStringMap* ec, String* name)
         m_string = (String*)(v & ~POINTER_VALUE_STRING_TAG_IN_DATA);
         return;
     }
+
     auto iter = ec->find(name);
     if (ec->end() == iter) {
         ec->insert(name);

--- a/third_party/yarr/WTFBridge.h
+++ b/third_party/yarr/WTFBridge.h
@@ -215,10 +215,6 @@ const size_t notFound = static_cast<size_t>(-1);
 #define HAVE_MMAP 1
 #endif
 
-#if !defined(FALLTHROUGH)
-#define FALLTHROUGH
-#endif
-
 #define WTFMove std::move
 
 // NOTE there is no make_unique in c++11


### PR DESCRIPTION
* Build numeral literal number in token only if needs
* Build string literal for ast only if needs
* Move NumeralData from ASTContext to ASTNode
* Fix compile error on gcc 7+

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>