### PR TITLE
Fix various bugs detected from vendor tests.

### DIFF
--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -219,11 +219,11 @@ void ArrayObject::enumeration(ExecutionState& state, bool (*callback)(ExecutionS
     Object::enumeration(state, callback, data, shouldSkipSymbolKey);
 }
 
-void ArrayObject::sort(ExecutionState& state, const std::function<bool(const Value& a, const Value& b)>& comp)
+void ArrayObject::sort(ExecutionState& state, int64_t length, const std::function<bool(const Value& a, const Value& b)>& comp)
 {
     if (isFastModeArray()) {
-        if (getArrayLength(state)) {
-            size_t orgLength = getArrayLength(state);
+        if (length) {
+            size_t orgLength = length;
             Value* tempBuffer = (Value*)GC_MALLOC(sizeof(Value) * orgLength);
 
             for (size_t i = 0; i < orgLength; i++) {
@@ -253,7 +253,7 @@ void ArrayObject::sort(ExecutionState& state, const std::function<bool(const Val
         }
         return;
     }
-    Object::sort(state, comp);
+    Object::sort(state, length, comp);
 }
 
 void* ArrayObject::operator new(size_t size)

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -73,7 +73,7 @@ public:
     {
         return getArrayLength(state);
     }
-    virtual void sort(ExecutionState& state, const std::function<bool(const Value& a, const Value& b)>& comp) override;
+    virtual void sort(ExecutionState& state, int64_t length, const std::function<bool(const Value& a, const Value& b)>& comp) override;
     virtual ObjectGetResult getIndexedProperty(ExecutionState& state, const Value& property) override;
     virtual ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override;
     virtual bool setIndexedProperty(ExecutionState& state, const Value& property, const Value& value) override;

--- a/src/runtime/GlobalObjectBuiltinArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinArray.cpp
@@ -347,7 +347,8 @@ static Value builtinArrayJoin(ExecutionState& state, Value thisValue, size_t arg
                     Data* e = (Data*)data;
                     int64_t* ret = &e->ret;
                     Value key = name.toPlainValue(state);
-                    if ((index = key.toArrayIndex(state)) != Value::InvalidArrayIndexValue) {
+                    index = key.toIndex(state);
+                    if ((uint64_t)index != Value::InvalidIndexValue) {
                         if (self->get(state, name).value(state, self).isUndefined()) {
                             return true;
                         }
@@ -441,7 +442,9 @@ static Value builtinArraySort(ExecutionState& state, Value thisValue, size_t arg
     }
     bool defaultSort = (argc == 0) || cmpfn.isUndefined();
 
-    thisObject->sort(state, [defaultSort, &cmpfn, &state](const Value& a, const Value& b) -> bool {
+    int64_t len = thisObject->lengthES6(state);
+
+    thisObject->sort(state, len, [defaultSort, &cmpfn, &state](const Value& a, const Value& b) -> bool {
         if (a.isEmpty() && b.isUndefined())
             return false;
         if (a.isUndefined() && b.isEmpty())

--- a/src/runtime/GlobalObjectBuiltinTypedArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinTypedArray.cpp
@@ -831,7 +831,7 @@ static Value builtinTypedArraySort(ExecutionState& state, Value thisValue, size_
     ArrayBufferObject* buffer = validateTypedArray(state, O, state.context()->staticStrings().sort.string());
 
     // Let len be the value of O’s [[ArrayLength]] internal slot.
-    double len = O->asArrayBufferView()->arrayLength();
+    int64_t len = O->asArrayBufferView()->arrayLength();
 
     Value cmpfn = argv[0];
     if (!cmpfn.isUndefined() && !cmpfn.isCallable()) {
@@ -840,7 +840,7 @@ static Value builtinTypedArraySort(ExecutionState& state, Value thisValue, size_
     bool defaultSort = (argc == 0) || cmpfn.isUndefined();
 
     // [defaultSort, &cmpfn, &state, &buffer]
-    O->sort(state, [&](const Value& x, const Value& y) -> bool {
+    O->sort(state, len, [&](const Value& x, const Value& y) -> bool {
         ASSERT(x.isNumber() && y.isNumber());
         if (!defaultSort) {
             Value args[] = { x, y };

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -891,7 +891,7 @@ public:
     static bool nextIndexForward(ExecutionState& state, Object* obj, const int64_t cur, const int64_t len, int64_t& nextIndex);
     static bool nextIndexBackward(ExecutionState& state, Object* obj, const int64_t cur, const int64_t end, int64_t& nextIndex);
 
-    virtual void sort(ExecutionState& state, const std::function<bool(const Value& a, const Value& b)>& comp);
+    virtual void sort(ExecutionState& state, int64_t length, const std::function<bool(const Value& a, const Value& b)>& comp);
 
     virtual bool isInlineCacheable()
     {

--- a/src/runtime/ProxyObject.cpp
+++ b/src/runtime/ProxyObject.cpp
@@ -159,7 +159,7 @@ bool ProxyObject::defineOwnProperty(ExecutionState& state, const ObjectPropertyN
     // a. Let settingConfigFalse be true.
     // 18. Else let settingConfigFalse be false.
     bool settingConfigFalse = false;
-    if (!desc.isConfigurable()) {
+    if (desc.isConfigurablePresent() && !desc.isConfigurable()) {
         settingConfigFalse = true;
     }
 
@@ -447,7 +447,7 @@ ObjectHasPropertyResult ProxyObject::hasProperty(ExecutionState& state, const Ob
     if (booleanTrapResult) {
         return ObjectHasPropertyResult([](ExecutionState& state, const ObjectPropertyName& P, void* handlerData) -> Value {
             ProxyObject* p = (ProxyObject*)handlerData;
-            return p->getOwnProperty(state, P).value(state, p);
+            return p->get(state, P).value(state, p);
         },
                                        this);
     }

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -360,25 +360,24 @@ public:
         return true;
     }
 
-    virtual void sort(ExecutionState& state, const std::function<bool(const Value& a, const Value& b)>& comp) override
+    virtual void sort(ExecutionState& state, int64_t length, const std::function<bool(const Value& a, const Value& b)>& comp) override
     {
-        size_t arrayLen = arrayLength();
-        if (arrayLen) {
-            Value* tempBuffer = (Value*)GC_MALLOC(sizeof(Value) * arrayLen);
+        if (length) {
+            Value* tempBuffer = (Value*)GC_MALLOC(sizeof(Value) * length);
 
-            for (size_t i = 0; i < arrayLen; i++) {
+            for (int64_t i = 0; i < length; i++) {
                 unsigned idxPosition = i * typedArrayElementSize;
                 tempBuffer[i] = getValueFromBuffer<typename TypeAdaptor::Type>(state, idxPosition);
             }
 
             TightVector<Value, GCUtil::gc_malloc_allocator<Value>> tempSpace;
-            tempSpace.resizeWithUninitializedValues(arrayLen);
-            mergeSort(tempBuffer, arrayLen, tempSpace.data(), [&](const Value& a, const Value& b, bool* lessOrEqualp) -> bool {
+            tempSpace.resizeWithUninitializedValues(length);
+            mergeSort(tempBuffer, length, tempSpace.data(), [&](const Value& a, const Value& b, bool* lessOrEqualp) -> bool {
                 *lessOrEqualp = comp(a, b);
                 return true;
             });
 
-            for (size_t i = 0; i < arrayLen; i++) {
+            for (int64_t i = 0; i < length; i++) {
                 unsigned idxPosition = i * typedArrayElementSize;
                 setValueInBuffer<TypeAdaptor>(state, idxPosition, tempBuffer[i]);
             }

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -215,7 +215,7 @@ public:
     Object* toObject(ExecutionState& ec) const; // $7.1.13 ToObject
     Value toPropertyKey(ExecutionState& state) const;
 
-    enum : uint32_t { InvalidIndexValue = std::numeric_limits<uint32_t>::max() };
+    enum : uint64_t { InvalidIndexValue = std::numeric_limits<uint64_t>::max() };
     typedef uint64_t ValueIndex;
     ValueIndex toIndex(ExecutionState& ec) const;
     inline ValueIndex tryToUseAsIndex(ExecutionState& ec) const;

--- a/tools/test/spidermonkey/excludelist.txt
+++ b/tools/test/spidermonkey/excludelist.txt
@@ -10,16 +10,13 @@ non262/Array/from-iterator-close.js
 non262/Array/from_primitive.js
 non262/Array/generics.js
 non262/Array/iterator_edge_cases.js
-
-# TODO
 non262/Array/regress-304828.js
 non262/Array/regress-313153.js
 non262/Array/regress-387501.js
 non262/Array/regress-415540.js
-non262/Array/shift-no-has-trap.js
+
+# TODO
 non262/Array/slice-sparse-with-large-index.js
-non262/Array/sort_small.js
-non262/Array/sort-typedarray-with-own-length.js
 non262/Array/species.js
 non262/Array/to-length.js
 non262/Array/toLocaleString.js


### PR DESCRIPTION
* In Proxy's defineOwnProperty, set settingConfigFalse to true if desc has a [[Configurable]] field and if desc.[[Configurable]] is false
* Use a length properly according to spec at each sort implementations
* Ignore tests where the only reason for the test failure is an error message difference

Signed-off-by: Boram Bae <boram21.bae@samsung.com>