### PR TITLE
Optimize memory management in Parsing

### DIFF
--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -108,13 +108,6 @@ int getValidValueInInterpretedCodeBlock(void* ptr, GC_mark_custom_result* arr)
     arr[7].to = (GC_word*)current->m_byteCodeBlock;
     arr[8].from = (GC_word*)&current->m_blockInfos;
     arr[8].to = (GC_word*)current->m_blockInfos.data();
-#ifdef NDEBUG
-    arr[9].from = (GC_word*)&current->m_context;
-    arr[9].to = (GC_word*)nullptr;
-#else
-    arr[9].from = (GC_word*)&current->m_scopeContext;
-    arr[9].to = (GC_word*)current->m_scopeContext;
-#endif
     return 0;
 }
 
@@ -149,7 +142,7 @@ void initializeCustomAllocators()
                                                                       TRUE);
 
     s_gcKinds[HeapObjectKind::InterpretedCodeBlockKind] = GC_new_kind_enumerable(GC_new_free_list(),
-                                                                                 GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 10>), 0),
+                                                                                 GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 9>), 0),
                                                                                  FALSE,
                                                                                  TRUE);
 }

--- a/src/parser/ASTAllocator.cpp
+++ b/src/parser/ASTAllocator.cpp
@@ -31,18 +31,6 @@ ASTAllocator::ASTAllocator()
 
 ASTAllocator::~ASTAllocator()
 {
-    /*
-    for (size_t i = 0; i < m_astDestructibleNodes.size(); i++) {
-        m_astDestructibleNodes[i]->~DestructibleNode();
-    }
-    m_astDestructibleNodes.clear();
-
-    for (size_t i = 0; i < m_astPools.size(); i++) {
-        free(m_astPools[i]);
-    }
-    m_astPools.clear();
-    */
-
     ASSERT(m_astPools.size() == 0);
     ASSERT(m_astDestructibleNodes.size() == 0);
 

--- a/src/parser/ASTAllocator.cpp
+++ b/src/parser/ASTAllocator.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2019-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#include "Escargot.h"
+#include "ASTAllocator.h"
+#include "parser/ast/Node.h"
+
+namespace Escargot {
+
+ASTAllocator::ASTAllocator()
+{
+    m_astPoolMemory = static_cast<char*>(malloc(initialASTPoolSize));
+    m_astPoolEnd = m_astPoolMemory + initialASTPoolSize;
+}
+
+ASTAllocator::~ASTAllocator()
+{
+    /*
+    for (size_t i = 0; i < m_astDestructibleNodes.size(); i++) {
+        m_astDestructibleNodes[i]->~DestructibleNode();
+    }
+    m_astDestructibleNodes.clear();
+
+    for (size_t i = 0; i < m_astPools.size(); i++) {
+        free(m_astPools[i]);
+    }
+    m_astPools.clear();
+    */
+
+    ASSERT(m_astPools.size() == 0);
+    ASSERT(m_astDestructibleNodes.size() == 0);
+
+    free(currentPool());
+}
+
+void ASTAllocator::reset()
+{
+    // check if GC is disabled (after reset() GC is enabled again)
+    ASSERT(GC_is_disabled());
+    ASSERT(m_astPoolMemory != nullptr && m_astPoolEnd != nullptr);
+    ASSERT(static_cast<size_t>(m_astPoolEnd - m_astPoolMemory) >= 0);
+
+    for (size_t i = 0; i < m_astDestructibleNodes.size(); i++) {
+        m_astDestructibleNodes[i]->~DestructibleNode();
+    }
+    m_astDestructibleNodes.clear();
+
+    for (size_t i = 0; i < m_astPools.size(); i++) {
+        free(m_astPools[i]);
+    }
+    m_astPools.clear();
+
+    m_astPoolMemory = static_cast<char*>(currentPool());
+}
+
+void* ASTAllocator::allocate(size_t size)
+{
+    ASSERT(size > 0);
+    ASSERT(size <= initialASTPoolSize);
+    size_t alignedSize = alignSize(size);
+    ASSERT(alignedSize <= initialASTPoolSize);
+    if (UNLIKELY(static_cast<size_t>(m_astPoolEnd - m_astPoolMemory) < alignedSize)) {
+        allocatePool();
+    }
+    void* block = m_astPoolMemory;
+    m_astPoolMemory += alignedSize;
+    return block;
+}
+
+void* ASTAllocator::allocateDestructible(size_t size)
+{
+    void* ptr = allocate(size);
+    DestructibleNode* destructible = static_cast<DestructibleNode*>(ptr);
+    m_astDestructibleNodes.push_back(destructible);
+
+    return ptr;
+}
+
+void ASTAllocator::allocatePool()
+{
+    ASSERT(m_astPoolMemory != nullptr && m_astPoolEnd != nullptr);
+    ASSERT(static_cast<size_t>(m_astPoolEnd - m_astPoolMemory) >= 0);
+
+    m_astPools.push_back(currentPool());
+
+    char* pool = static_cast<char*>(malloc(initialASTPoolSize));
+    m_astPoolMemory = pool;
+    m_astPoolEnd = pool + initialASTPoolSize;
+}
+}

--- a/src/parser/ASTAllocator.h
+++ b/src/parser/ASTAllocator.h
@@ -45,7 +45,7 @@ public:
     }
 
 private:
-    static const size_t initialASTPoolSize = 1024 * 1024;
+    static const size_t initialASTPoolSize = 1024 * 128;
 
     size_t alignSize(size_t size)
     {

--- a/src/parser/ASTAllocator.h
+++ b/src/parser/ASTAllocator.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#ifndef __EscargotASTAllocator__
+#define __EscargotASTAllocator__
+
+namespace Escargot {
+
+
+typedef intptr_t ASTAllocAlignment;
+
+class Node;
+class DestructibleNode;
+
+class ASTAllocator {
+public:
+    ASTAllocator();
+    ~ASTAllocator();
+
+    void reset();
+    void* allocate(size_t size);
+    void* allocateDestructible(size_t size);
+
+    bool isInitialized()
+    {
+        ASSERT(m_astPools.size() == 0);
+        ASSERT(m_astDestructibleNodes.size() == 0);
+        return (m_astPoolMemory == currentPool());
+    }
+
+private:
+    static const size_t initialASTPoolSize = 1024 * 1024;
+
+    size_t alignSize(size_t size)
+    {
+        return (size + sizeof(ASTAllocAlignment) - 1) & ~(sizeof(ASTAllocAlignment) - 1);
+    }
+    void allocatePool();
+    void* currentPool()
+    {
+        ASSERT(m_astPoolMemory != nullptr && m_astPoolEnd != nullptr);
+        ASSERT(static_cast<size_t>(m_astPoolEnd - m_astPoolMemory) >= 0);
+
+        return m_astPoolEnd - initialASTPoolSize;
+    }
+
+    char* m_astPoolMemory;
+    char* m_astPoolEnd;
+
+    std::vector<void*> m_astPools;
+    std::vector<DestructibleNode*> m_astDestructibleNodes;
+};
+}
+#endif

--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -116,6 +116,8 @@ namespace Escargot {
     F(WithStatement)                          \
     F(YieldExpression)
 
+class SyntaxNodeVector;
+
 class SyntaxNode {
 public:
     MAKE_STACK_ALLOCATED();
@@ -275,27 +277,28 @@ public:
         return;
     }
 
-    std::vector<SyntaxNode>& expressions()
+    SyntaxNodeVector& expressions()
     {
         // dummy function for expressions() of SequenceExpressionNode
-        // this function should never be invocked
+        // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
-        std::vector<SyntaxNode>* tempVector = new std::vector<SyntaxNode>();
+        SyntaxNodeVector* tempVector;
         return *tempVector;
     }
 
     ASTFunctionScopeContext* scopeContext()
     {
         // dummy function for scopeContext() of FunctionDeclarationNode
-        // this function should never be invocked
+        // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
-        return new ASTFunctionScopeContext();
+        ASTFunctionScopeContext* scopeContext;
+        return scopeContext;
     }
 
     ClassNode& classNode()
     {
         // dummy function for classNode() of ClassDeclarationNode
-        // this function should never be invocked
+        // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
         ClassNode* tempClassNode = new ClassNode();
         return *tempClassNode;
@@ -304,7 +307,7 @@ public:
     Value value()
     {
         // dummy function for value() of LiteralNode
-        // this function should never be invocked
+        // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
         return Value();
     }
@@ -312,7 +315,7 @@ public:
     IdentifierNode* imported()
     {
         // dummy function for imported() of ImportSpecifierNode
-        // this function should never be invocked
+        // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
         return new IdentifierNode();
     }
@@ -320,7 +323,7 @@ public:
     IdentifierNode* exported()
     {
         // dummy function for imported() of ExportSpecifierNode
-        // this function should never be invocked
+        // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
         return new IdentifierNode();
     }
@@ -328,7 +331,7 @@ public:
     IdentifierNode* local()
     {
         // dummy function for local() of Import/ExportSpecifierNode
-        // this function should never be invocked
+        // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
         return new IdentifierNode();
     }
@@ -344,7 +347,63 @@ private:
     AtomicString m_string;
 };
 
-typedef std::vector<SyntaxNode> SyntaxNodeVector;
+// Vector for SyntaxNode
+// SyntaxNodeVector allows insertion(push_back) operation only
+class SyntaxNodeVector {
+public:
+    SyntaxNodeVector()
+        : m_size(0)
+        , m_node()
+    {
+    }
+
+    size_t size() const
+    {
+        return m_size;
+    }
+
+    void push_back(const SyntaxNode& val)
+    {
+        m_size++;
+    }
+
+    void pop_back()
+    {
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    SyntaxNode& operator[](size_t idx)
+    {
+        return m_node;
+    }
+
+    SyntaxNode& back()
+    {
+        RELEASE_ASSERT_NOT_REACHED();
+        return m_node;
+    }
+
+    size_t begin()
+    {
+        return 0;
+    }
+
+    size_t end()
+    {
+        return m_size;
+    }
+
+    void insert(size_t pos, size_t first, size_t last)
+    {
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+private:
+    size_t m_size;
+    SyntaxNode m_node;
+};
+
+typedef VectorWithInlineStorage<16, SyntaxNode, std::allocator<SyntaxNode>> ParameterNodeVector;
 
 class SyntaxChecker {
 public:
@@ -352,7 +411,7 @@ public:
     typedef SyntaxNode ASTIdentifierNode;
     typedef SyntaxNode ASTStatementContainer;
     typedef SyntaxNode* ASTStatementNodePtr;
-    typedef std::vector<SyntaxNode> ASTNodeVector;
+    typedef SyntaxNodeVector ASTNodeVector;
 
     MAKE_STACK_ALLOCATED();
 

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -63,9 +63,6 @@ void* InterpretedCodeBlock::operator new(size_t size)
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_firstChild));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_nextSibling));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_byteCodeBlock));
-#ifndef NDEBUG
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_scopeContext));
-#endif
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(InterpretedCodeBlock));
         typeInited = true;
     }

--- a/src/parser/ast/ArrayExpressionNode.h
+++ b/src/parser/ast/ArrayExpressionNode.h
@@ -26,15 +26,16 @@
 
 namespace Escargot {
 
-class ArrayExpressionNode : public ExpressionNode {
+class ArrayExpressionNode : public ExpressionNode, public DestructibleNode {
 public:
-    ArrayExpressionNode(NodeVector&& elements, AtomicString additionalPropertyName = AtomicString(), Node* additionalPropertyExpression = nullptr, bool hasSpreadElement = false, bool isTaggedTempleateExpression = false)
+    using DestructibleNode::operator new;
+    ArrayExpressionNode(NodeVector&& elements, AtomicString additionalPropertyName = AtomicString(), Node* additionalPropertyExpression = nullptr, bool hasSpreadElement = false, bool isTaggedTemplateExpression = false)
         : ExpressionNode()
         , m_elements(elements)
         , m_additionalPropertyName(additionalPropertyName)
         , m_additionalPropertyExpression(additionalPropertyExpression)
         , m_hasSpreadElement(hasSpreadElement)
-        , m_isTaggedTempleateExpression(isTaggedTempleateExpression)
+        , m_isTaggedTemplateExpression(isTaggedTemplateExpression)
     {
     }
 
@@ -98,7 +99,7 @@ public:
             m_additionalPropertyExpression->generateExpressionByteCode(codeBlock, context, additionalPropertyExpressionRegsiter);
             codeBlock->pushCode(ObjectDefineOwnPropertyWithNameOperation(ByteCodeLOC(m_loc.index), dstRegister, m_additionalPropertyName, additionalPropertyExpressionRegsiter, ObjectPropertyDescriptor::NotPresent), context, this);
 
-            if (m_isTaggedTempleateExpression) {
+            if (m_isTaggedTemplateExpression) {
                 auto freezeFunctionRegister = context->getRegister();
                 codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), freezeFunctionRegister, Value(codeBlock->m_codeBlock->context()->globalObject()->objectFreeze())), context, this);
                 codeBlock->pushCode(CallFunction(ByteCodeLOC(m_loc.index), freezeFunctionRegister, additionalPropertyExpressionRegsiter, freezeFunctionRegister, 1), context, this);
@@ -108,7 +109,7 @@ public:
             context->giveUpRegister();
         }
 
-        if (m_isTaggedTempleateExpression) {
+        if (m_isTaggedTemplateExpression) {
             auto freezeFunctionRegister = context->getRegister();
             codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), freezeFunctionRegister, Value(codeBlock->m_codeBlock->context()->globalObject()->objectFreeze())), context, this);
             codeBlock->pushCode(CallFunction(ByteCodeLOC(m_loc.index), freezeFunctionRegister, dstRegister, freezeFunctionRegister, 1), context, this);
@@ -144,9 +145,9 @@ public:
 private:
     NodeVector m_elements;
     AtomicString m_additionalPropertyName;
-    RefPtr<Node> m_additionalPropertyExpression;
+    Node* m_additionalPropertyExpression;
     bool m_hasSpreadElement;
-    bool m_isTaggedTempleateExpression;
+    bool m_isTaggedTemplateExpression;
 };
 }
 

--- a/src/parser/ast/ArrayPatternNode.h
+++ b/src/parser/ast/ArrayPatternNode.h
@@ -25,8 +25,9 @@
 
 namespace Escargot {
 
-class ArrayPatternNode : public Node {
+class ArrayPatternNode : public Node, public DestructibleNode {
 public:
+    using DestructibleNode::operator new;
     ArrayPatternNode(NodeVector&& elements)
         : m_elements(elements)
     {

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -24,8 +24,9 @@
 
 namespace Escargot {
 
-class ArrowParameterPlaceHolderNode : public Node {
+class ArrowParameterPlaceHolderNode : public Node, public DestructibleNode {
 public:
+    using DestructibleNode::operator new;
     ArrowParameterPlaceHolderNode()
         : Node()
     {

--- a/src/parser/ast/AssignmentExpressionBitwiseAndNode.h
+++ b/src/parser/ast/AssignmentExpressionBitwiseAndNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionBitwiseAndNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionBitwiseAnd; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionBitwiseOrNode.h
+++ b/src/parser/ast/AssignmentExpressionBitwiseOrNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionBitwiseOrNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionBitwiseOr; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionBitwiseXorNode.h
+++ b/src/parser/ast/AssignmentExpressionBitwiseXorNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionBitwiseXorNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionBitwiseXor; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionDivisionNode.h
+++ b/src/parser/ast/AssignmentExpressionDivisionNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionDivisionNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionDivision; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionLeftShiftNode.h
+++ b/src/parser/ast/AssignmentExpressionLeftShiftNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionLeftShiftNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionLeftShift; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionMinusNode.h
+++ b/src/parser/ast/AssignmentExpressionMinusNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionMinusNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionMinus; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionModNode.h
+++ b/src/parser/ast/AssignmentExpressionModNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionModNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionMod; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionMultiplyNode.h
+++ b/src/parser/ast/AssignmentExpressionMultiplyNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionMultiplyNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionMultiply; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionPlusNode.h
+++ b/src/parser/ast/AssignmentExpressionPlusNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionPlusNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionPlus; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionSignedRightShiftNode.h
+++ b/src/parser/ast/AssignmentExpressionSignedRightShiftNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionSignedRightShiftNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionSignedRightShift; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionSimpleNode.h
+++ b/src/parser/ast/AssignmentExpressionSimpleNode.h
@@ -39,23 +39,14 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionSimpleNode()
-    {
-    }
-
-    void giveupChildren()
-    {
-        m_left = m_right = nullptr;
-    }
-
     Node* left()
     {
-        return m_left.get();
+        return m_left;
     }
 
     Node* right()
     {
-        return m_right.get();
+        return m_right;
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionSimple; }
@@ -107,11 +98,11 @@ public:
 
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlowMode = isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool isSlowMode = isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
 
         if (codeBlock->m_codeBlock->hasEval()) {
             // x = (eval("var x;"), 1);
-            isSlowMode = isSlowMode || isLeftBindingAffectedByRightExpression(m_left.get(), m_right.get());
+            isSlowMode = isSlowMode || isLeftBindingAffectedByRightExpression(m_left, m_right);
         }
 
         bool isBase = context->m_registerStack->size() == 0;
@@ -122,7 +113,7 @@ public:
             context->m_canSkipCopyToRegister = false;
 
             bool oldIsLeftBindingAffectedByRightExpression = context->m_isLeftBindingAffectedByRightExpression;
-            context->m_isLeftBindingAffectedByRightExpression = isLeftBindingAffectedByRightExpression(m_left.get(), m_right.get());
+            context->m_isLeftBindingAffectedByRightExpression = isLeftBindingAffectedByRightExpression(m_left, m_right);
 
             m_left->generateResolveAddressByteCode(codeBlock, context);
             context->m_canSkipCopyToRegister = oldCanSkipCopyToRegister;
@@ -213,7 +204,7 @@ public:
 
     virtual void generateResultNotRequiredExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
-        generateResultNotRequiredAssignmentByteCode(this, m_left.get(), m_right.get(), codeBlock, context);
+        generateResultNotRequiredAssignmentByteCode(this, m_left, m_right, codeBlock, context);
     }
 
     virtual void iterateChildrenIdentifier(const std::function<void(AtomicString name, bool isAssignment)>& fn) override
@@ -231,8 +222,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentExpressionUnsignedRightShiftNode.h
+++ b/src/parser/ast/AssignmentExpressionUnsignedRightShiftNode.h
@@ -36,14 +36,10 @@ public:
     {
     }
 
-    virtual ~AssignmentExpressionUnsignedRightShiftNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentExpressionUnsignedRightShift; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left.get(), m_right.get());
+        bool slowMode = AssignmentExpressionSimpleNode::isLeftReferenceExpressionRelatedWithRightExpression(m_left, m_right);
         bool flagBefore;
         if (slowMode) {
             flagBefore = context->m_canSkipCopyToRegister;
@@ -85,8 +81,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/AssignmentPatternNode.h
+++ b/src/parser/ast/AssignmentPatternNode.h
@@ -45,23 +45,14 @@ public:
         m_loc = loc;
     }
 
-    virtual ~AssignmentPatternNode()
-    {
-    }
-
-    void giveupChildren()
-    {
-        m_left = m_right = nullptr;
-    }
-
     Node* left()
     {
-        return m_left.get();
+        return m_left;
     }
 
     Node* right()
     {
-        return m_right.get();
+        return m_right;
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::AssignmentPattern; }
@@ -114,8 +105,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left; // left: Pattern;
-    RefPtr<Node> m_right; // right: Expression;
+    Node* m_left; // left: Pattern;
+    Node* m_right; // right: Expression;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionBitwiseAndNode.h
+++ b/src/parser/ast/BinaryExpressionBitwiseAndNode.h
@@ -28,19 +28,15 @@ class BinaryExpressionBitwiseAndNode : public ExpressionNode {
 public:
     BinaryExpressionBitwiseAndNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
-    {
-    }
-
-    virtual ~BinaryExpressionBitwiseAndNode()
+        , m_left(left)
+        , m_right(right)
     {
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionBitwiseAnd; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -73,8 +69,8 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionBitwiseOrNode.h
+++ b/src/parser/ast/BinaryExpressionBitwiseOrNode.h
@@ -28,19 +28,15 @@ class BinaryExpressionBitwiseOrNode : public ExpressionNode {
 public:
     BinaryExpressionBitwiseOrNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
-    {
-    }
-
-    virtual ~BinaryExpressionBitwiseOrNode()
+        , m_left(left)
+        , m_right(right)
     {
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionBitwiseOr; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -73,8 +69,8 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionBitwiseXorNode.h
+++ b/src/parser/ast/BinaryExpressionBitwiseXorNode.h
@@ -28,19 +28,19 @@ class BinaryExpressionBitwiseXorNode : public ExpressionNode {
 public:
     BinaryExpressionBitwiseXorNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
-
 
     virtual ~BinaryExpressionBitwiseXorNode()
     {
     }
+
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionBitwiseXor; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -73,8 +73,8 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionDivisionNode.h
+++ b/src/parser/ast/BinaryExpressionDivisionNode.h
@@ -28,18 +28,19 @@ class BinaryExpressionDivisionNode : public ExpressionNode {
 public:
     BinaryExpressionDivisionNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
     virtual ~BinaryExpressionDivisionNode()
     {
     }
+
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionDivision; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -72,8 +73,8 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionEqualNode.h
+++ b/src/parser/ast/BinaryExpressionEqualNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionEqualNode : public ExpressionNode {
 public:
     BinaryExpressionEqualNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -78,8 +78,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionGreaterThanNode.h
+++ b/src/parser/ast/BinaryExpressionGreaterThanNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionGreaterThanNode : public ExpressionNode {
 public:
     BinaryExpressionGreaterThanNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionGreaterThan; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -78,8 +78,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionGreaterThanOrEqualNode.h
+++ b/src/parser/ast/BinaryExpressionGreaterThanOrEqualNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionGreaterThanOrEqualNode : public ExpressionNode {
 public:
     BinaryExpressionGreaterThanOrEqualNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionGreaterThanOrEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -78,8 +78,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionInNode.h
+++ b/src/parser/ast/BinaryExpressionInNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionInNode : public ExpressionNode {
 public:
     BinaryExpressionInNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -39,7 +39,7 @@ public:
 
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -74,8 +74,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionInstanceOfNode.h
+++ b/src/parser/ast/BinaryExpressionInstanceOfNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionInstanceOfNode : public ExpressionNode {
 public:
     BinaryExpressionInstanceOfNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionInstanceOf; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -74,8 +74,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionLeftShiftNode.h
+++ b/src/parser/ast/BinaryExpressionLeftShiftNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionLeftShiftNode : public ExpressionNode {
 public:
     BinaryExpressionLeftShiftNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLeftShift; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -74,8 +74,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionLessThanNode.h
+++ b/src/parser/ast/BinaryExpressionLessThanNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionLessThanNode : public ExpressionNode {
 public:
     BinaryExpressionLessThanNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLessThan; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -78,8 +78,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionLessThanOrEqualNode.h
+++ b/src/parser/ast/BinaryExpressionLessThanOrEqualNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionLessThanOrEqualNode : public ExpressionNode {
 public:
     BinaryExpressionLessThanOrEqualNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLessThanOrEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -78,8 +78,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionLogicalAndNode.h
+++ b/src/parser/ast/BinaryExpressionLogicalAndNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionLogicalAndNode : public ExpressionNode {
 public:
     BinaryExpressionLogicalAndNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLogicalAnd; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -76,8 +76,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionLogicalOrNode.h
+++ b/src/parser/ast/BinaryExpressionLogicalOrNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionLogicalOrNode : public ExpressionNode {
 public:
     BinaryExpressionLogicalOrNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLogicalOr; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -74,8 +74,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionMinusNode.h
+++ b/src/parser/ast/BinaryExpressionMinusNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionMinusNode : public ExpressionNode {
 public:
     BinaryExpressionMinusNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionMinus; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -74,8 +74,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionModNode.h
+++ b/src/parser/ast/BinaryExpressionModNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionModNode : public ExpressionNode {
 public:
     BinaryExpressionModNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionMod; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -74,8 +74,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionMultiplyNode.h
+++ b/src/parser/ast/BinaryExpressionMultiplyNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionMultiplyNode : public ExpressionNode {
 public:
     BinaryExpressionMultiplyNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionMultiply; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -74,8 +74,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionNotEqualNode.h
+++ b/src/parser/ast/BinaryExpressionNotEqualNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionNotEqualNode : public ExpressionNode {
 public:
     BinaryExpressionNotEqualNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionNotEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -78,8 +78,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionNotStrictEqualNode.h
+++ b/src/parser/ast/BinaryExpressionNotStrictEqualNode.h
@@ -28,8 +28,8 @@ class BinaryExpressionNotStrictEqualNode : public ExpressionNode {
 public:
     BinaryExpressionNotStrictEqualNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionNotStrictEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -78,8 +78,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionPlusNode.h
+++ b/src/parser/ast/BinaryExpressionPlusNode.h
@@ -28,18 +28,19 @@ class BinaryExpressionPlusNode : public ExpressionNode {
 public:
     BinaryExpressionPlusNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
     virtual ~BinaryExpressionPlusNode()
     {
     }
+
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionPlus; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -73,8 +74,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionSignedRightShiftNode.h
+++ b/src/parser/ast/BinaryExpressionSignedRightShiftNode.h
@@ -28,18 +28,19 @@ class BinaryExpressionSignedRightShiftNode : public ExpressionNode {
 public:
     BinaryExpressionSignedRightShiftNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
     virtual ~BinaryExpressionSignedRightShiftNode()
     {
     }
+
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionSignedRightShift; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -73,8 +74,8 @@ public:
 
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionStrictEqualNode.h
+++ b/src/parser/ast/BinaryExpressionStrictEqualNode.h
@@ -28,18 +28,19 @@ class BinaryExpressionStrictEqualNode : public ExpressionNode {
 public:
     BinaryExpressionStrictEqualNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
     virtual ~BinaryExpressionStrictEqualNode()
     {
     }
+
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionStrictEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -76,8 +77,8 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BinaryExpressionUnsignedRightShiftNode.h
+++ b/src/parser/ast/BinaryExpressionUnsignedRightShiftNode.h
@@ -28,18 +28,19 @@ class BinaryExpressionUnsignedRightShiftNode : public ExpressionNode {
 public:
     BinaryExpressionUnsignedRightShiftNode(Node* left, Node* right)
         : ExpressionNode()
-        , m_left((ExpressionNode*)left)
-        , m_right((ExpressionNode*)right)
+        , m_left(left)
+        , m_right(right)
     {
     }
 
     virtual ~BinaryExpressionUnsignedRightShiftNode()
     {
     }
+
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionUnsignedRightShift; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !canUseDirectRegister(context, m_left.get(), m_right.get());
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -72,8 +73,8 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_left;
-    RefPtr<ExpressionNode> m_right;
+    Node* m_left;
+    Node* m_right;
 };
 }
 

--- a/src/parser/ast/BlockStatementNode.h
+++ b/src/parser/ast/BlockStatementNode.h
@@ -37,6 +37,7 @@ public:
     virtual ~BlockStatementNode()
     {
     }
+
     virtual ASTNodeType type() override { return ASTNodeType::BlockStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
@@ -71,7 +72,7 @@ public:
 
 
 private:
-    RefPtr<StatementContainer> m_container;
+    StatementContainer* m_container;
     LexicalBlockIndex m_lexicalBlockIndex;
 };
 }

--- a/src/parser/ast/BreakLabelStatementNode.h
+++ b/src/parser/ast/BreakLabelStatementNode.h
@@ -32,6 +32,10 @@ public:
     {
     }
 
+    virtual ~BreakLabelStatementNode()
+    {
+    }
+
     virtual ASTNodeType type() override { return ASTNodeType::BreakLabelStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {

--- a/src/parser/ast/CatchClauseNode.h
+++ b/src/parser/ast/CatchClauseNode.h
@@ -32,11 +32,11 @@ class FunctionDeclarationNode;
 // interface CatchClause <: Node {
 class CatchClauseNode : public Node {
 public:
-    CatchClauseNode(Node *param, Node *guard, Node *body, LexicalBlockIndex paramLexicalBlockIndex)
+    CatchClauseNode(Node* param, Node* guard, Node* body, LexicalBlockIndex paramLexicalBlockIndex)
         : Node()
         , m_param(param)
-        , m_guard((ExpressionNode *)guard)
-        , m_body((BlockStatementNode *)body)
+        , m_guard(guard)
+        , m_body(body)
         , m_paramLexicalBlockIndex(paramLexicalBlockIndex)
     {
     }
@@ -45,14 +45,14 @@ public:
     {
     }
 
-    Node *param()
+    Node* param()
     {
-        return m_param.get();
+        return m_param;
     }
 
-    BlockStatementNode *body()
+    BlockStatementNode* body()
     {
-        return m_body.get();
+        return (BlockStatementNode*)m_body;
     }
 
     LexicalBlockIndex paramLexicalBlockIndex()
@@ -62,9 +62,9 @@ public:
 
     virtual ASTNodeType type() override { return ASTNodeType::CatchClause; }
 private:
-    RefPtr<Node> m_param;
-    RefPtr<ExpressionNode> m_guard;
-    RefPtr<BlockStatementNode> m_body;
+    Node* m_param;
+    Node* m_guard;
+    Node* m_body;
     LexicalBlockIndex m_paramLexicalBlockIndex;
 };
 }

--- a/src/parser/ast/ClassBodyNode.h
+++ b/src/parser/ast/ClassBodyNode.h
@@ -28,9 +28,10 @@
 namespace Escargot {
 
 
-class ClassBodyNode : public Node {
+class ClassBodyNode : public Node, public DestructibleNode {
 public:
-    ClassBodyNode(NodeVector&& elementList, RefPtr<Node> constructor)
+    using DestructibleNode::operator new;
+    ClassBodyNode(NodeVector&& elementList, Node* constructor)
         : Node()
         , m_elementList(elementList)
         , m_constructor(constructor)
@@ -44,7 +45,7 @@ public:
 
     Node* constructor()
     {
-        return m_constructor.get();
+        return m_constructor;
     }
 
     void generateClassInitializer(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex classIndex)
@@ -133,7 +134,7 @@ public:
 
 private:
     NodeVector m_elementList;
-    RefPtr<Node> m_constructor;
+    Node* m_constructor;
 };
 }
 

--- a/src/parser/ast/ClassDeclarationNode.h
+++ b/src/parser/ast/ClassDeclarationNode.h
@@ -29,7 +29,7 @@ namespace Escargot {
 class ClassDeclarationNode : public StatementNode {
 public:
     ClassDeclarationNode() {}
-    ClassDeclarationNode(RefPtr<Node> id, RefPtr<Node> superClass, RefPtr<Node> classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
+    ClassDeclarationNode(Node* id, Node* superClass, Node* classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
         : StatementNode()
         // id can be nullptr
         , m_class(id, superClass, classBody->asClassBody(), classBodyLexicalBlockIndex, classSrc)
@@ -46,7 +46,7 @@ public:
     {
         context->getRegister(); // To ensure that the result of the classDeclaration is undefined
         size_t classIndex = context->getRegister();
-        RefPtr<Node> classIdent = m_class.id();
+        Node* classIdent = m_class.id();
 
         const ClassContextInformation classInfoBefore = context->m_classInfo;
         context->m_classInfo.m_constructorIndex = classIndex;

--- a/src/parser/ast/ClassElementNode.h
+++ b/src/parser/ast/ClassElementNode.h
@@ -47,12 +47,12 @@ public:
 
     Node* key()
     {
-        return m_key.get();
+        return m_key;
     }
 
     Node* value()
     {
-        return m_value.get();
+        return m_value;
     }
 
     Kind kind()
@@ -80,8 +80,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_key; // key: Literal | Identifier;
-    RefPtr<Node> m_value; // value: Expression;
+    Node* m_key; // key: Literal | Identifier;
+    Node* m_value; // value: Expression;
     Kind m_kind;
     bool m_isComputed : 1;
     bool m_isStatic : 1;

--- a/src/parser/ast/ClassExpressionNode.h
+++ b/src/parser/ast/ClassExpressionNode.h
@@ -30,7 +30,7 @@ namespace Escargot {
 class ClassExpressionNode : public ExpressionNode {
 public:
     ClassExpressionNode() {}
-    ClassExpressionNode(RefPtr<Node> id, RefPtr<Node> superClass, RefPtr<Node> classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
+    ClassExpressionNode(Node* id, Node* superClass, Node* classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
         : ExpressionNode()
         // id can be nullptr
         , m_class(id, superClass, classBody->asClassBody(), classBodyLexicalBlockIndex, classSrc)
@@ -45,7 +45,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::ClassExpression; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstIndex) override
     {
-        RefPtr<Node> classIdent = m_class.id();
+        Node* classIdent = m_class.id();
 
         const ClassContextInformation classInfoBefore = context->m_classInfo;
         context->m_classInfo.m_constructorIndex = dstIndex;

--- a/src/parser/ast/ClassNode.h
+++ b/src/parser/ast/ClassNode.h
@@ -36,7 +36,7 @@ public:
     {
     }
 
-    ClassNode(RefPtr<Node> id, RefPtr<Node> superClass, RefPtr<ClassBodyNode> classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
+    ClassNode(Node* id, Node* superClass, Node* classBody, LexicalBlockIndex classBodyLexicalBlockIndex, StringView classSrc)
         : m_classBodyLexicalBlockIndex(classBodyLexicalBlockIndex)
         , m_id(id)
         , m_superClass(superClass)
@@ -45,16 +45,16 @@ public:
     {
     }
 
-    inline const RefPtr<Node>& id() const { return m_id; }
-    inline const RefPtr<Node>& superClass() const { return m_superClass; }
-    inline const RefPtr<ClassBodyNode>& classBody() const { return m_classBody; }
+    inline Node* id() const { return m_id; }
+    inline Node* superClass() const { return m_superClass; }
+    inline ClassBodyNode* classBody() const { return (ClassBodyNode*)m_classBody; }
     inline LexicalBlockIndex classBodyLexicalBlockIndex() const { return m_classBodyLexicalBlockIndex; }
     inline const StringView& classSrc() const { return m_classSrc; }
 private:
     LexicalBlockIndex m_classBodyLexicalBlockIndex;
-    RefPtr<Node> m_id; // Id
-    RefPtr<Node> m_superClass;
-    RefPtr<ClassBodyNode> m_classBody;
+    Node* m_id; // Id
+    Node* m_superClass;
+    Node* m_classBody;
     StringView m_classSrc;
 };
 }

--- a/src/parser/ast/ConditionalExpressionNode.h
+++ b/src/parser/ast/ConditionalExpressionNode.h
@@ -28,9 +28,9 @@ class ConditionalExpressionNode : public ExpressionNode {
 public:
     ConditionalExpressionNode(Node* test, Node* consequente, Node* alternate)
         : ExpressionNode()
-        , m_test((ExpressionNode*)test)
-        , m_consequente((ExpressionNode*)consequente)
-        , m_alternate((ExpressionNode*)alternate)
+        , m_test(test)
+        , m_consequente(consequente)
+        , m_alternate(alternate)
     {
     }
     virtual ~ConditionalExpressionNode()
@@ -79,9 +79,9 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_test;
-    RefPtr<ExpressionNode> m_consequente;
-    RefPtr<ExpressionNode> m_alternate;
+    Node* m_test;
+    Node* m_consequente;
+    Node* m_alternate;
 };
 }
 

--- a/src/parser/ast/ContinueStatementNode.h
+++ b/src/parser/ast/ContinueStatementNode.h
@@ -26,7 +26,6 @@ namespace Escargot {
 
 class ContinueStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
     ContinueStatementNode()
         : StatementNode()
     {

--- a/src/parser/ast/DebuggerStatementNode.h
+++ b/src/parser/ast/DebuggerStatementNode.h
@@ -27,7 +27,6 @@ namespace Escargot {
 
 class DebuggerStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
     DebuggerStatementNode()
         : StatementNode()
     {

--- a/src/parser/ast/DeclarationNode.h
+++ b/src/parser/ast/DeclarationNode.h
@@ -32,6 +32,10 @@ public:
     {
     }
 
+    virtual ~DeclarationNode()
+    {
+    }
+
 protected:
 };
 }

--- a/src/parser/ast/DirectiveNode.h
+++ b/src/parser/ast/DirectiveNode.h
@@ -52,7 +52,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_expr;
+    Node* m_expr;
 };
 }
 

--- a/src/parser/ast/DoWhileStatementNode.h
+++ b/src/parser/ast/DoWhileStatementNode.h
@@ -27,11 +27,10 @@ namespace Escargot {
 
 class DoWhileStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
-    DoWhileStatementNode(Node *test, Node *body)
+    DoWhileStatementNode(Node* test, Node* body)
         : StatementNode()
-        , m_test((ExpressionNode *)test)
-        , m_body((StatementNode *)body)
+        , m_test(test)
+        , m_body(body)
     {
     }
 
@@ -40,7 +39,7 @@ public:
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::DoWhileStatement; }
-    virtual void generateStatementByteCode(ByteCodeBlock *codeBlock, ByteCodeGenerateContext *context) override
+    virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
         ByteCodeGenerateContext newContext(*context);
 
@@ -63,7 +62,7 @@ public:
         newContext.propagateInformationTo(*context);
     }
 
-    virtual void iterateChildren(const std::function<void(Node *node)> &fn) override
+    virtual void iterateChildren(const std::function<void(Node* node)>& fn) override
     {
         fn(this);
 
@@ -72,8 +71,8 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_test;
-    RefPtr<StatementNode> m_body;
+    Node* m_test;
+    Node* m_body;
 };
 }
 

--- a/src/parser/ast/EmptyStatementNode.h
+++ b/src/parser/ast/EmptyStatementNode.h
@@ -36,8 +36,6 @@ public:
     virtual void generateStatementByteCode(ByteCodeBlock *codeBlock, ByteCodeGenerateContext *context) override
     {
     }
-
-protected:
 };
 }
 

--- a/src/parser/ast/ExportAllDeclarationNode.h
+++ b/src/parser/ast/ExportAllDeclarationNode.h
@@ -27,8 +27,7 @@ namespace Escargot {
 
 class ExportAllDeclarationNode : public ExportDeclarationNode {
 public:
-    friend class ScriptParser;
-    ExportAllDeclarationNode(RefPtr<Node> src)
+    ExportAllDeclarationNode(Node* src)
         : m_src(src)
     {
         ASSERT(src->isLiteral());
@@ -47,7 +46,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_src;
+    Node* m_src;
 };
 }
 

--- a/src/parser/ast/ExportDeclarationNode.h
+++ b/src/parser/ast/ExportDeclarationNode.h
@@ -27,13 +27,15 @@ namespace Escargot {
 
 class ExportDeclarationNode : public StatementNode {
 public:
-    friend class ScriptParser;
     ExportDeclarationNode()
     {
     }
 
+    virtual ~ExportDeclarationNode()
+    {
+    }
+
     virtual ASTNodeType type() override { return ASTNodeType::ExportDeclaration; }
-private:
 };
 }
 

--- a/src/parser/ast/ExportDefaultDeclarationNode.h
+++ b/src/parser/ast/ExportDefaultDeclarationNode.h
@@ -28,8 +28,7 @@ namespace Escargot {
 
 class ExportDefaultDeclarationNode : public ExportDeclarationNode {
 public:
-    friend class ScriptParser;
-    ExportDefaultDeclarationNode(RefPtr<Node> declaration, AtomicString exportName, AtomicString localName)
+    ExportDefaultDeclarationNode(Node* declaration, AtomicString exportName, AtomicString localName)
         : m_declaration(declaration)
         , m_exportName(exportName)
         , m_localName(localName)
@@ -58,7 +57,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_declaration;
+    Node* m_declaration;
     AtomicString m_exportName;
     AtomicString m_localName;
 };

--- a/src/parser/ast/ExportNamedDeclarationNode.h
+++ b/src/parser/ast/ExportNamedDeclarationNode.h
@@ -26,13 +26,17 @@
 
 namespace Escargot {
 
-class ExportNamedDeclarationNode : public ExportDeclarationNode {
+class ExportNamedDeclarationNode : public ExportDeclarationNode, public DestructibleNode {
 public:
-    friend class ScriptParser;
-    ExportNamedDeclarationNode(RefPtr<Node> declaration, NodeVector&& specifiers, RefPtr<Node> source)
+    using DestructibleNode::operator new;
+    ExportNamedDeclarationNode(Node* declaration, NodeVector&& specifiers, Node* source)
         : m_declaration(declaration)
         , m_specifiers(std::move(specifiers))
         , m_source(source)
+    {
+    }
+
+    virtual ~ExportNamedDeclarationNode()
     {
     }
 
@@ -63,9 +67,9 @@ public:
 
 
 private:
-    RefPtr<Node> m_declaration;
+    Node* m_declaration;
     NodeVector m_specifiers;
-    RefPtr<Node> m_source;
+    Node* m_source;
 };
 }
 

--- a/src/parser/ast/ExportSpecifierNode.h
+++ b/src/parser/ast/ExportSpecifierNode.h
@@ -26,8 +26,7 @@ namespace Escargot {
 
 class ExportSpecifierNode : public Node {
 public:
-    friend class ScriptParser;
-    ExportSpecifierNode(RefPtr<Node> local, RefPtr<Node> exported)
+    ExportSpecifierNode(Node* local, Node* exported)
         : m_local(local)
         , m_exported(exported)
     {
@@ -59,8 +58,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_local;
-    RefPtr<Node> m_exported;
+    Node* m_local;
+    Node* m_exported;
 };
 }
 

--- a/src/parser/ast/ExpressionNode.h
+++ b/src/parser/ast/ExpressionNode.h
@@ -34,6 +34,10 @@ public:
     {
     }
 
+    virtual ~ExpressionNode()
+    {
+    }
+
     virtual bool isExpression() override
     {
         return true;
@@ -86,9 +90,6 @@ public:
 
         return true;
     }
-
-
-protected:
 };
 }
 

--- a/src/parser/ast/ExpressionStatementNode.h
+++ b/src/parser/ast/ExpressionStatementNode.h
@@ -27,7 +27,6 @@ namespace Escargot {
 // An expression statement, i.e., a statement consisting of a single expression.
 class ExpressionStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
     explicit ExpressionStatementNode(Node* expression)
         : StatementNode()
         , m_expression(expression)
@@ -39,7 +38,7 @@ public:
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::ExpressionStatement; }
-    Node* expression() { return m_expression.get(); }
+    Node* expression() { return m_expression; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
         if (!context->m_isEvalCode && !context->m_isGlobalScope) {
@@ -62,7 +61,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_expression; // expression: Expression;
+    Node* m_expression; // expression: Expression;
 };
 }
 

--- a/src/parser/ast/ForInOfStatementNode.h
+++ b/src/parser/ast/ForInOfStatementNode.h
@@ -28,12 +28,11 @@ namespace Escargot {
 
 class ForInOfStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
-    ForInOfStatementNode(Node *left, Node *right, Node *body, bool forIn, bool hasLexicalDeclarationOnInit, LexicalBlockIndex headLexicalBlockIndex, LexicalBlockIndex iterationLexicalBlockIndex)
+    ForInOfStatementNode(Node* left, Node* right, Node* body, bool forIn, bool hasLexicalDeclarationOnInit, LexicalBlockIndex headLexicalBlockIndex, LexicalBlockIndex iterationLexicalBlockIndex)
         : StatementNode()
         , m_left(left)
         , m_right(right)
-        , m_body((StatementNode *)body)
+        , m_body(body)
         , m_forIn(forIn)
         , m_hasLexicalDeclarationOnInit(hasLexicalDeclarationOnInit)
         , m_headLexicalBlockIndex(headLexicalBlockIndex)
@@ -54,7 +53,7 @@ public:
         }
     }
 
-    void generateBodyByteCode(ByteCodeBlock *codeBlock, ByteCodeGenerateContext *context, ByteCodeGenerateContext &newContext)
+    void generateBodyByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeGenerateContext& newContext)
     {
         // per iteration block
         size_t iterationLexicalBlockIndexBefore = newContext.m_lexicalBlockIndex;
@@ -62,14 +61,14 @@ public:
         uint8_t tmpIdentifierNode[sizeof(IdentifierNode)];
 
         if (m_iterationLexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
-            InterpretedCodeBlock::BlockInfo *bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
+            InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
             std::vector<size_t> nameRegisters;
             for (size_t i = 0; i < bi->m_identifiers.size(); i++) {
                 nameRegisters.push_back(newContext.getRegister());
             }
 
             for (size_t i = 0; i < bi->m_identifiers.size(); i++) {
-                IdentifierNode *id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[i].m_name);
+                IdentifierNode* id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[i].m_name);
                 id->m_loc = m_loc;
                 id->generateExpressionByteCode(codeBlock, &newContext, nameRegisters[i]);
             }
@@ -83,7 +82,7 @@ public:
 
             size_t reverse = bi->m_identifiers.size() - 1;
             for (size_t i = 0; i < bi->m_identifiers.size(); i++, reverse--) {
-                IdentifierNode *id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[reverse].m_name);
+                IdentifierNode* id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[reverse].m_name);
                 id->m_loc = m_loc;
                 newContext.m_isLexicallyDeclaredBindingInitialization = m_hasLexicalDeclarationOnInit;
                 id->generateStoreByteCode(codeBlock, &newContext, nameRegisters[reverse], true);
@@ -95,14 +94,14 @@ public:
         m_body->generateStatementByteCode(codeBlock, &newContext);
 
         if (m_iterationLexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
-            InterpretedCodeBlock::BlockInfo *bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
+            InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
             std::vector<size_t> nameRegisters;
             for (size_t i = 0; i < bi->m_identifiers.size(); i++) {
                 nameRegisters.push_back(newContext.getRegister());
             }
 
             for (size_t i = 0; i < bi->m_identifiers.size(); i++) {
-                IdentifierNode *id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[i].m_name);
+                IdentifierNode* id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[i].m_name);
                 id->m_loc = m_loc;
                 id->generateExpressionByteCode(codeBlock, &newContext, nameRegisters[i]);
             }
@@ -112,7 +111,7 @@ public:
 
             size_t reverse = bi->m_identifiers.size() - 1;
             for (size_t i = 0; i < bi->m_identifiers.size(); i++, reverse--) {
-                IdentifierNode *id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[reverse].m_name);
+                IdentifierNode* id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[reverse].m_name);
                 id->m_loc = m_loc;
                 newContext.m_isLexicallyDeclaredBindingInitialization = m_hasLexicalDeclarationOnInit;
                 id->generateStoreByteCode(codeBlock, &newContext, nameRegisters[reverse], true);
@@ -122,7 +121,7 @@ public:
         }
     }
 
-    virtual void generateStatementByteCode(ByteCodeBlock *codeBlock, ByteCodeGenerateContext *context) override
+    virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
         bool canSkipCopyToRegisterBefore = context->m_canSkipCopyToRegister;
         context->m_canSkipCopyToRegister = false;
@@ -131,7 +130,7 @@ public:
         ByteCodeBlock::ByteCodeLexicalBlockContext headBlockContext;
         if (m_headLexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
             context->m_lexicalBlockIndex = m_headLexicalBlockIndex;
-            InterpretedCodeBlock::BlockInfo *bi = codeBlock->m_codeBlock->blockInfo(m_headLexicalBlockIndex);
+            InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(m_headLexicalBlockIndex);
             headBlockContext = codeBlock->pushLexicalBlock(context, bi, this);
         }
 
@@ -332,7 +331,7 @@ public:
         }
     }
 
-    virtual void iterateChildren(const std::function<void(Node *node)> &fn) override
+    virtual void iterateChildren(const std::function<void(Node* node)>& fn) override
     {
         fn(this);
 
@@ -342,9 +341,9 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left;
-    RefPtr<Node> m_right;
-    RefPtr<StatementNode> m_body;
+    Node* m_left;
+    Node* m_right;
+    Node* m_body;
     bool m_forIn;
     bool m_hasLexicalDeclarationOnInit;
     LexicalBlockIndex m_headLexicalBlockIndex;

--- a/src/parser/ast/ForStatementNode.h
+++ b/src/parser/ast/ForStatementNode.h
@@ -27,15 +27,13 @@ namespace Escargot {
 
 class ForStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
-    ForStatementNode(Node *init, Node *test, Node *update, Node *body, bool hasLexicalDeclarationOnInit, LexicalBlockIndex headLexicalBlockIndex,
+    ForStatementNode(Node* init, Node* test, Node* update, Node* body, bool hasLexicalDeclarationOnInit, LexicalBlockIndex headLexicalBlockIndex,
                      LexicalBlockIndex iterationLexicalBlockIndex)
         : StatementNode()
-        , m_init((ExpressionNode *)init)
-        , m_test((ExpressionNode *)test)
-        , m_update((ExpressionNode *)update)
-        , m_body(
-              (StatementNode *)body)
+        , m_init(init)
+        , m_test(test)
+        , m_update(update)
+        , m_body(body)
         , m_hasLexicalDeclarationOnInit(hasLexicalDeclarationOnInit)
         , m_headLexicalBlockIndex(headLexicalBlockIndex)
         , m_iterationLexicalBlockIndex(
@@ -52,14 +50,14 @@ public:
         return ASTNodeType::ForStatement;
     }
 
-    virtual void generateStatementByteCode(ByteCodeBlock *codeBlock, ByteCodeGenerateContext *context) override
+    virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
         // TODO remove iterationLexicalBlock if there is no capture from child blocks or self
         size_t headLexicalBlockIndexBefore = context->m_lexicalBlockIndex;
         ByteCodeBlock::ByteCodeLexicalBlockContext headBlockContext;
         if (m_headLexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
             context->m_lexicalBlockIndex = m_headLexicalBlockIndex;
-            InterpretedCodeBlock::BlockInfo *bi = codeBlock->m_codeBlock->blockInfo(m_headLexicalBlockIndex);
+            InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(m_headLexicalBlockIndex);
             headBlockContext = codeBlock->pushLexicalBlock(context, bi, this);
         }
 
@@ -77,14 +75,14 @@ public:
         uint8_t tmpIdentifierNode[sizeof(IdentifierNode)];
 
         if (m_iterationLexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
-            InterpretedCodeBlock::BlockInfo *bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
+            InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
             std::vector<size_t> nameRegisters;
             for (size_t i = 0; i < bi->m_identifiers.size(); i++) {
                 nameRegisters.push_back(newContext.getRegister());
             }
 
             for (size_t i = 0; i < bi->m_identifiers.size(); i++) {
-                IdentifierNode *id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[i].m_name);
+                IdentifierNode* id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[i].m_name);
                 id->m_loc = m_loc;
                 id->generateExpressionByteCode(codeBlock, &newContext, nameRegisters[i]);
             }
@@ -98,7 +96,7 @@ public:
 
             size_t reverse = bi->m_identifiers.size() - 1;
             for (size_t i = 0; i < bi->m_identifiers.size(); i++, reverse--) {
-                IdentifierNode *id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[reverse].m_name);
+                IdentifierNode* id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[reverse].m_name);
                 id->m_loc = m_loc;
                 newContext.m_isLexicallyDeclaredBindingInitialization = m_hasLexicalDeclarationOnInit;
                 id->generateStoreByteCode(codeBlock, &newContext, nameRegisters[reverse], true);
@@ -137,7 +135,7 @@ public:
 
         // replace env if needed
         if (m_iterationLexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
-            InterpretedCodeBlock::BlockInfo *bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
+            InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
             if (bi->m_shouldAllocateEnvironment) {
                 newContext.getRegister();
 
@@ -147,7 +145,7 @@ public:
                 }
 
                 for (size_t i = 0; i < bi->m_identifiers.size(); i++) {
-                    IdentifierNode *id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[i].m_name);
+                    IdentifierNode* id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[i].m_name);
                     id->m_loc = m_loc;
                     id->generateExpressionByteCode(codeBlock, &newContext, nameRegisters[i]);
                 }
@@ -158,7 +156,7 @@ public:
 
                 size_t reverse = bi->m_identifiers.size() - 1;
                 for (size_t i = 0; i < bi->m_identifiers.size(); i++, reverse--) {
-                    IdentifierNode *id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[reverse].m_name);
+                    IdentifierNode* id = new (tmpIdentifierNode) IdentifierNode(bi->m_identifiers[reverse].m_name);
                     id->m_loc = m_loc;
                     newContext.m_isLexicallyDeclaredBindingInitialization = m_hasLexicalDeclarationOnInit;
                     id->generateStoreByteCode(codeBlock, &newContext, nameRegisters[reverse], true);
@@ -188,7 +186,7 @@ public:
         }
 
         if (m_iterationLexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {
-            InterpretedCodeBlock::BlockInfo *bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
+            InterpretedCodeBlock::BlockInfo* bi = codeBlock->m_codeBlock->blockInfo(m_iterationLexicalBlockIndex);
             codeBlock->finalizeLexicalBlock(&newContext, iterationBlockContext);
             newContext.m_lexicalBlockIndex = iterationLexicalBlockIndexBefore;
             if (bi->m_shouldAllocateEnvironment) {
@@ -207,7 +205,7 @@ public:
         }
     }
 
-    virtual void iterateChildren(const std::function<void(Node *node)> &fn) override
+    virtual void iterateChildren(const std::function<void(Node* node)>& fn) override
     {
         fn(this);
 
@@ -229,10 +227,10 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_init;
-    RefPtr<ExpressionNode> m_test;
-    RefPtr<ExpressionNode> m_update;
-    RefPtr<StatementNode> m_body;
+    Node* m_init;
+    Node* m_test;
+    Node* m_update;
+    Node* m_body;
     bool m_hasLexicalDeclarationOnInit;
     LexicalBlockIndex m_headLexicalBlockIndex;
     LexicalBlockIndex m_iterationLexicalBlockIndex;

--- a/src/parser/ast/FunctionDeclarationNode.h
+++ b/src/parser/ast/FunctionDeclarationNode.h
@@ -24,7 +24,6 @@ namespace Escargot {
 
 class FunctionDeclarationNode : public StatementNode {
 public:
-    friend class ScriptParser;
     FunctionDeclarationNode(ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t /*subCodeBlockIndex not used yet*/)
         : m_isGenerator(isGenerator)
         , m_scopeContext(scopeContext)

--- a/src/parser/ast/FunctionExpressionNode.h
+++ b/src/parser/ast/FunctionExpressionNode.h
@@ -24,7 +24,6 @@ namespace Escargot {
 
 class FunctionExpressionNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
     FunctionExpressionNode(ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t subCodeBlockIndex)
         : m_isGenerator(isGenerator)
         , m_scopeContext(scopeContext)

--- a/src/parser/ast/FunctionNode.h
+++ b/src/parser/ast/FunctionNode.h
@@ -51,12 +51,12 @@ public:
     BlockStatementNode* body()
     {
         ASSERT(!!m_body);
-        return m_body.get();
+        return m_body;
     }
 
 private:
-    RefPtr<StatementContainer> m_params;
-    RefPtr<BlockStatementNode> m_body;
+    StatementContainer* m_params;
+    BlockStatementNode* m_body;
     NumeralLiteralVector m_numeralLiteralVector;
 };
 }

--- a/src/parser/ast/IdentifierNode.h
+++ b/src/parser/ast/IdentifierNode.h
@@ -30,8 +30,6 @@ namespace Escargot {
 // interface Identifier <: Node, Expression, Pattern {
 class IdentifierNode : public Node {
 public:
-    friend class ScriptParser;
-
     IdentifierNode()
         : Node()
         , m_name()

--- a/src/parser/ast/IfStatementNode.h
+++ b/src/parser/ast/IfStatementNode.h
@@ -26,12 +26,11 @@ namespace Escargot {
 
 class IfStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
     IfStatementNode(Node* test, Node* consequente, Node* alternate)
         : StatementNode()
-        , m_test((ExpressionNode*)test)
-        , m_consequente((StatementNode*)consequente)
-        , m_alternate((StatementNode*)alternate)
+        , m_test(test)
+        , m_consequente(consequente)
+        , m_alternate(alternate)
     {
     }
 
@@ -97,9 +96,9 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_test;
-    RefPtr<StatementNode> m_consequente;
-    RefPtr<StatementNode> m_alternate;
+    Node* m_test;
+    Node* m_consequente;
+    Node* m_alternate;
 };
 }
 

--- a/src/parser/ast/ImportDeclarationNode.h
+++ b/src/parser/ast/ImportDeclarationNode.h
@@ -25,12 +25,16 @@
 
 namespace Escargot {
 
-class ImportDeclarationNode : public StatementNode {
+class ImportDeclarationNode : public StatementNode, public DestructibleNode {
 public:
-    friend class ScriptParser;
-    ImportDeclarationNode(NodeVector&& specifiers, RefPtr<Node> src)
+    using DestructibleNode::operator new;
+    ImportDeclarationNode(NodeVector&& specifiers, Node* src)
         : m_specifiers(specifiers)
         , m_src(src)
+    {
+    }
+
+    virtual ~ImportDeclarationNode()
     {
     }
 
@@ -51,7 +55,7 @@ public:
 
 private:
     NodeVector m_specifiers;
-    RefPtr<Node> m_src;
+    Node* m_src;
 };
 }
 

--- a/src/parser/ast/ImportDefaultSpecifierNode.h
+++ b/src/parser/ast/ImportDefaultSpecifierNode.h
@@ -26,8 +26,7 @@ namespace Escargot {
 
 class ImportDefaultSpecifierNode : public Node {
 public:
-    friend class ScriptParser;
-    ImportDefaultSpecifierNode(RefPtr<Node> local)
+    ImportDefaultSpecifierNode(Node* local)
         : m_local(local)
     {
         ASSERT(local->isIdentifier());
@@ -47,7 +46,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_local;
+    Node* m_local;
 };
 }
 

--- a/src/parser/ast/ImportNamespaceSpecifierNode.h
+++ b/src/parser/ast/ImportNamespaceSpecifierNode.h
@@ -26,8 +26,7 @@ namespace Escargot {
 
 class ImportNamespaceSpecifierNode : public Node {
 public:
-    friend class ScriptParser;
-    ImportNamespaceSpecifierNode(RefPtr<Node> local)
+    ImportNamespaceSpecifierNode(Node* local)
         : m_local(local)
     {
         ASSERT(local->isIdentifier());
@@ -47,7 +46,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_local;
+    Node* m_local;
 };
 }
 

--- a/src/parser/ast/ImportSpecifierNode.h
+++ b/src/parser/ast/ImportSpecifierNode.h
@@ -26,8 +26,7 @@ namespace Escargot {
 
 class ImportSpecifierNode : public Node {
 public:
-    friend class ScriptParser;
-    ImportSpecifierNode(RefPtr<Node> local, RefPtr<Node> imported)
+    ImportSpecifierNode(Node* local, Node* imported)
         : m_local(local)
         , m_imported(imported)
     {
@@ -54,8 +53,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_local;
-    RefPtr<Node> m_imported;
+    Node* m_local;
+    Node* m_imported;
 };
 }
 

--- a/src/parser/ast/InitializeParameterExpressionNode.h
+++ b/src/parser/ast/InitializeParameterExpressionNode.h
@@ -27,8 +27,6 @@ namespace Escargot {
 
 class InitializeParameterExpressionNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
-
     InitializeParameterExpressionNode(Node* left, size_t index)
         : ExpressionNode()
         , m_left(left)
@@ -78,7 +76,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_left;
+    Node* m_left;
     size_t m_paramIndex; // parameter index
 };
 }

--- a/src/parser/ast/LabeledStatementNode.h
+++ b/src/parser/ast/LabeledStatementNode.h
@@ -26,7 +26,6 @@ namespace Escargot {
 
 class LabeledStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
     LabeledStatementNode(Node* statementNode, String* label)
         : StatementNode()
         , m_statementNode(statementNode)
@@ -57,7 +56,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_statementNode;
+    Node* m_statementNode;
     String* m_label;
 };
 }

--- a/src/parser/ast/MemberExpressionNode.h
+++ b/src/parser/ast/MemberExpressionNode.h
@@ -43,12 +43,12 @@ public:
 
     Node* object()
     {
-        return m_object.get();
+        return m_object;
     }
 
     Node* property()
     {
-        return m_property.get();
+        return m_property;
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::MemberExpression; }
@@ -60,7 +60,7 @@ public:
     AtomicString propertyName()
     {
         ASSERT(isPreComputedCase());
-        return ((IdentifierNode*)m_property.get())->name();
+        return ((IdentifierNode*)m_property)->name();
     }
 
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstIndex) override
@@ -87,7 +87,7 @@ public:
             ASSERT(m_property->isIdentifier());
             if (m_object->isSuperExpression()) {
                 size_t propertyIndex = m_property->getRegister(codeBlock, context);
-                codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_property->asIdentifier()->m_loc.index), propertyIndex, m_property->asIdentifier()->name().string()), context, m_property.get());
+                codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_property->asIdentifier()->m_loc.index), propertyIndex, m_property->asIdentifier()->name().string()), context, m_property);
                 codeBlock->pushCode(SuperGetObjectOperation(ByteCodeLOC(m_loc.index), objectIndex, dstIndex, propertyIndex), context, this);
                 context->giveUpRegister();
             } else {
@@ -127,7 +127,7 @@ public:
 
             if (m_object->isSuperExpression()) {
                 size_t propertyIndex = m_property->getRegister(codeBlock, context);
-                codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_property->asIdentifier()->m_loc.index), propertyIndex, m_property->asIdentifier()->name().string()), context, m_property.get());
+                codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_property->asIdentifier()->m_loc.index), propertyIndex, m_property->asIdentifier()->name().string()), context, m_property);
                 codeBlock->pushCode(SuperSetObjectOperation(ByteCodeLOC(m_loc.index), objectIndex, propertyIndex, valueIndex), context, this);
                 context->giveUpRegister();
                 context->giveUpRegister();
@@ -215,8 +215,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_object; // object: Expression;
-    RefPtr<Node> m_property; // property: Identifier | Expression;
+    Node* m_object; // object: Expression;
+    Node* m_property; // property: Identifier | Expression;
 
     bool m_computed : 1;
 };

--- a/src/parser/ast/MetaPropertyNode.h
+++ b/src/parser/ast/MetaPropertyNode.h
@@ -37,8 +37,6 @@ public:
     {
         codeBlock->pushCode(NewTargetOperation(ByteCodeLOC(m_loc.index), dstRegister), context, this);
     }
-
-private:
 };
 }
 

--- a/src/parser/ast/NewExpressionNode.h
+++ b/src/parser/ast/NewExpressionNode.h
@@ -25,9 +25,9 @@
 
 namespace Escargot {
 
-class NewExpressionNode : public ExpressionNode {
+class NewExpressionNode : public ExpressionNode, public DestructibleNode {
 public:
-    friend class ScriptParser;
+    using DestructibleNode::operator new;
     NewExpressionNode(Node* callee, NodeVector&& arguments)
         : ExpressionNode()
         , m_callee(callee)
@@ -93,7 +93,7 @@ public:
     }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
-        bool isSlow = !CallExpressionNode::canUseDirectRegister(context, m_callee.get(), m_arguments);
+        bool isSlow = !CallExpressionNode::canUseDirectRegister(context, m_callee, m_arguments);
         bool directBefore = context->m_canSkipCopyToRegister;
         if (isSlow) {
             context->m_canSkipCopyToRegister = false;
@@ -137,7 +137,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_callee;
+    Node* m_callee;
     NodeVector m_arguments;
     bool m_hasSpreadElement;
 };

--- a/src/parser/ast/Node.cpp
+++ b/src/parser/ast/Node.cpp
@@ -53,35 +53,4 @@ void Node::generateReferenceResolvedAddressByteCode(ByteCodeBlock* codeBlock, By
     codeBlock->pushCode(ThrowStaticErrorOperation(ByteCodeLOC(m_loc.index), ErrorObject::ReferenceError, "Invalid assignment left-hand side"), context, this);
     return;
 }
-
-void* ASTBlockScopeContext::operator new(size_t size)
-{
-    static bool typeInited = false;
-    static GC_descr descr;
-    if (!typeInited) {
-        GC_word obj_bitmap[GC_BITMAP_SIZE(ASTBlockScopeContext)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTBlockScopeContext, m_names));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTBlockScopeContext, m_usingNames));
-        descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(ASTBlockScopeContext));
-        typeInited = true;
-    }
-    return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
-}
-
-void* ASTFunctionScopeContext::operator new(size_t size)
-{
-    static bool typeInited = false;
-    static GC_descr descr;
-    if (!typeInited) {
-        GC_word obj_bitmap[GC_BITMAP_SIZE(ASTFunctionScopeContext)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_varNames));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_parameters));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_firstChild));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_nextSibling));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ASTFunctionScopeContext, m_childBlockScopes));
-        descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(ASTFunctionScopeContext));
-        typeInited = true;
-    }
-    return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
-}
 }

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -277,12 +277,6 @@ public:
 
     void* operator new(size_t) = delete;
     void* operator new[](size_t) = delete;
-    /*
-    void operator delete(void *)
-    {
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-    */
     void operator delete[](void*) = delete;
 };
 

--- a/src/parser/ast/ObjectExpressionNode.h
+++ b/src/parser/ast/ObjectExpressionNode.h
@@ -27,9 +27,9 @@
 
 namespace Escargot {
 
-class ObjectExpressionNode : public ExpressionNode {
+class ObjectExpressionNode : public ExpressionNode, public DestructibleNode {
 public:
-    friend class ScriptParser;
+    using DestructibleNode::operator new;
     explicit ObjectExpressionNode(NodeVector&& properties)
         : ExpressionNode()
         , m_properties(properties)
@@ -51,7 +51,7 @@ public:
         codeBlock->pushCode(CreateObject(ByteCodeLOC(m_loc.index), dstRegister), context, this);
         size_t objIndex = dstRegister;
         for (unsigned i = 0; i < m_properties.size(); i++) {
-            PropertyNode* p = m_properties[i].get()->asProperty();
+            PropertyNode* p = m_properties[i]->asProperty();
             AtomicString propertyAtomicName;
             bool hasKey = false;
             size_t propertyIndex = SIZE_MAX;
@@ -110,7 +110,7 @@ public:
     virtual void iterateChildrenIdentifier(const std::function<void(AtomicString name, bool isAssignment)>& fn) override
     {
         for (size_t i = 0; i < m_properties.size(); i++) {
-            PropertyNode* p = m_properties[i].get()->asProperty();
+            PropertyNode* p = m_properties[i]->asProperty();
             if (!(p->key()->isIdentifier() && !p->computed())) {
                 p->key()->iterateChildrenIdentifier(fn);
             }

--- a/src/parser/ast/ObjectPatternNode.h
+++ b/src/parser/ast/ObjectPatternNode.h
@@ -25,9 +25,9 @@
 
 namespace Escargot {
 
-class ObjectPatternNode : public Node {
+class ObjectPatternNode : public Node, public DestructibleNode {
 public:
-    friend class ScriptParser;
+    using DestructibleNode::operator new;
     ObjectPatternNode(NodeVector&& properties)
         : m_properties(properties)
     {
@@ -91,7 +91,7 @@ public:
     virtual void iterateChildrenIdentifier(const std::function<void(AtomicString name, bool isAssignment)>& fn) override
     {
         for (size_t i = 0; i < m_properties.size(); i++) {
-            PropertyNode* p = m_properties[i].get()->asProperty();
+            PropertyNode* p = m_properties[i]->asProperty();
             if (!(p->key()->isIdentifier() && !p->computed())) {
                 p->key()->iterateChildrenIdentifier(fn);
             }

--- a/src/parser/ast/ProgramNode.h
+++ b/src/parser/ast/ProgramNode.h
@@ -29,7 +29,6 @@ namespace Escargot {
 
 class ProgramNode : public StatementNode {
 public:
-    friend class ScriptParser;
     ProgramNode(StatementContainer* body, ASTFunctionScopeContext* scopeContext, Script::ModuleData* moduleData, NumeralLiteralVector&& numeralLiteralVector)
         : StatementNode()
         , m_container(body)
@@ -42,7 +41,6 @@ public:
     virtual ~ProgramNode()
     {
     }
-
 
     virtual ASTNodeType type() override { return ASTNodeType::Program; }
     ASTFunctionScopeContext* scopeContext() { return m_scopeContext; }
@@ -69,7 +67,7 @@ public:
     }
 
 private:
-    RefPtr<StatementContainer> m_container;
+    StatementContainer* m_container;
     ASTFunctionScopeContext* m_scopeContext;
     Script::ModuleData* m_moduleData;
     NumeralLiteralVector m_numeralLiteralVector;

--- a/src/parser/ast/PropertyNode.h
+++ b/src/parser/ast/PropertyNode.h
@@ -27,7 +27,6 @@ namespace Escargot {
 
 class PropertyNode : public Node {
 public:
-    friend class ScriptParser;
     enum Kind {
         Init,
         Get,
@@ -51,12 +50,12 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::Property; }
     Node* key()
     {
-        return m_key.get();
+        return m_key;
     }
 
     Node* value()
     {
-        return m_value.get();
+        return m_value;
     }
 
     void setValue(Node* value)
@@ -111,8 +110,8 @@ private:
     Kind m_kind; // kind: "init" | "get" | "set";
     bool m_computed : 1;
     bool m_shorthand : 1;
-    RefPtr<Node> m_key; // key: Literal | Identifier;
-    RefPtr<Node> m_value; // value: Expression;
+    Node* m_key; // key: Literal | Identifier;
+    Node* m_value; // value: Expression;
 };
 }
 

--- a/src/parser/ast/RegisterReferenceNode.h
+++ b/src/parser/ast/RegisterReferenceNode.h
@@ -27,7 +27,6 @@ namespace Escargot {
 
 class RegisterReferenceNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
     RegisterReferenceNode(size_t registerIdx)
         : ExpressionNode()
         , m_registerIdx(registerIdx)

--- a/src/parser/ast/RestElementNode.h
+++ b/src/parser/ast/RestElementNode.h
@@ -47,7 +47,7 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::RestElement; }
     Node* argument()
     {
-        return m_argument.get();
+        return m_argument;
     }
 
     virtual void generateStoreByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex srcRegister, bool needToReferenceSelf) override
@@ -77,7 +77,7 @@ public:
     }
 
 protected:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/ReturnStatementNode.h
+++ b/src/parser/ast/ReturnStatementNode.h
@@ -26,7 +26,6 @@ namespace Escargot {
 
 class ReturnStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
     explicit ReturnStatementNode(Node* argument)
         : StatementNode()
         , m_argument(argument)
@@ -76,7 +75,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/SequenceExpressionNode.h
+++ b/src/parser/ast/SequenceExpressionNode.h
@@ -25,9 +25,9 @@
 namespace Escargot {
 
 // An sequence expression, i.e., a statement consisting of vector of expressions.
-class SequenceExpressionNode : public ExpressionNode {
+class SequenceExpressionNode : public ExpressionNode, public DestructibleNode {
 public:
-    friend class ScriptParser;
+    using DestructibleNode::operator new;
     explicit SequenceExpressionNode(NodeVector&& expressions)
         : ExpressionNode()
         , m_expressions(expressions)

--- a/src/parser/ast/SpreadElementNode.h
+++ b/src/parser/ast/SpreadElementNode.h
@@ -39,7 +39,7 @@ public:
     virtual ASTNodeType type() override { return SpreadElement; }
     Node* argument()
     {
-        return m_argument.get();
+        return m_argument;
     }
 
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
@@ -58,7 +58,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/SuperExpressionNode.h
+++ b/src/parser/ast/SuperExpressionNode.h
@@ -26,8 +26,6 @@ namespace Escargot {
 
 class SuperExpressionNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
-
     SuperExpressionNode(bool isCall)
         : ExpressionNode()
         , m_isCall(isCall)

--- a/src/parser/ast/SwitchCaseNode.h
+++ b/src/parser/ast/SwitchCaseNode.h
@@ -27,11 +27,9 @@ namespace Escargot {
 
 class SwitchCaseNode : public StatementNode {
 public:
-    friend class ScriptParser;
-    friend class SwitchStatementNode;
     SwitchCaseNode(Node* test, StatementContainer* consequent)
         : StatementNode()
-        , m_test((ExpressionNode*)test)
+        , m_test(test)
         , m_consequent(consequent)
     {
     }
@@ -44,6 +42,12 @@ public:
     bool isDefaultNode()
     {
         return !m_test;
+    }
+
+    Node* test()
+    {
+        ASSERT(!!m_test);
+        return m_test;
     }
 
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
@@ -62,8 +66,8 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_test;
-    RefPtr<StatementContainer> m_consequent;
+    Node* m_test;
+    StatementContainer* m_consequent;
 };
 }
 

--- a/src/parser/ast/SwitchStatementNode.h
+++ b/src/parser/ast/SwitchStatementNode.h
@@ -28,12 +28,11 @@ namespace Escargot {
 
 class SwitchStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
     SwitchStatementNode(Node* discriminant, StatementContainer* casesA, Node* deflt, StatementContainer* casesB)
         : StatementNode()
-        , m_discriminant((ExpressionNode*)discriminant)
+        , m_discriminant(discriminant)
         , m_casesA(casesA)
-        , m_default((StatementNode*)deflt)
+        , m_default(deflt)
         , m_casesB(casesB)
     {
     }
@@ -57,8 +56,8 @@ public:
         StatementNode* nd = m_casesB->firstChild();
         while (nd) {
             SwitchCaseNode* caseNode = (SwitchCaseNode*)nd;
-            size_t refIndex = caseNode->m_test->getRegister(codeBlock, &newContext);
-            caseNode->m_test->generateExpressionByteCode(codeBlock, &newContext, refIndex);
+            size_t refIndex = caseNode->test()->getRegister(codeBlock, &newContext);
+            caseNode->test()->generateExpressionByteCode(codeBlock, &newContext, refIndex);
             size_t resultIndex = newContext.getRegister();
             codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), refIndex, rIndex0, resultIndex), &newContext, this);
             jumpCodePerCaseNodePosition.push_back(codeBlock->currentCodeSize());
@@ -72,8 +71,8 @@ public:
         nd = m_casesA->firstChild();
         while (nd) {
             SwitchCaseNode* caseNode = (SwitchCaseNode*)nd;
-            size_t refIndex = caseNode->m_test->getRegister(codeBlock, &newContext);
-            caseNode->m_test->generateExpressionByteCode(codeBlock, &newContext, refIndex);
+            size_t refIndex = caseNode->test()->getRegister(codeBlock, &newContext);
+            caseNode->test()->generateExpressionByteCode(codeBlock, &newContext, refIndex);
             size_t resultIndex = newContext.getRegister();
             codeBlock->pushCode(BinaryStrictEqual(ByteCodeLOC(m_loc.index), refIndex, rIndex0, resultIndex), &newContext, this);
             jumpCodePerCaseNodePosition.push_back(codeBlock->currentCodeSize());
@@ -132,10 +131,10 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_discriminant;
-    RefPtr<StatementContainer> m_casesA;
-    RefPtr<StatementNode> m_default;
-    RefPtr<StatementContainer> m_casesB;
+    Node* m_discriminant;
+    StatementContainer* m_casesA;
+    Node* m_default;
+    StatementContainer* m_casesB;
 };
 }
 

--- a/src/parser/ast/TaggedTemplateExpressionNode.h
+++ b/src/parser/ast/TaggedTemplateExpressionNode.h
@@ -36,12 +36,12 @@ public:
 
     Node* expr()
     {
-        return m_expr.get();
+        return m_expr;
     }
 
     Node* quasi()
     {
-        return m_quasi.get();
+        return m_quasi;
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::TaggedTemplateExpression; }
@@ -56,8 +56,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_expr;
-    RefPtr<Node> m_quasi;
+    Node* m_expr;
+    Node* m_quasi;
 };
 }
 

--- a/src/parser/ast/TemplateLiteralNode.h
+++ b/src/parser/ast/TemplateLiteralNode.h
@@ -32,12 +32,17 @@ struct TemplateElement : public gc {
 
 typedef Vector<TemplateElement*, GCUtil::gc_malloc_allocator<TemplateElement*>> TemplateElementVector;
 
-class TemplateLiteralNode : public ExpressionNode {
+class TemplateLiteralNode : public ExpressionNode, public DestructibleNode {
 public:
+    using DestructibleNode::operator new;
     TemplateLiteralNode(TemplateElementVector* vector, NodeVector&& expressions)
         : ExpressionNode()
         , m_quasis(vector)
         , m_expressions(std::move(expressions))
+    {
+    }
+
+    virtual ~TemplateLiteralNode()
     {
     }
 

--- a/src/parser/ast/ThisExpressionNode.h
+++ b/src/parser/ast/ThisExpressionNode.h
@@ -51,8 +51,6 @@ public:
             codeBlock->pushCode(Move(ByteCodeLOC(m_loc.index), REGULAR_REGISTER_LIMIT, dstRegister), context, this);
         }
     }
-
-protected:
 };
 }
 

--- a/src/parser/ast/ThrowStatementNode.h
+++ b/src/parser/ast/ThrowStatementNode.h
@@ -27,7 +27,6 @@ namespace Escargot {
 // interface ThrowStatement <: Statement {
 class ThrowStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
     explicit ThrowStatementNode(Node* argument)
         : StatementNode()
         , m_argument(argument)
@@ -56,7 +55,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UnaryExpressionBitwiseNotNode.h
+++ b/src/parser/ast/UnaryExpressionBitwiseNotNode.h
@@ -26,7 +26,6 @@ namespace Escargot {
 
 class UnaryExpressionBitwiseNotNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
     UnaryExpressionBitwiseNotNode(Node* argument)
         : ExpressionNode()
         , m_argument(argument)
@@ -59,7 +58,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UnaryExpressionDeleteNode.h
+++ b/src/parser/ast/UnaryExpressionDeleteNode.h
@@ -26,10 +26,9 @@ namespace Escargot {
 
 class UnaryExpressionDeleteNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
     explicit UnaryExpressionDeleteNode(Node* argument)
         : ExpressionNode()
-        , m_argument((ExpressionNode*)argument)
+        , m_argument(argument)
     {
     }
     virtual ~UnaryExpressionDeleteNode()
@@ -58,17 +57,17 @@ public:
             }
         } else if (m_argument->isMemberExpression()) {
             ByteCodeRegisterIndex o = m_argument->getRegister(codeBlock, context);
-            ((MemberExpressionNode*)m_argument.get())->object()->generateExpressionByteCode(codeBlock, context, o);
+            ((MemberExpressionNode*)m_argument)->object()->generateExpressionByteCode(codeBlock, context, o);
             ByteCodeRegisterIndex p;
-            if (((MemberExpressionNode*)m_argument.get())->isPreComputedCase()) {
+            if (((MemberExpressionNode*)m_argument)->isPreComputedCase()) {
                 // we can use LoadLiteral here
                 // because, (MemberExpressionNode*)m_argument)->property()->asIdentifier()->name().string()
                 // is private by AtomicString (IdentifierNode always has AtomicString)
                 p = context->getRegister();
-                codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), p, Value(((MemberExpressionNode*)m_argument.get())->property()->asIdentifier()->name().string())), context, this);
+                codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), p, Value(((MemberExpressionNode*)m_argument)->property()->asIdentifier()->name().string())), context, this);
             } else {
-                p = ((MemberExpressionNode*)m_argument.get())->property()->getRegister(codeBlock, context);
-                ((MemberExpressionNode*)m_argument.get())->property()->generateExpressionByteCode(codeBlock, context, p);
+                p = ((MemberExpressionNode*)m_argument)->property()->getRegister(codeBlock, context);
+                ((MemberExpressionNode*)m_argument)->property()->generateExpressionByteCode(codeBlock, context, p);
             }
 
             context->giveUpRegister();
@@ -97,11 +96,11 @@ public:
 
     ExpressionNode* argument()
     {
-        return m_argument.get();
+        return (ExpressionNode*)m_argument;
     }
 
 private:
-    RefPtr<ExpressionNode> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UnaryExpressionLogicalNotNode.h
+++ b/src/parser/ast/UnaryExpressionLogicalNotNode.h
@@ -26,7 +26,6 @@ namespace Escargot {
 
 class UnaryExpressionLogicalNotNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
     explicit UnaryExpressionLogicalNotNode(Node* argument)
         : ExpressionNode()
         , m_argument(argument)
@@ -58,7 +57,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UnaryExpressionMinusNode.h
+++ b/src/parser/ast/UnaryExpressionMinusNode.h
@@ -26,7 +26,6 @@ namespace Escargot {
 
 class UnaryExpressionMinusNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
     explicit UnaryExpressionMinusNode(Node* argument)
         : ExpressionNode()
         , m_argument(argument)
@@ -59,7 +58,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UnaryExpressionPlusNode.h
+++ b/src/parser/ast/UnaryExpressionPlusNode.h
@@ -26,7 +26,6 @@ namespace Escargot {
 
 class UnaryExpressionPlusNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
     explicit UnaryExpressionPlusNode(Node* argument)
         : ExpressionNode()
         , m_argument(argument)
@@ -58,7 +57,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UnaryExpressionTypeOfNode.h
+++ b/src/parser/ast/UnaryExpressionTypeOfNode.h
@@ -26,7 +26,6 @@ namespace Escargot {
 
 class UnaryExpressionTypeOfNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
     explicit UnaryExpressionTypeOfNode(Node* argument)
         : ExpressionNode()
         , m_argument(argument)
@@ -82,7 +81,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UnaryExpressionVoidNode.h
+++ b/src/parser/ast/UnaryExpressionVoidNode.h
@@ -26,7 +26,6 @@ namespace Escargot {
 
 class UnaryExpressionVoidNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
     explicit UnaryExpressionVoidNode(Node* argument)
         : ExpressionNode()
         , m_argument(argument)
@@ -58,7 +57,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UpdateExpressionDecrementPostfixNode.h
+++ b/src/parser/ast/UpdateExpressionDecrementPostfixNode.h
@@ -26,11 +26,9 @@ namespace Escargot {
 
 class UpdateExpressionDecrementPostfixNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
-
     UpdateExpressionDecrementPostfixNode(Node* argument)
         : ExpressionNode()
-        , m_argument((ExpressionNode*)argument)
+        , m_argument(argument)
     {
     }
     virtual ~UpdateExpressionDecrementPostfixNode()
@@ -81,7 +79,7 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UpdateExpressionDecrementPrefixNode.h
+++ b/src/parser/ast/UpdateExpressionDecrementPrefixNode.h
@@ -26,11 +26,9 @@ namespace Escargot {
 
 class UpdateExpressionDecrementPrefixNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
-
     explicit UpdateExpressionDecrementPrefixNode(Node* argument)
         : ExpressionNode()
-        , m_argument((ExpressionNode*)argument)
+        , m_argument(argument)
     {
     }
     virtual ~UpdateExpressionDecrementPrefixNode()
@@ -79,7 +77,7 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UpdateExpressionIncrementPostfixNode.h
+++ b/src/parser/ast/UpdateExpressionIncrementPostfixNode.h
@@ -26,11 +26,9 @@ namespace Escargot {
 
 class UpdateExpressionIncrementPostfixNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
-
     explicit UpdateExpressionIncrementPostfixNode(Node* argument)
         : ExpressionNode()
-        , m_argument((ExpressionNode*)argument)
+        , m_argument(argument)
     {
     }
     virtual ~UpdateExpressionIncrementPostfixNode()
@@ -81,7 +79,7 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/UpdateExpressionIncrementPrefixNode.h
+++ b/src/parser/ast/UpdateExpressionIncrementPrefixNode.h
@@ -26,11 +26,9 @@ namespace Escargot {
 
 class UpdateExpressionIncrementPrefixNode : public ExpressionNode {
 public:
-    friend class ScriptParser;
-
     explicit UpdateExpressionIncrementPrefixNode(Node* argument)
         : ExpressionNode()
-        , m_argument((ExpressionNode*)argument)
+        , m_argument(argument)
     {
     }
     virtual ~UpdateExpressionIncrementPrefixNode()
@@ -79,7 +77,7 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_argument;
+    Node* m_argument;
 };
 }
 

--- a/src/parser/ast/VariableDeclarationNode.h
+++ b/src/parser/ast/VariableDeclarationNode.h
@@ -26,9 +26,9 @@
 
 namespace Escargot {
 
-class VariableDeclarationNode : public DeclarationNode {
+class VariableDeclarationNode : public DeclarationNode, public DestructibleNode {
 public:
-    friend class ScriptParser;
+    using DestructibleNode::operator new;
     explicit VariableDeclarationNode(NodeVector&& decl, EscargotLexer::KeywordKind kind)
         : DeclarationNode()
         , m_declarations(decl)

--- a/src/parser/ast/WhileStatementNode.h
+++ b/src/parser/ast/WhileStatementNode.h
@@ -27,11 +27,10 @@ namespace Escargot {
 
 class WhileStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
-    WhileStatementNode(Node *test, Node *body)
+    WhileStatementNode(Node* test, Node* body)
         : StatementNode()
-        , m_test((ExpressionNode *)test)
-        , m_body((StatementNode *)body)
+        , m_test(test)
+        , m_body(body)
     {
     }
 
@@ -40,7 +39,7 @@ public:
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::WhileStatement; }
-    virtual void generateStatementByteCode(ByteCodeBlock *codeBlock, ByteCodeGenerateContext *context) override
+    virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
         ByteCodeGenerateContext newContext(*context);
 
@@ -81,7 +80,7 @@ public:
         newContext.propagateInformationTo(*context);
     }
 
-    virtual void iterateChildren(const std::function<void(Node *node)> &fn) override
+    virtual void iterateChildren(const std::function<void(Node* node)>& fn) override
     {
         fn(this);
 
@@ -90,8 +89,8 @@ public:
     }
 
 private:
-    RefPtr<ExpressionNode> m_test;
-    RefPtr<StatementNode> m_body;
+    Node* m_test;
+    Node* m_body;
 };
 }
 

--- a/src/parser/ast/WithStatementNode.h
+++ b/src/parser/ast/WithStatementNode.h
@@ -26,8 +26,7 @@ namespace Escargot {
 
 class WithStatementNode : public StatementNode {
 public:
-    friend class ScriptParser;
-    WithStatementNode(RefPtr<Node> object, RefPtr<Node> body)
+    WithStatementNode(Node* object, Node* body)
         : StatementNode()
         , m_object(object)
         , m_body(body)
@@ -66,8 +65,8 @@ public:
     }
 
 private:
-    RefPtr<Node> m_object;
-    RefPtr<Node> m_body; // body: [ Statement ];
+    Node* m_object;
+    Node* m_body; // body: [ Statement ];
 };
 }
 

--- a/src/parser/ast/YieldExpressionNode.h
+++ b/src/parser/ast/YieldExpressionNode.h
@@ -26,7 +26,7 @@ namespace Escargot {
 
 class YieldExpressionNode : public ExpressionNode {
 public:
-    YieldExpressionNode(RefPtr<Node> argument, bool isDelegate)
+    YieldExpressionNode(Node* argument, bool isDelegate)
         : ExpressionNode()
         , m_argument(argument)
         , m_isDelegate(isDelegate)
@@ -100,7 +100,7 @@ public:
     }
 
 private:
-    RefPtr<Node> m_argument;
+    Node* m_argument;
     bool m_isDelegate : 1;
 };
 }

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -50,8 +50,6 @@
 #define ALLOC_TOKEN(tokenName) Scanner::ScannerResult* tokenName = ALLOCA(sizeof(Scanner::ScannerResult), Scanner::ScannerResult, ec);
 
 #define ASTNode typename ASTBuilder::ASTNode
-#define ASTPassNode typename ASTBuilder::ASTPassNode
-#define ASTNodePtr typename ASTBuilder::ASTNodePtr
 #define ASTIdentifierNode typename ASTBuilder::ASTIdentifierNode
 #define ASTStatementContainer typename ASTBuilder::ASTStatementContainer
 #define ASTStatementNodePtr typename ASTBuilder::ASTStatementNodePtr
@@ -600,11 +598,12 @@ public:
         return n;
     }
 
+    // FIXME remove finalize methods
     template <typename T>
-    ALWAYS_INLINE PassRefPtr<T> finalize(MetaNode meta, T* node)
+    ALWAYS_INLINE T* finalize(MetaNode meta, T* node)
     {
         node->m_loc = NodeLOC(meta.index);
-        return adoptRef(node);
+        return node;
     }
 
     ALWAYS_INLINE SyntaxNode finalize(MetaNode meta, SyntaxNode node)
@@ -738,11 +737,11 @@ public:
         return false;
     }
 
-    bool isPropertyKey(SyntaxNode* key, const StringView& name, const char* value)
+    bool isPropertyKey(SyntaxNode key, const StringView& name, const char* value)
     {
-        if (key->type() == Identifier) {
-            return key->name() == value;
-        } else if (key->type() == Literal) {
+        if (key.type() == Identifier) {
+            return key.name() == value;
+        } else if (key.type() == Literal) {
             return name.equals(value);
         }
 
@@ -843,36 +842,36 @@ public:
     }
 
     template <class ASTBuilder, typename T>
-    ALWAYS_INLINE ASTPassNode isolateCoverGrammar(ASTBuilder& builder, T parseFunction)
+    ALWAYS_INLINE ASTNode isolateCoverGrammar(ASTBuilder& builder, T parseFunction)
     {
         IsolateCoverGrammarContext grammarContext;
         startCoverGrammar(&grammarContext);
 
-        ASTPassNode result = (this->*parseFunction)(builder);
+        ASTNode result = (this->*parseFunction)(builder);
         endIsolateCoverGrammar(&grammarContext);
 
         return result;
     }
 
     template <class ASTBuilder, typename T>
-    ALWAYS_INLINE ASTPassNode isolateCoverGrammarWithFunctor(ASTBuilder& builder, T parseFunction)
+    ALWAYS_INLINE ASTNode isolateCoverGrammarWithFunctor(ASTBuilder& builder, T parseFunction)
     {
         IsolateCoverGrammarContext grammarContext;
         startCoverGrammar(&grammarContext);
 
-        ASTPassNode result = parseFunction();
+        ASTNode result = parseFunction();
         endIsolateCoverGrammar(&grammarContext);
 
         return result;
     }
 
     template <class ASTBuilder, typename T>
-    ALWAYS_INLINE ASTPassNode inheritCoverGrammar(ASTBuilder& builder, T parseFunction)
+    ALWAYS_INLINE ASTNode inheritCoverGrammar(ASTBuilder& builder, T parseFunction)
     {
         IsolateCoverGrammarContext grammarContext;
         startCoverGrammar(&grammarContext);
 
-        ASTPassNode result = (this->*parseFunction)(builder);
+        ASTNode result = (this->*parseFunction)(builder);
         endInheritCoverGrammar(&grammarContext);
 
         return result;
@@ -905,7 +904,7 @@ public:
     // ECMA-262 12.2 Primary Expressions
 
     template <class ASTBuilder>
-    ASTPassNode parsePrimaryExpression(ASTBuilder& builder)
+    ASTNode parsePrimaryExpression(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
 
@@ -1044,7 +1043,7 @@ public:
         }
 
         ASSERT_NOT_REACHED();
-        return ASTPassNode();
+        return ASTNode();
     }
 
     void validateParam(ParseFormalParametersResult& options, const Scanner::SmallScannerResult& param, AtomicString name)
@@ -1076,7 +1075,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseRestElement(ASTBuilder& builder, SmallScannerResultVector& params)
+    ASTNode parseRestElement(ASTBuilder& builder, SmallScannerResultVector& params)
     {
         MetaNode node = this->createNode();
 
@@ -1088,22 +1087,22 @@ public:
         if (!this->match(RightParenthesis)) {
             this->throwError(Messages::ParameterAfterRestParameter);
         }
-        return this->finalize(node, builder.createRestElementNode(arg.get()));
+        return this->finalize(node, builder.createRestElementNode(arg));
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseBindingRestElement(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
+    ASTNode parseBindingRestElement(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
     {
         MetaNode node = this->createNode();
         this->expect(PeriodPeriodPeriod);
         ASTNode arg = this->parsePattern(builder, params, kind, isExplicitVariableDeclaration);
-        return this->finalize(node, builder.createRestElementNode(arg.get()));
+        return this->finalize(node, builder.createRestElementNode(arg));
     }
 
     // ECMA-262 13.3.3 Destructuring Binding Patterns
 
     template <class ASTBuilder>
-    ASTPassNode parseArrayPattern(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
+    ASTNode parseArrayPattern(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
     {
         MetaNode node = this->createNode();
 
@@ -1131,7 +1130,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parsePropertyPattern(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
+    ASTNode parsePropertyPattern(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
     {
         MetaNode node = this->createNode();
 
@@ -1139,8 +1138,8 @@ public:
         bool shorthand = false;
         bool method = false;
 
-        ASTNode keyNode; //'': Node.PropertyKey;
-        ASTNode valueNode; //: Node.PropertyValue;
+        ASTNode keyNode = nullptr; //'': Node.PropertyKey;
+        ASTNode valueNode = nullptr; //: Node.PropertyValue;
 
         if (this->lookahead.type == Token::IdentifierToken) {
             ALLOC_TOKEN(keyToken);
@@ -1153,7 +1152,7 @@ public:
                 this->nextToken();
 
                 ASTNode expr = this->parseAssignmentExpression<ASTBuilder, false>(builder);
-                valueNode = this->finalize(this->startNode(keyToken), builder.createAssignmentPatternNode(keyNode.get(), expr.get()));
+                valueNode = this->finalize(this->startNode(keyToken), builder.createAssignmentPatternNode(keyNode, expr));
             } else if (!this->match(Colon)) {
                 params.push_back(*keyToken);
                 if (isExplicitVariableDeclaration) {
@@ -1174,11 +1173,11 @@ public:
             valueNode = this->parsePatternWithDefault(builder, params, kind, isExplicitVariableDeclaration);
         }
 
-        return this->finalize(node, builder.createPropertyNode(keyNode.get(), valueNode.get(), PropertyNode::Kind::Init, computed, shorthand));
+        return this->finalize(node, builder.createPropertyNode(keyNode, valueNode, PropertyNode::Kind::Init, computed, shorthand));
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseObjectPattern(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
+    ASTNode parseObjectPattern(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
     {
         MetaNode node = this->createNode();
         ASTNodeVector properties;
@@ -1197,7 +1196,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parsePattern(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
+    ASTNode parsePattern(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
     {
         if (this->match(LeftSquareBracket)) {
             return this->parseArrayPattern(builder, params, kind, isExplicitVariableDeclaration);
@@ -1213,27 +1212,27 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parsePatternWithDefault(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
+    ASTNode parsePatternWithDefault(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
     {
         ALLOC_TOKEN(startToken);
         *startToken = this->lookahead;
 
-        ASTPassNode pattern = this->parsePattern(builder, params, kind, isExplicitVariableDeclaration);
+        ASTNode pattern = this->parsePattern(builder, params, kind, isExplicitVariableDeclaration);
         if (this->match(PunctuatorKind::Substitution)) {
             this->nextToken();
             const bool previousAllowYield = this->context->allowYield;
-            ASTPassNode right = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
+            ASTNode right = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
 
-            return this->finalize(this->startNode(startToken), builder.createAssignmentPatternNode(pattern.get(), right.get()));
+            return this->finalize(this->startNode(startToken), builder.createAssignmentPatternNode(pattern, right));
         }
 
         return pattern;
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseFormalParameter(ASTBuilder& builder, ParseFormalParametersResult& options, bool& end)
+    ASTNode parseFormalParameter(ASTBuilder& builder, ParseFormalParametersResult& options, bool& end)
     {
-        ASTNode param;
+        ASTNode param = nullptr;
         bool trackUsingNamesBefore = this->trackUsingNames;
         this->trackUsingNames = false;
         SmallScannerResultVector params;
@@ -1292,22 +1291,21 @@ public:
     // ECMA-262 12.2.5 Array Initializer
 
     template <class ASTBuilder, bool checkLeftHasRestrictedWord>
-    ASTPassNode parseSpreadElement(ASTBuilder& builder)
+    ASTNode parseSpreadElement(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
         this->expect(PunctuatorKind::PeriodPeriodPeriod);
 
-        ASTNode arg;
-        arg = this->inheritCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, checkLeftHasRestrictedWord>);
+        ASTNode arg = this->inheritCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, checkLeftHasRestrictedWord>);
         if (arg->isAssignmentOperation()) {
             this->throwError(Messages::DefaultRestParameter);
         }
 
-        return this->finalize(node, builder.createSpreadElementNode(arg.get()));
+        return this->finalize(node, builder.createSpreadElementNode(arg));
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseArrayInitializer(ASTBuilder& builder)
+    ASTNode parseArrayInitializer(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
         ASTNodeVector elements;
@@ -1343,13 +1341,13 @@ public:
     // ECMA-262 12.2.6 Object Initializer
 
     template <class ASTBuilder>
-    ASTPassNode parsePropertyMethod(ASTBuilder& builder, ParseFormalParametersResult& params)
+    ASTNode parsePropertyMethod(ASTBuilder& builder, ParseFormalParametersResult& params)
     {
         this->context->isAssignmentTarget = false;
         this->context->isBindingElement = false;
 
         const bool previousStrict = this->context->strict;
-        ASTPassNode body = this->isolateCoverGrammar(builder, &Parser::parseFunctionSourceElements<ASTBuilder>);
+        ASTNode body = this->isolateCoverGrammar(builder, &Parser::parseFunctionSourceElements<ASTBuilder>);
         if (this->context->strict && params.firstRestricted) {
             this->throwUnexpectedToken(params.firstRestricted, params.message);
         }
@@ -1362,7 +1360,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parsePropertyMethodFunction(ASTBuilder& builder, bool allowSuperCall)
+    ASTNode parsePropertyMethodFunction(ASTBuilder& builder, bool allowSuperCall)
     {
         const bool isGenerator = false;
         const bool previousAllowYield = this->context->allowYield;
@@ -1404,13 +1402,13 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseObjectPropertyKey(ASTBuilder& builder, StringView& keyString)
+    ASTNode parseObjectPropertyKey(ASTBuilder& builder, StringView& keyString)
     {
         MetaNode node = this->createNode();
         ALLOC_TOKEN(token);
         this->nextToken(token);
 
-        ASTNode key;
+        ASTNode key = nullptr;
         switch (token->type) {
         case Token::NumericLiteralToken:
         case Token::StringLiteralToken:
@@ -1471,15 +1469,15 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseObjectProperty(ASTBuilder& builder, bool& hasProto) //: Node.Property
+    ASTNode parseObjectProperty(ASTBuilder& builder, bool& hasProto) //: Node.Property
     {
         ALLOC_TOKEN(token);
         *token = this->lookahead;
         MetaNode node = this->createNode();
 
         PropertyNode::Kind kind;
-        ASTNode keyNode; //'': Node.PropertyKey;
-        ASTNode valueNode; //: Node.PropertyValue;
+        ASTNode keyNode = nullptr; //'': Node.PropertyKey;
+        ASTNode valueNode = nullptr; //: Node.PropertyValue;
         StringView keyString;
 
         bool computed = false;
@@ -1537,7 +1535,7 @@ public:
             kind = PropertyNode::Kind::Init;
             if (this->match(PunctuatorKind::Colon)) {
                 // FIXME check !this->isParsingSingleFunction
-                isProto = !this->isParsingSingleFunction && this->isPropertyKey(keyNode.get(), keyString, "__proto__");
+                isProto = !this->isParsingSingleFunction && this->isPropertyKey(keyNode, keyString, "__proto__");
 
                 if (!computed && isProto) {
                     if (hasProto) {
@@ -1582,7 +1580,7 @@ public:
                     this->nextToken();
                     shorthand = true;
                     ASTNode init = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
-                    valueNode = this->finalize(node, builder.createAssignmentPatternNode(keyNode.get(), init.get()));
+                    valueNode = this->finalize(node, builder.createAssignmentPatternNode(keyNode, init));
                 } else {
                     shorthand = true;
                     valueNode = keyNode;
@@ -1611,11 +1609,11 @@ public:
                 this->lastPoppedScopeContext->m_isClassMethod = true;
             }
         }
-        return this->finalize(node, builder.createPropertyNode(keyNode.get(), valueNode.get(), kind, computed, shorthand));
+        return this->finalize(node, builder.createPropertyNode(keyNode, valueNode, kind, computed, shorthand));
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseObjectInitializer(ASTBuilder& builder)
+    ASTNode parseObjectInitializer(ASTBuilder& builder)
     {
         this->expect(LeftBrace);
         MetaNode node = this->createNode();
@@ -1671,7 +1669,7 @@ public:
 
 
     template <class ASTBuilder>
-    ASTPassNode parseTemplateLiteral(ASTBuilder& builder)
+    ASTNode parseTemplateLiteral(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
 
@@ -1687,9 +1685,9 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseGroupExpression(ASTBuilder& builder)
+    ASTNode parseGroupExpression(ASTBuilder& builder)
     {
-        ASTNode exprNode;
+        ASTNode exprNode = nullptr;
 
         this->expect(LeftParenthesis);
         if (this->match(RightParenthesis)) {
@@ -1709,7 +1707,7 @@ public:
                 if (!this->match(Arrow)) {
                     this->expect(Arrow);
                 }
-                exprNode = this->finalize(this->createNode(), builder.createArrowParameterPlaceHolderNode(exprNode.get()));
+                exprNode = this->finalize(this->createNode(), builder.createArrowParameterPlaceHolderNode(exprNode));
             } else {
                 bool arrow = false;
                 this->context->isBindingElement = true;
@@ -1729,7 +1727,7 @@ public:
                         if (this->match(RightParenthesis)) {
                             this->nextToken();
                             for (size_t i = 0; i < expressions.size(); i++) {
-                                expressions[i] = builder.reinterpretExpressionAsPattern(expressions[i].get());
+                                expressions[i] = builder.reinterpretExpressionAsPattern(expressions[i]);
                             }
                             arrow = true;
                             exprNode = this->finalize(this->createNode(), builder.createArrowParameterPlaceHolderNode(std::move(expressions)));
@@ -1744,7 +1742,7 @@ public:
                             }
                             this->context->isBindingElement = false;
                             for (size_t i = 0; i < expressions.size(); i++) {
-                                expressions[i] = builder.reinterpretExpressionAsPattern(expressions[i].get());
+                                expressions[i] = builder.reinterpretExpressionAsPattern(expressions[i]);
                             }
                             arrow = true;
                             exprNode = this->finalize(this->createNode(), builder.createArrowParameterPlaceHolderNode(std::move(expressions)));
@@ -1765,7 +1763,7 @@ public:
                     if (this->match(Arrow)) {
                         if (exprNode->type() == Identifier && exprNode->asIdentifier()->name() == "yield") {
                             arrow = true;
-                            exprNode = this->finalize(this->createNode(), builder.createArrowParameterPlaceHolderNode(exprNode.get()));
+                            exprNode = this->finalize(this->createNode(), builder.createArrowParameterPlaceHolderNode(exprNode));
                         }
                         if (!arrow) {
                             if (!this->context->isBindingElement) {
@@ -1775,10 +1773,10 @@ public:
                             if (builder.isNodeGenerator() && (exprNode->type() == SequenceExpression)) {
                                 ASTNodeVector& expressions = exprNode->asSequenceExpression()->expressions();
                                 for (size_t i = 0; i < expressions.size(); i++) {
-                                    expressions[i] = builder.reinterpretExpressionAsPattern(expressions[i].get());
+                                    expressions[i] = builder.reinterpretExpressionAsPattern(expressions[i]);
                                 }
                             } else {
-                                exprNode = builder.reinterpretExpressionAsPattern(exprNode.get());
+                                exprNode = builder.reinterpretExpressionAsPattern(exprNode);
                             }
 
                             ASTNodeVector params;
@@ -1796,7 +1794,7 @@ public:
             }
         }
 
-        return exprNode.release();
+        return exprNode;
     }
 
     // ECMA-262 12.3 Left-Hand-Side Expressions
@@ -1808,7 +1806,7 @@ public:
         ASTNodeVector args;
         if (!this->match(RightParenthesis)) {
             while (true) {
-                ASTNode expr;
+                ASTNode expr = nullptr;
                 if (this->match(PeriodPeriodPeriod)) {
                     expr = this->parseSpreadElement<ASTBuilder, false>(builder);
                 } else {
@@ -1836,7 +1834,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseIdentifierName(ASTBuilder& builder)
+    ASTNode parseIdentifierName(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
         ALLOC_TOKEN(token);
@@ -1848,7 +1846,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseNewExpression(ASTBuilder& builder)
+    ASTNode parseNewExpression(ASTBuilder& builder)
     {
         this->nextToken();
 
@@ -1873,18 +1871,18 @@ public:
         this->context->isAssignmentTarget = false;
         this->context->isBindingElement = false;
 
-        return this->finalize(node, builder.createNewExpressionNode(callee.get(), std::move(args)));
+        return this->finalize(node, builder.createNewExpressionNode(callee, std::move(args)));
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseLeftHandSideExpressionAllowCall(ASTBuilder& builder)
+    ASTNode parseLeftHandSideExpressionAllowCall(ASTBuilder& builder)
     {
         ALLOC_TOKEN(startToken);
         *startToken = this->lookahead;
         bool previousAllowIn = this->context->allowIn;
         this->context->allowIn = true;
 
-        ASTNode exprNode;
+        ASTNode exprNode = nullptr;
 
         if (this->context->inFunctionBody && this->matchKeyword(SuperKeyword)) {
             throwIfSuperOperationIsNotAllowed();
@@ -1907,7 +1905,7 @@ public:
                     bool trackUsingNamesBefore = this->trackUsingNames;
                     this->trackUsingNames = false;
                     ASTNode property = this->parseIdentifierName(builder);
-                    exprNode = this->finalize(this->startNode(startToken), builder.createMemberExpressionNode(exprNode.get(), property.get(), true));
+                    exprNode = this->finalize(this->startNode(startToken), builder.createMemberExpressionNode(exprNode, property, true));
                     this->trackUsingNames = trackUsingNamesBefore;
                 } else if (this->lookahead.valuePunctuatorKind == LeftParenthesis) {
                     this->context->isBindingElement = false;
@@ -1916,13 +1914,13 @@ public:
                     if (exprNode->isIdentifier() && exprNode->asIdentifier()->name() == escargotContext->staticStrings().eval) {
                         this->currentScopeContext->m_hasEval = true;
                     }
-                    exprNode = this->finalize(this->startNode(startToken), builder.createCallExpressionNode(exprNode.get(), this->parseArguments(builder)));
+                    exprNode = this->finalize(this->startNode(startToken), builder.createCallExpressionNode(exprNode, this->parseArguments(builder)));
                 } else if (this->lookahead.valuePunctuatorKind == LeftSquareBracket) {
                     this->context->isBindingElement = false;
                     this->context->isAssignmentTarget = true;
                     this->nextToken();
                     ASTNode property = this->isolateCoverGrammar(builder, &Parser::parseExpression<ASTBuilder>);
-                    exprNode = this->finalize(this->startNode(startToken), builder.createMemberExpressionNode(exprNode.get(), property.get(), false));
+                    exprNode = this->finalize(this->startNode(startToken), builder.createMemberExpressionNode(exprNode, property, false));
                     this->expect(RightSquareBracket);
                 } else {
                     break;
@@ -1930,18 +1928,18 @@ public:
             } else if (this->lookahead.type == Token::TemplateToken && this->lookahead.valueTemplate->head) {
                 ASTNode quasi = this->parseTemplateLiteral(builder);
                 // FIXME convertTaggedTemplateExpressionToCallExpression
-                exprNode = builder.convertTaggedTemplateExpressionToCallExpression(this->finalize(this->startNode(startToken), builder.createTaggedTemplateExpressionNode(exprNode.get(), quasi.get())), this->currentScopeContext, escargotContext->staticStrings().raw);
+                exprNode = builder.convertTaggedTemplateExpressionToCallExpression(this->finalize(this->startNode(startToken), builder.createTaggedTemplateExpressionNode(exprNode, quasi)), this->currentScopeContext, escargotContext->staticStrings().raw);
             } else {
                 break;
             }
         }
         this->context->allowIn = previousAllowIn;
 
-        return exprNode.release();
+        return exprNode;
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseSuper(ASTBuilder& builder)
+    ASTNode parseSuper(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
 
@@ -1956,12 +1954,12 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseLeftHandSideExpression(ASTBuilder& builder)
+    ASTNode parseLeftHandSideExpression(ASTBuilder& builder)
     {
         // assert(this->context->allowIn, 'callee of new expression always allow in keyword.');
         ASSERT(this->context->allowIn);
 
-        ASTNode exprNode;
+        ASTNode exprNode = nullptr;
 
         if (this->matchKeyword(SuperKeyword) && this->context->inFunctionBody) {
             exprNode = this->parseSuper(builder);
@@ -1979,7 +1977,7 @@ public:
                 this->context->isAssignmentTarget = true;
                 this->expect(LeftSquareBracket);
                 ASTNode property = this->isolateCoverGrammar(builder, &Parser::parseExpression<ASTBuilder>);
-                exprNode = this->finalize(node, builder.createMemberExpressionNode(exprNode.get(), property.get(), false));
+                exprNode = this->finalize(node, builder.createMemberExpressionNode(exprNode, property, false));
                 this->expect(RightSquareBracket);
             } else if (this->match(Period)) {
                 this->context->isBindingElement = false;
@@ -1988,26 +1986,26 @@ public:
                 bool trackUsingNamesBefore = this->trackUsingNames;
                 this->trackUsingNames = false;
                 ASTNode property = this->parseIdentifierName(builder);
-                exprNode = this->finalize(node, builder.createMemberExpressionNode(exprNode.get(), property.get(), true));
+                exprNode = this->finalize(node, builder.createMemberExpressionNode(exprNode, property, true));
                 this->trackUsingNames = trackUsingNamesBefore;
             } else if (this->lookahead.type == Token::TemplateToken && this->lookahead.valueTemplate->head) {
                 ASTNode quasi = this->parseTemplateLiteral(builder);
                 // FIXME convertTaggedTemplateExpressionToCallExpression
-                exprNode = builder.convertTaggedTemplateExpressionToCallExpression(this->finalize(node, builder.createTaggedTemplateExpressionNode(exprNode.get(), quasi.get())), this->currentScopeContext, escargotContext->staticStrings().raw);
+                exprNode = builder.convertTaggedTemplateExpressionToCallExpression(this->finalize(node, builder.createTaggedTemplateExpressionNode(exprNode, quasi)), this->currentScopeContext, escargotContext->staticStrings().raw);
             } else {
                 break;
             }
         }
 
-        return exprNode.release();
+        return exprNode;
     }
 
     // ECMA-262 12.4 Update Expressions
 
     template <class ASTBuilder>
-    ASTPassNode parseUpdateExpression(ASTBuilder& builder)
+    ASTNode parseUpdateExpression(ASTBuilder& builder)
     {
-        ASTNode exprNode;
+        ASTNode exprNode = nullptr;
         ALLOC_TOKEN(startToken);
         *startToken = this->lookahead;
 
@@ -2030,9 +2028,9 @@ public:
 
             MetaNode node = this->startNode(startToken);
             if (isPlus) {
-                exprNode = this->finalize(node, builder.createUpdateExpressionIncrementPrefixNode(exprNode.get()));
+                exprNode = this->finalize(node, builder.createUpdateExpressionIncrementPrefixNode(exprNode));
             } else {
-                exprNode = this->finalize(node, builder.createUpdateExpressionDecrementPrefixNode(exprNode.get()));
+                exprNode = this->finalize(node, builder.createUpdateExpressionDecrementPrefixNode(exprNode));
             }
 
             this->context->isAssignmentTarget = false;
@@ -2056,64 +2054,64 @@ public:
                 this->nextToken();
 
                 if (isPlus) {
-                    exprNode = this->finalize(this->startNode(startToken), builder.createUpdateExpressionIncrementPostfixNode(exprNode.get()));
+                    exprNode = this->finalize(this->startNode(startToken), builder.createUpdateExpressionIncrementPostfixNode(exprNode));
                 } else {
-                    exprNode = this->finalize(this->startNode(startToken), builder.createUpdateExpressionDecrementPostfixNode(exprNode.get()));
+                    exprNode = this->finalize(this->startNode(startToken), builder.createUpdateExpressionDecrementPostfixNode(exprNode));
                 }
             }
         }
 
-        return exprNode.release();
+        return exprNode;
     }
 
     // ECMA-262 12.5 Unary Operators
 
     template <class ASTBuilder>
-    ASTPassNode parseUnaryExpression(ASTBuilder& builder)
+    ASTNode parseUnaryExpression(ASTBuilder& builder)
     {
         if (this->lookahead.type == Token::PunctuatorToken) {
             auto punctuatorsKind = this->lookahead.valuePunctuatorKind;
-            ASTNode exprNode;
+            ASTNode exprNode = nullptr;
 
             if (punctuatorsKind == Plus) {
                 this->nextToken();
                 MetaNode node = this->startNode(&this->lookahead);
                 ASTNode subExpr = this->inheritCoverGrammar(builder, &Parser::parseUnaryExpression<ASTBuilder>);
-                exprNode = this->finalize(node, builder.createUnaryExpressionPlusNode(subExpr.get()));
+                exprNode = this->finalize(node, builder.createUnaryExpressionPlusNode(subExpr));
                 this->context->isAssignmentTarget = false;
                 this->context->isBindingElement = false;
-                return exprNode.release();
+                return exprNode;
             } else if (punctuatorsKind == Minus) {
                 this->nextToken();
                 MetaNode node = this->startNode(&this->lookahead);
                 ASTNode subExpr = this->inheritCoverGrammar(builder, &Parser::parseUnaryExpression<ASTBuilder>);
-                exprNode = this->finalize(node, builder.createUnaryExpressionMinusNode(subExpr.get()));
+                exprNode = this->finalize(node, builder.createUnaryExpressionMinusNode(subExpr));
                 this->context->isAssignmentTarget = false;
                 this->context->isBindingElement = false;
-                return exprNode.release();
+                return exprNode;
             } else if (punctuatorsKind == Wave) {
                 this->nextToken();
                 MetaNode node = this->startNode(&this->lookahead);
                 ASTNode subExpr = this->inheritCoverGrammar(builder, &Parser::parseUnaryExpression<ASTBuilder>);
-                exprNode = this->finalize(node, builder.createUnaryExpressionBitwiseNotNode(subExpr.get()));
+                exprNode = this->finalize(node, builder.createUnaryExpressionBitwiseNotNode(subExpr));
                 this->context->isAssignmentTarget = false;
                 this->context->isBindingElement = false;
-                return exprNode.release();
+                return exprNode;
             } else if (punctuatorsKind == ExclamationMark) {
                 this->nextToken();
                 MetaNode node = this->startNode(&this->lookahead);
                 ASTNode subExpr = this->inheritCoverGrammar(builder, &Parser::parseUnaryExpression<ASTBuilder>);
-                exprNode = this->finalize(node, builder.createUnaryExpressionLogicalNotNode(subExpr.get()));
+                exprNode = this->finalize(node, builder.createUnaryExpressionLogicalNotNode(subExpr));
                 this->context->isAssignmentTarget = false;
                 this->context->isBindingElement = false;
-                return exprNode.release();
+                return exprNode;
             }
         }
 
         bool isKeyword = this->lookahead.type == Token::KeywordToken;
 
         if (isKeyword) {
-            ASTNode exprNode;
+            ASTNode exprNode = nullptr;
 
             if (this->lookahead.valueKeywordKind == DeleteKeyword) {
                 this->nextToken();
@@ -2124,30 +2122,30 @@ public:
                     this->throwError(Messages::StrictDelete);
                 }
 
-                exprNode = this->finalize(node, builder.createUnaryExpressionDeleteNode(subExpr.get()));
+                exprNode = this->finalize(node, builder.createUnaryExpressionDeleteNode(subExpr));
                 this->context->isAssignmentTarget = false;
                 this->context->isBindingElement = false;
 
-                return exprNode.release();
+                return exprNode;
             } else if (this->lookahead.valueKeywordKind == VoidKeyword) {
                 this->nextToken();
                 MetaNode node = this->startNode(&this->lookahead);
                 ASTNode subExpr = this->inheritCoverGrammar(builder, &Parser::parseUnaryExpression<ASTBuilder>);
-                exprNode = this->finalize(node, builder.createUnaryExpressionVoidNode(subExpr.get()));
+                exprNode = this->finalize(node, builder.createUnaryExpressionVoidNode(subExpr));
                 this->context->isAssignmentTarget = false;
                 this->context->isBindingElement = false;
 
-                return exprNode.release();
+                return exprNode;
             } else if (this->lookahead.valueKeywordKind == TypeofKeyword) {
                 this->nextToken();
 
                 MetaNode node = this->startNode(&this->lookahead);
                 ASTNode subExpr = this->inheritCoverGrammar(builder, &Parser::parseUnaryExpression<ASTBuilder>);
-                exprNode = this->finalize(node, builder.createUnaryExpressionTypeOfNode(subExpr.get()));
+                exprNode = this->finalize(node, builder.createUnaryExpressionTypeOfNode(subExpr));
                 this->context->isAssignmentTarget = false;
                 this->context->isBindingElement = false;
 
-                return exprNode.release();
+                return exprNode;
             }
         }
 
@@ -2155,7 +2153,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseExponentiationExpression(ASTBuilder& builder)
+    ASTNode parseExponentiationExpression(ASTBuilder& builder)
     {
         ALLOC_TOKEN(startToken);
         *startToken = this->lookahead;
@@ -2248,7 +2246,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseBinaryExpression(ASTBuilder& builder)
+    ASTNode parseBinaryExpression(ASTBuilder& builder)
     {
         ALLOC_TOKEN(startToken);
         *startToken = this->lookahead;
@@ -2296,7 +2294,7 @@ public:
                     stack.pop_back();
                     markers.pop_back();
                     MetaNode node = this->startNode(&markers.back());
-                    auto e = this->finalize(node, finishBinaryExpression(builder, left.get(), right.get(), &operator_));
+                    auto e = this->finalize(node, finishBinaryExpression(builder, left, right, &operator_));
                     stack.push_back(e);
                 }
 
@@ -2315,18 +2313,18 @@ public:
             markers.pop_back();
             while (i > 0) {
                 MetaNode node = this->startNode(&markers.back());
-                expr = this->finalize(node, finishBinaryExpression(builder, stack[i - 1].get(), expr.get(), &tokenStack.back()));
+                expr = this->finalize(node, finishBinaryExpression(builder, stack[i - 1], expr, &tokenStack.back()));
                 markers.pop_back();
                 tokenStack.pop_back();
                 i--;
             }
         }
 
-        return expr.release();
+        return expr;
     }
 
     template <class ASTBuilder>
-    ASTNodePtr finishBinaryExpression(ASTBuilder& builder, ASTNodePtr left, ASTNodePtr right, Scanner::SmallScannerResult* token)
+    ASTNode finishBinaryExpression(ASTBuilder& builder, ASTNode left, ASTNode right, Scanner::SmallScannerResult* token)
     {
         if (token->type == Token::PunctuatorToken) {
             PunctuatorKind oper = token->valuePunctuatorKind;
@@ -2393,16 +2391,16 @@ public:
     // ECMA-262 12.14 Conditional Operator
 
     template <class ASTBuilder>
-    ASTPassNode parseConditionalExpression(ASTBuilder& builder)
+    ASTNode parseConditionalExpression(ASTBuilder& builder)
     {
         ALLOC_TOKEN(startToken);
         *startToken = this->lookahead;
-        ASTNode exprNode;
+        ASTNode exprNode = nullptr;
 
         exprNode = this->inheritCoverGrammar(builder, &Parser::parseBinaryExpression<ASTBuilder>);
 
         if (this->match(GuessMark)) {
-            ASTNode consequent;
+            ASTNode consequent = nullptr;
 
             this->nextToken();
 
@@ -2413,21 +2411,21 @@ public:
 
             this->expect(Colon);
             ASTNode alternate = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
-            exprNode = this->finalize(this->startNode(startToken), builder.createConditionalExpressionNode(exprNode.get(), consequent.get(), alternate.get()));
+            exprNode = this->finalize(this->startNode(startToken), builder.createConditionalExpressionNode(exprNode, consequent, alternate));
 
             this->context->isAssignmentTarget = false;
             this->context->isBindingElement = false;
         }
 
-        return exprNode.release();
+        return exprNode;
     }
 
     // ECMA-262 12.15 Assignment Operators
 
     template <class ASTBuilder, bool checkLeftHasRestrictedWord>
-    ASTPassNode parseAssignmentExpression(ASTBuilder& builder)
+    ASTNode parseAssignmentExpression(ASTBuilder& builder)
     {
-        ASTNode exprNode;
+        ASTNode exprNode = nullptr;
 
         if (!this->context->allowYield && this->matchKeyword(YieldKeyword)) {
             exprNode = this->parseYieldExpression(builder);
@@ -2477,8 +2475,6 @@ public:
 
                     list = this->parseFormalParameters(builder);
                 }
-
-                exprNode.release();
 
                 // FIXME remove validity check?
                 if (list.valid) {
@@ -2619,7 +2615,7 @@ public:
                         this->context->isAssignmentTarget = false;
                         this->context->isBindingElement = false;
                     } else {
-                        exprNode = builder.reinterpretExpressionAsPattern(exprNode.get());
+                        exprNode = builder.reinterpretExpressionAsPattern(exprNode);
 
                         if (exprNode->isLiteral() || exprNode->type() == ASTNodeType::ThisExpression) {
                             this->throwError(Messages::InvalidLHSInAssignment, String::emptyString, String::emptyString, ErrorObject::ReferenceError);
@@ -2627,47 +2623,47 @@ public:
                     }
 
                     this->nextToken(token);
-                    ASTNode rightNode;
-                    ASTNodePtr exprResult;
+                    ASTNode rightNode = nullptr;
+                    ASTNode exprResult = nullptr;
 
                     rightNode = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
 
                     switch (token->valuePunctuatorKind) {
                     case Substitution:
-                        exprResult = builder.createAssignmentExpressionSimpleNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionSimpleNode(exprNode, rightNode);
                         break;
                     case PlusEqual:
-                        exprResult = builder.createAssignmentExpressionPlusNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionPlusNode(exprNode, rightNode);
                         break;
                     case MinusEqual:
-                        exprResult = builder.createAssignmentExpressionMinusNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionMinusNode(exprNode, rightNode);
                         break;
                     case MultiplyEqual:
-                        exprResult = builder.createAssignmentExpressionMultiplyNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionMultiplyNode(exprNode, rightNode);
                         break;
                     case DivideEqual:
-                        exprResult = builder.createAssignmentExpressionDivisionNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionDivisionNode(exprNode, rightNode);
                         break;
                     case ModEqual:
-                        exprResult = builder.createAssignmentExpressionModNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionModNode(exprNode, rightNode);
                         break;
                     case LeftShiftEqual:
-                        exprResult = builder.createAssignmentExpressionLeftShiftNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionLeftShiftNode(exprNode, rightNode);
                         break;
                     case RightShiftEqual:
-                        exprResult = builder.createAssignmentExpressionSignedRightShiftNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionSignedRightShiftNode(exprNode, rightNode);
                         break;
                     case UnsignedRightShiftEqual:
-                        exprResult = builder.createAssignmentExpressionUnsignedRightShiftNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionUnsignedRightShiftNode(exprNode, rightNode);
                         break;
                     case BitwiseXorEqual:
-                        exprResult = builder.createAssignmentExpressionBitwiseXorNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionBitwiseXorNode(exprNode, rightNode);
                         break;
                     case BitwiseAndEqual:
-                        exprResult = builder.createAssignmentExpressionBitwiseAndNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionBitwiseAndNode(exprNode, rightNode);
                         break;
                     case BitwiseOrEqual:
-                        exprResult = builder.createAssignmentExpressionBitwiseOrNode(exprNode.get(), rightNode.get());
+                        exprResult = builder.createAssignmentExpressionBitwiseOrNode(exprNode, rightNode);
                         break;
                     default:
                         RELEASE_ASSERT_NOT_REACHED();
@@ -2679,17 +2675,17 @@ public:
             }
         }
 
-        return exprNode.release();
+        return exprNode;
     }
 
     // ECMA-262 12.16 Comma Operator
 
     template <class ASTBuilder>
-    ASTPassNode parseExpression(ASTBuilder& builder)
+    ASTNode parseExpression(ASTBuilder& builder)
     {
         ALLOC_TOKEN(startToken);
         *startToken = this->lookahead;
-        ASTNode exprNode;
+        ASTNode exprNode = nullptr;
 
         exprNode = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
 
@@ -2707,15 +2703,15 @@ public:
             exprNode = this->finalize(this->startNode(startToken), builder.createSequenceExpressionNode(std::move(expressions)));
         }
 
-        return exprNode.release();
+        return exprNode;
     }
 
     // ECMA-262 13.2 Block
 
     template <class ASTBuilder>
-    ASTPassNode parseStatementListItem(ASTBuilder& builder)
+    ASTNode parseStatementListItem(ASTBuilder& builder)
     {
-        ASTNode statement;
+        ASTNode statement = nullptr;
         this->context->isAssignmentTarget = true;
         this->context->isBindingElement = true;
         this->context->hasRestrictedWordInArrayOrObjectInitializer = false;
@@ -2753,7 +2749,7 @@ public:
             statement = this->parseStatement(builder);
         }
 
-        return statement.release();
+        return statement;
     }
 
     struct ParserBlockContext {
@@ -2861,23 +2857,22 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseBlock(ASTBuilder& builder)
+    ASTNode parseBlock(ASTBuilder& builder)
     {
         this->expect(LeftBrace);
-        ASTStatementContainer block;
-        ASTStatementNodePtr referNode = nullptr;
+        ASTNode referNode = nullptr;
 
         ParserBlockContext blockContext = openBlock();
 
         bool allowLexicalDeclarationBefore = this->context->allowLexicalDeclaration;
         this->context->allowLexicalDeclaration = true;
 
-        block = builder.createStatementContainer();
+        ASTStatementContainer block = builder.createStatementContainer();
         while (true) {
             if (this->match(RightBrace)) {
                 break;
             }
-            referNode = block->appendChild(this->parseStatementListItem(builder).get(), referNode);
+            referNode = block->appendChild(this->parseStatementListItem(builder), referNode);
         }
         this->expect(RightBrace);
 
@@ -2886,17 +2881,17 @@ public:
         closeBlock(blockContext);
 
         MetaNode node = this->createNode();
-        return this->finalize(node, builder.createBlockStatementNode(block.get(), blockContext.childLexicalBlockIndex));
+        return this->finalize(node, builder.createBlockStatementNode(block, blockContext.childLexicalBlockIndex));
     }
 
     // ECMA-262 13.3.1 Let and Const Declarations
 
     template <class ASTBuilder>
-    ASTPassNode parseLexicalBinding(ASTBuilder& builder, KeywordKind kind, bool inFor)
+    ASTNode parseLexicalBinding(ASTBuilder& builder, KeywordKind kind, bool inFor)
     {
         auto node = this->createNode();
         SmallScannerResultVector params;
-        ASTNode idNode;
+        ASTNode idNode = nullptr;
         bool isIdentifier;
         AtomicString name;
 
@@ -2911,7 +2906,7 @@ public:
             this->throwError(Messages::StrictVarName);
         }
 
-        ASTNode init;
+        ASTNode init = nullptr;
         if (kind == KeywordKind::ConstKeyword) {
             if (!this->matchKeyword(KeywordKind::InKeyword) && !this->matchContextualKeyword("of")) {
                 this->expect(Substitution);
@@ -2922,7 +2917,7 @@ public:
             init = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
         }
 
-        return this->finalize(node, builder.createVariableDeclaratorNode(kind, idNode.get(), init.get()));
+        return this->finalize(node, builder.createVariableDeclaratorNode(kind, idNode, init));
     }
 
     template <class ASTBuilder>
@@ -2938,7 +2933,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseLexicalDeclaration(ASTBuilder& builder, bool inFor)
+    ASTNode parseLexicalDeclaration(ASTBuilder& builder, bool inFor)
     {
         auto node = this->createNode();
         ALLOC_TOKEN(token);
@@ -2970,7 +2965,7 @@ public:
 
     // ECMA-262 13.3.2 Variable Statement
     template <class ASTBuilder>
-    ASTPassNode parseVariableIdentifier(ASTBuilder& builder, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
+    ASTNode parseVariableIdentifier(ASTBuilder& builder, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
     {
         MetaNode node = this->createNode();
 
@@ -3040,10 +3035,10 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseVariableDeclaration(ASTBuilder& builder, DeclarationOptions& options, bool& hasInit, ASTNodeType& leftSideType)
+    ASTNode parseVariableDeclaration(ASTBuilder& builder, DeclarationOptions& options, bool& hasInit, ASTNodeType& leftSideType)
     {
         SmallScannerResultVector params;
-        ASTNode idNode;
+        ASTNode idNode = nullptr;
         bool isIdentifier;
         AtomicString name;
 
@@ -3063,7 +3058,7 @@ public:
             this->throwError("Lexical declaration cannot appear in a single-statement context");
         }
 
-        ASTNode initNode;
+        ASTNode initNode = nullptr;
         hasInit = false;
         if (this->match(Substitution)) {
             hasInit = true;
@@ -3094,7 +3089,7 @@ public:
         }
 
         MetaNode node = this->createNode();
-        return this->finalize(node, builder.createVariableDeclaratorNode(options.kind, idNode.get(), initNode.get()));
+        return this->finalize(node, builder.createVariableDeclaratorNode(options.kind, idNode, initNode));
     }
 
     template <class ASTBuilder>
@@ -3120,7 +3115,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseVariableStatement(ASTBuilder& builder, KeywordKind kind = VarKeyword)
+    ASTNode parseVariableStatement(ASTBuilder& builder, KeywordKind kind = VarKeyword)
     {
         this->expectKeyword(kind);
         MetaNode node = this->createNode();
@@ -3137,7 +3132,7 @@ public:
     // ECMA-262 13.4 Empty Statement
 
     template <class ASTBuilder>
-    ASTPassNode parseEmptyStatement(ASTBuilder& builder)
+    ASTNode parseEmptyStatement(ASTBuilder& builder)
     {
         this->expect(SemiColon);
 
@@ -3148,22 +3143,22 @@ public:
     // ECMA-262 13.5 Expression Statement
 
     template <class ASTBuilder>
-    ASTPassNode parseExpressionStatement(ASTBuilder& builder)
+    ASTNode parseExpressionStatement(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
         ASTNode expr = this->parseExpression(builder);
         this->consumeSemicolon();
-        return this->finalize(node, builder.createExpressionStatementNode(expr.get()));
+        return this->finalize(node, builder.createExpressionStatementNode(expr));
     }
 
     // ECMA-262 13.6 If statement
 
     template <class ASTBuilder>
-    ASTPassNode parseIfStatement(ASTBuilder& builder)
+    ASTNode parseIfStatement(ASTBuilder& builder)
     {
-        ASTNode test;
-        ASTNode consequent;
-        ASTNode alternate;
+        ASTNode test = nullptr;
+        ASTNode consequent = nullptr;
+        ASTNode alternate = nullptr;
         bool allowFunctionDeclaration = !this->context->strict;
 
         this->expectKeyword(IfKeyword);
@@ -3186,13 +3181,13 @@ public:
 
         this->context->allowLexicalDeclaration = allowLexicalDeclarationBefore;
 
-        return this->finalize(this->createNode(), builder.createIfStatementNode(test.get(), consequent.get(), alternate.get()));
+        return this->finalize(this->createNode(), builder.createIfStatementNode(test, consequent, alternate));
     }
 
     // ECMA-262 13.7.2 The do-while Statement
 
     template <class ASTBuilder>
-    ASTPassNode parseDoWhileStatement(ASTBuilder& builder)
+    ASTNode parseDoWhileStatement(ASTBuilder& builder)
     {
         this->expectKeyword(DoKeyword);
 
@@ -3201,28 +3196,26 @@ public:
         this->context->allowLexicalDeclaration = false;
         this->context->inIteration = true;
 
-        ASTNode body;
-        body = this->parseStatement(builder, false);
+        ASTNode body = this->parseStatement(builder, false);
         this->context->inIteration = previousInIteration;
         this->context->allowLexicalDeclaration = allowLexicalDeclarationBefore;
 
         this->expectKeyword(WhileKeyword);
         this->expect(LeftParenthesis);
-        ASTNode test;
-        test = this->parseExpression(builder);
+        ASTNode test = this->parseExpression(builder);
 
         this->expect(RightParenthesis);
         if (this->match(SemiColon)) {
             this->nextToken();
         }
 
-        return this->finalize(this->createNode(), builder.createDoWhileStatementNode(test.get(), body.get()));
+        return this->finalize(this->createNode(), builder.createDoWhileStatementNode(test, body));
     }
 
     // ECMA-262 13.7.3 The while Statement
 
     template <class ASTBuilder>
-    ASTPassNode parseWhileStatement(ASTBuilder& builder)
+    ASTNode parseWhileStatement(ASTBuilder& builder)
     {
         bool prevInLoop = this->context->inLoop;
         bool allowLexicalDeclarationBefore = this->context->allowLexicalDeclaration;
@@ -3231,19 +3224,17 @@ public:
 
         this->expectKeyword(WhileKeyword);
         this->expect(LeftParenthesis);
-        ASTNode test;
-        test = this->parseExpression(builder);
+        ASTNode test = this->parseExpression(builder);
         this->expect(RightParenthesis);
 
         bool previousInIteration = this->context->inIteration;
         this->context->inIteration = true;
-        ASTNode body;
-        body = this->parseStatement(builder, false);
+        ASTNode body = this->parseStatement(builder, false);
         this->context->inIteration = previousInIteration;
         this->context->inLoop = prevInLoop;
         this->context->allowLexicalDeclaration = allowLexicalDeclarationBefore;
 
-        return this->finalize(this->createNode(), builder.createWhileStatementNode(test.get(), body.get()));
+        return this->finalize(this->createNode(), builder.createWhileStatementNode(test, body));
     }
 
     // ECMA-262 13.7.4 The for Statement
@@ -3256,13 +3247,13 @@ public:
     };
 
     template <class ASTBuilder>
-    ASTPassNode parseForStatement(ASTBuilder& builder)
+    ASTNode parseForStatement(ASTBuilder& builder)
     {
-        ASTNode init;
-        ASTNode test;
-        ASTNode update;
-        ASTNode left;
-        ASTNode right;
+        ASTNode init = nullptr;
+        ASTNode test = nullptr;
+        ASTNode update = nullptr;
+        ASTNode left = nullptr;
+        ASTNode right = nullptr;
         ForStatementType type = statementTypeFor;
         bool prevInLoop = this->context->inLoop;
         bool isLexicalDeclaration = false;
@@ -3359,7 +3350,7 @@ public:
                     }
 
                     this->nextToken();
-                    init = builder.reinterpretExpressionAsPattern(init.get());
+                    init = builder.reinterpretExpressionAsPattern(init);
                     left = init;
                     init = nullptr;
                     type = statementTypeForIn;
@@ -3369,7 +3360,7 @@ public:
                     }
 
                     this->nextToken();
-                    init = builder.reinterpretExpressionAsPattern(init.get());
+                    init = builder.reinterpretExpressionAsPattern(init);
                     left = init;
                     init = nullptr;
                     type = statementTypeForOf;
@@ -3424,7 +3415,7 @@ public:
         bool allowLexicalDeclarationBefore = this->context->allowLexicalDeclaration;
         this->context->allowLexicalDeclaration = false;
         this->context->inIteration = true;
-        ASTNode body;
+        ASTNode body = nullptr;
         auto functor = std::bind(&Parser::parseStatement<ASTBuilder>, std::ref(*this), builder, false);
         body = this->isolateCoverGrammarWithFunctor(builder, functor);
 
@@ -3438,17 +3429,17 @@ public:
         MetaNode node = this->createNode();
 
         if (type == statementTypeFor) {
-            ASTNodePtr forNode = builder.createForStatementNode(init.get(), test.get(), update.get(), body.get(), isLexicalDeclaration, headBlockContext.childLexicalBlockIndex, iterationBlockContext.childLexicalBlockIndex);
+            ASTNode forNode = builder.createForStatementNode(init, test, update, body, isLexicalDeclaration, headBlockContext.childLexicalBlockIndex, iterationBlockContext.childLexicalBlockIndex);
             return this->finalize(node, forNode);
         }
 
         if (type == statementTypeForIn) {
-            ASTNodePtr forInNode = builder.createForInOfStatementNode(left.get(), right.get(), body.get(), true, isLexicalDeclaration, headBlockContext.childLexicalBlockIndex, iterationBlockContext.childLexicalBlockIndex);
+            ASTNode forInNode = builder.createForInOfStatementNode(left, right, body, true, isLexicalDeclaration, headBlockContext.childLexicalBlockIndex, iterationBlockContext.childLexicalBlockIndex);
             return this->finalize(node, forInNode);
         }
 
         ASSERT(type == statementTypeForOf);
-        ASTNodePtr forOfNode = builder.createForInOfStatementNode(left.get(), right.get(), body.get(), false, isLexicalDeclaration, headBlockContext.childLexicalBlockIndex, iterationBlockContext.childLexicalBlockIndex);
+        ASTNode forOfNode = builder.createForInOfStatementNode(left, right, body, false, isLexicalDeclaration, headBlockContext.childLexicalBlockIndex, iterationBlockContext.childLexicalBlockIndex);
         return this->finalize(node, forOfNode);
     }
 
@@ -3475,7 +3466,7 @@ public:
     // ECMA-262 13.8 The continue statement
 
     template <class ASTBuilder>
-    ASTPassNode parseContinueStatement(ASTBuilder& builder)
+    ASTNode parseContinueStatement(ASTBuilder& builder)
     {
         this->expectKeyword(ContinueKeyword);
 
@@ -3510,7 +3501,7 @@ public:
     // ECMA-262 13.9 The break statement
 
     template <class ASTBuilder>
-    ASTPassNode parseBreakStatement(ASTBuilder& builder)
+    ASTNode parseBreakStatement(ASTBuilder& builder)
     {
         this->expectKeyword(BreakKeyword);
 
@@ -3539,7 +3530,7 @@ public:
     // ECMA-262 13.10 The return statement
 
     template <class ASTBuilder>
-    ASTPassNode parseReturnStatement(ASTBuilder& builder)
+    ASTNode parseReturnStatement(ASTBuilder& builder)
     {
         if (!this->context->inFunctionBody) {
             this->throwError(Messages::IllegalReturn);
@@ -3548,19 +3539,19 @@ public:
         this->expectKeyword(ReturnKeyword);
 
         bool hasArgument = !this->match(SemiColon) && !this->match(RightBrace) && !this->hasLineTerminator && this->lookahead.type != EOFToken;
-        ASTNode argument;
+        ASTNode argument = nullptr;
         if (hasArgument) {
             argument = this->parseExpression(builder);
         }
         this->consumeSemicolon();
 
-        return this->finalize(this->createNode(), builder.createReturnStatementNode(argument.get()));
+        return this->finalize(this->createNode(), builder.createReturnStatementNode(argument));
     }
 
     // ECMA-262 13.11 The with statement
 
     template <class ASTBuilder>
-    ASTPassNode parseWithStatement(ASTBuilder& builder)
+    ASTNode parseWithStatement(ASTBuilder& builder)
     {
         if (this->context->strict) {
             this->throwError(Messages::StrictModeWith);
@@ -3580,17 +3571,17 @@ public:
         ASTNode body = this->parseStatement(builder, false);
         this->context->inWith = prevInWith;
 
-        return this->finalize(node, builder.createWithStatementNode(object, body.get()));
+        return this->finalize(node, builder.createWithStatementNode(object, body));
     }
 
     // ECMA-262 13.12 The switch statement
 
     template <class ASTBuilder>
-    ASTPassNode parseSwitchCase(ASTBuilder& builder, bool& isDefaultNode)
+    ASTNode parseSwitchCase(ASTBuilder& builder, bool& isDefaultNode)
     {
         MetaNode node = this->createNode();
 
-        ASTNode test;
+        ASTNode test = nullptr;
         if (this->matchKeyword(DefaultKeyword)) {
             node = this->createNode();
             this->nextToken();
@@ -3608,27 +3599,26 @@ public:
             if (this->match(RightBrace) || this->matchKeyword(DefaultKeyword) || this->matchKeyword(CaseKeyword)) {
                 break;
             }
-            consequent->appendChild(this->parseStatementListItem(builder).get());
+            consequent->appendChild(this->parseStatementListItem(builder));
         }
 
-        return this->finalize(node, builder.createSwitchCaseNode(test.get(), consequent.get()));
+        return this->finalize(node, builder.createSwitchCaseNode(test, consequent));
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseSwitchStatement(ASTBuilder& builder)
+    ASTNode parseSwitchStatement(ASTBuilder& builder)
     {
         this->expectKeyword(SwitchKeyword);
 
         this->expect(LeftParenthesis);
-        ASTNode discriminant;
-        discriminant = this->parseExpression(builder);
+        ASTNode discriminant = this->parseExpression(builder);
         this->expect(RightParenthesis);
 
         bool previousInSwitch = this->context->inSwitch;
         this->context->inSwitch = true;
 
         ASTStatementContainer casesA, casesB;
-        ASTNode deflt;
+        ASTNode deflt = nullptr;
         casesA = builder.createStatementContainer();
         casesB = builder.createStatementContainer();
 
@@ -3650,24 +3640,24 @@ public:
                 defaultFound = true;
             } else {
                 if (defaultFound) {
-                    casesA->appendChild(clause.get());
+                    casesA->appendChild(clause);
                 } else {
-                    casesB->appendChild(clause.get());
+                    casesB->appendChild(clause);
                 }
             }
         }
         this->expect(RightBrace);
 
         this->context->inSwitch = previousInSwitch;
-        return this->finalize(this->createNode(), builder.createSwitchStatementNode(discriminant.get(), casesA.get(), deflt.get(), casesB.get()));
+        return this->finalize(this->createNode(), builder.createSwitchStatementNode(discriminant, casesA, deflt, casesB));
     }
 
     // ECMA-262 13.13 Labelled Statements
 
     template <class ASTBuilder>
-    ASTPassNode parseLabelledStatement(ASTBuilder& builder, size_t multiLabelCount = 1)
+    ASTNode parseLabelledStatement(ASTBuilder& builder, size_t multiLabelCount = 1)
     {
-        ASTNode expr;
+        ASTNode expr = nullptr;
         AtomicString name;
         bool isIdentifier = false;
 
@@ -3677,7 +3667,7 @@ public:
             name = expr->asIdentifier()->name();
         }
 
-        ASTNodePtr statement;
+        ASTNode statement = nullptr;
         if (isIdentifier && this->match(Colon)) {
             this->nextToken();
 
@@ -3689,7 +3679,7 @@ public:
 
             if (this->lookahead.type == IdentifierToken) {
                 ASTNode labeledBody = this->parseLabelledStatement(builder, multiLabelCount + 1);
-                statement = builder.createLabeledStatementNode(labeledBody.get(), name.string());
+                statement = builder.createLabeledStatementNode(labeledBody, name.string());
             } else {
                 if (this->matchKeyword(DoKeyword) || this->matchKeyword(ForKeyword) || this->matchKeyword(WhileKeyword)) {
                     // Turn labels to accept continue references.
@@ -3702,12 +3692,12 @@ public:
                 }
 
                 ASTNode labeledBody = this->parseStatement(builder, !this->context->strict);
-                statement = builder.createLabeledStatementNode(labeledBody.get(), name.string());
+                statement = builder.createLabeledStatementNode(labeledBody, name.string());
             }
             removeLabel(name);
         } else {
             this->consumeSemicolon();
-            statement = builder.createExpressionStatementNode(expr.get());
+            statement = builder.createExpressionStatementNode(expr);
         }
 
         return this->finalize(this->createNode(), statement);
@@ -3716,7 +3706,7 @@ public:
     // ECMA-262 13.14 The throw statement
 
     template <class ASTBuilder>
-    ASTPassNode parseThrowStatement(ASTBuilder& builder)
+    ASTNode parseThrowStatement(ASTBuilder& builder)
     {
         auto metaNode = this->createNode();
         this->expectKeyword(ThrowKeyword);
@@ -3725,17 +3715,16 @@ public:
             this->throwError(Messages::NewlineAfterThrow);
         }
 
-        ASTNode argument;
-        argument = this->parseExpression(builder);
+        ASTNode argument = this->parseExpression(builder);
         this->consumeSemicolon();
 
-        return this->finalize(metaNode, builder.createThrowStatementNode(argument.get()));
+        return this->finalize(metaNode, builder.createThrowStatementNode(argument));
     }
 
     // ECMA-262 13.15 The try statement
 
     template <class ASTBuilder>
-    ASTPassNode parseCatchClause(ASTBuilder& builder)
+    ASTNode parseCatchClause(ASTBuilder& builder)
     {
         this->expectKeyword(CatchKeyword);
 
@@ -3766,8 +3755,7 @@ public:
             this->context->catchClauseSimplyDeclaredVariableNames.push_back(param->asIdentifier()->name());
         }
 
-        ASTNode body;
-        body = this->parseBlock(builder);
+        ASTNode body = this->parseBlock(builder);
 
         if (gotSimplyDeclaredVariableName) {
             this->context->catchClauseSimplyDeclaredVariableNames.pop_back();
@@ -3777,27 +3765,27 @@ public:
 
         closeBlock(catchBlockContext);
 
-        return this->finalize(this->createNode(), builder.createCatchClauseNode(param.get(), nullptr, body.get(), catchBlockContext.childLexicalBlockIndex));
+        return this->finalize(this->createNode(), builder.createCatchClauseNode(param, nullptr, body, catchBlockContext.childLexicalBlockIndex));
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseFinallyClause(ASTBuilder& builder)
+    ASTNode parseFinallyClause(ASTBuilder& builder)
     {
         this->expectKeyword(FinallyKeyword);
         return this->parseBlock(builder);
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseTryStatement(ASTBuilder& builder)
+    ASTNode parseTryStatement(ASTBuilder& builder)
     {
         this->expectKeyword(TryKeyword);
 
         ASTNode block = this->parseBlock(builder);
-        ASTNode handler;
+        ASTNode handler = nullptr;
         if (this->matchKeyword(CatchKeyword)) {
             handler = this->parseCatchClause(builder);
         }
-        ASTNode finalizer;
+        ASTNode finalizer = nullptr;
         if (this->matchKeyword(FinallyKeyword)) {
             finalizer = this->parseFinallyClause(builder);
         }
@@ -3806,7 +3794,7 @@ public:
             this->throwError(Messages::NoCatchOrFinally);
         }
 
-        return this->finalize(this->createNode(), builder.createTryStatementNode(block.get(), handler.get(), finalizer.get()));
+        return this->finalize(this->createNode(), builder.createTryStatementNode(block, handler, finalizer));
     }
 
     // ECMA-262 13.16 The debugger statement
@@ -3822,10 +3810,10 @@ public:
 
     // ECMA-262 13 Statements
     template <class ASTBuilder>
-    ASTPassNode parseStatement(ASTBuilder& builder, bool allowFunctionDeclaration = true)
+    ASTNode parseStatement(ASTBuilder& builder, bool allowFunctionDeclaration = true)
     {
         checkRecursiveLimit();
-        ASTNode statement;
+        ASTNode statement = nullptr;
         switch (this->lookahead.type) {
         case Token::BooleanLiteralToken:
         case Token::NullLiteralToken:
@@ -3930,9 +3918,9 @@ public:
         return statement;
     }
 
-    PassRefPtr<StatementContainer> parseFunctionParameters(NodeGenerator& builder)
+    StatementContainer* parseFunctionParameters(NodeGenerator& builder)
     {
-        RefPtr<StatementContainer> container = StatementContainer::create();
+        StatementContainer* container = builder.createStatementContainer();
 
         this->expect(LeftParenthesis);
         ParseFormalParametersResult options;
@@ -3940,21 +3928,21 @@ public:
         size_t paramIndex = 0;
         MetaNode node = this->createNode();
         while (!this->match(RightParenthesis)) {
-            RefPtr<Node> param = this->parseFormalParameter(builder, options, end);
+            Node* param = this->parseFormalParameter(builder, options, end);
 
             switch (param->type()) {
             case Identifier:
             case AssignmentPattern:
             case ArrayPattern:
             case ObjectPattern: {
-                RefPtr<InitializeParameterExpressionNode> init = this->finalize(node, new InitializeParameterExpressionNode(param.get(), paramIndex));
-                RefPtr<Node> statement = this->finalize(node, new ExpressionStatementNode(init.get()));
-                container->appendChild(statement.get());
+                InitializeParameterExpressionNode* init = this->finalize(node, builder.createInitializeParameterExpressionNode(param, paramIndex));
+                Node* statement = this->finalize(node, builder.createExpressionStatementNode(init));
+                container->appendChild(statement);
                 break;
             }
             case RestElement: {
-                RefPtr<Node> statement = this->finalize(node, new ExpressionStatementNode(param.get()));
-                container->appendChild(statement.get());
+                Node* statement = this->finalize(node, builder.createExpressionStatementNode(param));
+                container->appendChild(statement);
                 break;
             }
             default: {
@@ -3975,7 +3963,7 @@ public:
     }
 
 
-    PassRefPtr<BlockStatementNode> parseFunctionBody(NodeGenerator& builder)
+    BlockStatementNode* parseFunctionBody(NodeGenerator& builder)
     {
         // only for parsing the body of callee function
         ASSERT(this->isParsingSingleFunction);
@@ -3988,10 +3976,10 @@ public:
         this->context->inCatchClause = false;
 
         MetaNode nodeStart = this->createNode();
-        RefPtr<StatementContainer> body = StatementContainer::create();
+        StatementContainer* body = builder.createStatementContainer();
 
         this->expect(LeftBrace);
-        this->parseDirectivePrologues(builder, body.get());
+        this->parseDirectivePrologues(builder, body);
 
         this->context->labelSet.clear();
         this->context->inIteration = false;
@@ -4003,25 +3991,25 @@ public:
             if (this->match(RightBrace)) {
                 break;
             }
-            referNode = body->appendChild(this->parseStatementListItem(builder).get(), referNode);
+            referNode = body->appendChild(this->parseStatementListItem(builder), referNode);
         }
 
         bool isEndedWithReturnNode = referNode && referNode->type() == ASTNodeType::ReturnStatement;
         if (!isEndedWithReturnNode) {
-            referNode = body->appendChild(adoptRef(builder.createReturnStatementNode(nullptr)));
+            referNode = body->appendChild(builder.createReturnStatementNode(nullptr));
         }
 
         this->expect(RightBrace);
 
-        return this->finalize(nodeStart, builder.createBlockStatementNode(body.get(), 0));
+        return this->finalize(nodeStart, builder.createBlockStatementNode(body, 0));
     }
 
     // ECMA-262 14.1 Function Definition
     template <class ASTBuilder>
-    ASTPassNode parseFunctionSourceElements(ASTBuilder& builder)
+    ASTNode parseFunctionSourceElements(ASTBuilder& builder)
     {
         // return empty node because the function body node is never used now
-        ASTNode result;
+        ASTNode result = nullptr;
 
         if (this->isParsingSingleFunction && !this->context->inParameterParsing) {
             // when parsing for function call, parseFunctionSourceElements should parse only for child functions
@@ -4046,7 +4034,7 @@ public:
             this->lookahead.valuePunctuatorKind = PunctuatorKind::RightBrace;
             this->expect(RightBrace);
 
-            //return this->finalize(this->createNode(), builder.createBlockStatementNode(StatementContainer::create().get(), this->lexicalBlockIndex));
+            //return this->finalize(this->createNode(), builder.createBlockStatementNode(StatementContainer::create(), this->lexicalBlockIndex));
             return result;
         }
 
@@ -4118,12 +4106,12 @@ public:
         this->currentScopeContext->m_bodyEndLOC.column = this->lastMarker.index - this->lastMarker.lineStart;
 #endif
 
-        //return this->finalize(nodeStart, builder.createBlockStatementNode(StatementContainer::create().get(), this->lexicalBlockIndex));
+        //return this->finalize(nodeStart, builder.createBlockStatementNode(StatementContainer::create(), this->lexicalBlockIndex));
         return result;
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseFunctionDeclaration(ASTBuilder& builder)
+    ASTNode parseFunctionDeclaration(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
         this->expectKeyword(FunctionKeyword);
@@ -4134,7 +4122,7 @@ public:
         }
 
         const char* message = nullptr;
-        ASTNode id;
+        ASTNode id = nullptr;
         Scanner::SmallScannerResult firstRestricted;
 
         {
@@ -4201,7 +4189,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseFunctionExpression(ASTBuilder& builder)
+    ASTNode parseFunctionExpression(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
         this->expectKeyword(FunctionKeyword);
@@ -4212,7 +4200,7 @@ public:
         }
 
         const char* message = nullptr;
-        ASTNode id;
+        ASTNode id = nullptr;
         Scanner::SmallScannerResult firstRestricted;
 
         bool previousAllowYield = this->context->allowYield;
@@ -4282,7 +4270,7 @@ public:
     // ECMA-262 14.1.1 Directive Prologues
 
     template <class ASTBuilder>
-    ASTPassNode parseDirective(ASTBuilder& builder, bool& useStrict)
+    ASTNode parseDirective(ASTBuilder& builder, bool& useStrict)
     {
         ALLOC_TOKEN(token);
         *token = this->lookahead;
@@ -4300,9 +4288,9 @@ public:
         this->consumeSemicolon();
 
         if (isLiteral) {
-            return this->finalize(node, builder.createDirectiveNode(expr.get()));
+            return this->finalize(node, builder.createDirectiveNode(expr));
         } else {
-            return this->finalize(node, builder.createExpressionStatementNode(expr.get()));
+            return this->finalize(node, builder.createExpressionStatementNode(expr));
         }
     }
 
@@ -4321,7 +4309,7 @@ public:
             }
 
             ASTNode statement = this->parseDirective(builder, useStrict);
-            container->appendChild(statement.get());
+            container->appendChild(statement);
 
             if (statement->type() != Directive) {
                 break;
@@ -4343,7 +4331,7 @@ public:
     // ECMA-262 14.3 Method Definitions
 
     template <class ASTBuilder>
-    ASTPassNode parseGetterMethod(ASTBuilder& builder)
+    ASTNode parseGetterMethod(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
         this->expect(LeftParenthesis);
@@ -4378,7 +4366,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseSetterMethod(ASTBuilder& builder)
+    ASTNode parseSetterMethod(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
 
@@ -4417,7 +4405,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseGeneratorMethod(ASTBuilder& builder)
+    ASTNode parseGeneratorMethod(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
 
@@ -4498,7 +4486,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseYieldExpression(ASTBuilder& builder)
+    ASTNode parseYieldExpression(ASTBuilder& builder)
     {
         if (this->context->inParameterParsing) {
             this->throwError("Cannot use yield expression within parameters");
@@ -4507,7 +4495,7 @@ public:
         MetaNode node = this->createNode();
         this->expectKeyword(YieldKeyword);
 
-        ASTNode exprNode;
+        ASTNode exprNode = nullptr;
         bool delegate = false;
 
         if (!this->hasLineTerminator) {
@@ -4532,7 +4520,7 @@ public:
     // ECMA-262 14.5 Class Definitions
 
     template <class ASTBuilder>
-    ASTPassNode parseClassElement(ASTBuilder& builder, ASTNode& constructor, bool hasSuperClass)
+    ASTNode parseClassElement(ASTBuilder& builder, ASTNode& constructor, bool hasSuperClass)
     {
         ALLOC_TOKEN(token);
         *token = this->lookahead;
@@ -4540,8 +4528,8 @@ public:
 
         ClassElementNode::Kind kind = ClassElementNode::Kind::None;
 
-        ASTNode keyNode;
-        ASTNode value;
+        ASTNode keyNode = nullptr;
+        ASTNode value = nullptr;
         StringView keyString;
 
         bool computed = false;
@@ -4592,7 +4580,7 @@ public:
             kind = ClassElementNode::Kind::Method;
             bool allowSuperCall = false;
             if (hasSuperClass) {
-                if (keyNode && this->isPropertyKey(keyNode.get(), keyString, "constructor")) {
+                if (keyNode && this->isPropertyKey(keyNode, keyString, "constructor")) {
                     allowSuperCall = true;
                 }
             }
@@ -4603,10 +4591,10 @@ public:
             this->throwUnexpectedToken(this->lookahead);
         }
 
-        if (isStatic && !computed && this->isPropertyKey(keyNode.get(), keyString, "prototype")) {
+        if (isStatic && !computed && this->isPropertyKey(keyNode, keyString, "prototype")) {
             this->throwUnexpectedToken(*token, Messages::StaticPrototype);
         }
-        if (!isStatic && !computed && this->isPropertyKey(keyNode.get(), keyString, "constructor")) {
+        if (!isStatic && !computed && this->isPropertyKey(keyNode, keyString, "constructor")) {
             if (kind != ClassElementNode::Kind::Method) {
                 this->throwUnexpectedToken(*token, Messages::ConstructorSpecialMethod);
             }
@@ -4622,7 +4610,7 @@ public:
                     this->lastPoppedScopeContext->m_isDerivedClassConstructor = hasSuperClass;
                 }
                 constructor = value;
-                ASTNode empty;
+                ASTNode empty = nullptr;
                 return empty;
             }
         }
@@ -4638,16 +4626,16 @@ public:
             }
         }
 
-        return this->finalize(node, builder.createClassElementNode(keyNode.get(), value.get(), kind, computed, isStatic));
+        return this->finalize(node, builder.createClassElementNode(keyNode, value, kind, computed, isStatic));
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseClassBody(ASTBuilder& builder, bool hasSuperClass, MetaNode& endNode)
+    ASTNode parseClassBody(ASTBuilder& builder, bool hasSuperClass, MetaNode& endNode)
     {
         MetaNode node = this->createNode();
 
         ASTNodeVector body;
-        ASTNode constructor;
+        ASTNode constructor = nullptr;
 
         this->expect(LeftBrace);
         while (!this->match(RightBrace)) {
@@ -4668,14 +4656,14 @@ public:
     }
 
     template <class ASTBuilder, typename ClassType>
-    ASTPassNode classDeclaration(ASTBuilder& builder, bool identifierIsOptional)
+    ASTNode classDeclaration(ASTBuilder& builder, bool identifierIsOptional)
     {
         bool previousStrict = this->context->strict;
         this->context->strict = true;
         MetaNode startNode = this->createNode();
         this->expectKeyword(ClassKeyword);
 
-        ASTNode idNode;
+        ASTNode idNode = nullptr;
         AtomicString id;
 
         if (!identifierIsOptional || this->lookahead.type == Token::IdentifierToken) {
@@ -4688,7 +4676,7 @@ public:
         }
 
         bool hasSuperClass = false;
-        ASTNode superClass;
+        ASTNode superClass = nullptr;
         if (this->matchKeyword(ExtendsKeyword)) {
             hasSuperClass = true;
             this->nextToken();
@@ -4710,13 +4698,13 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseClassDeclaration(ASTBuilder& builder)
+    ASTNode parseClassDeclaration(ASTBuilder& builder)
     {
         return classDeclaration<ASTBuilder, ClassDeclarationNode>(builder, false);
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseClassExpression(ASTBuilder& builder)
+    ASTNode parseClassExpression(ASTBuilder& builder)
     {
         return classDeclaration<ASTBuilder, ClassExpressionNode>(builder, true);
     }
@@ -4725,7 +4713,7 @@ public:
     // ECMA-262 15.2.2 Imports
 
     template <class ASTBuilder>
-    ASTPassNode parseModuleSpecifier(ASTBuilder& builder)
+    ASTNode parseModuleSpecifier(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
 
@@ -4743,11 +4731,11 @@ public:
 
     // import {<foo as bar>} ...;
     template <class ASTBuilder>
-    ASTPassNode parseImportSpecifier(ASTBuilder& builder)
+    ASTNode parseImportSpecifier(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
 
-        ASTNode local;
+        ASTNode local = nullptr;
         ASTNode imported = this->parseIdentifierName(builder);
         if (this->matchContextualKeyword("as")) {
             this->nextToken();
@@ -4777,7 +4765,7 @@ public:
 
     // import <foo> ...;
     template <class ASTBuilder>
-    ASTPassNode parseImportDefaultSpecifier(ASTBuilder& builder)
+    ASTNode parseImportDefaultSpecifier(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
         ASTNode local = this->parseIdentifierName(builder);
@@ -4786,7 +4774,7 @@ public:
 
     // import <* as foo> ...;
     template <class ASTBuilder>
-    ASTPassNode parseImportNamespaceSpecifier(ASTBuilder& builder)
+    ASTNode parseImportNamespaceSpecifier(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
 
@@ -4800,7 +4788,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseImportDeclaration(ASTBuilder& builder)
+    ASTNode parseImportDeclaration(ASTBuilder& builder)
     {
         if (this->context->inFunctionBody) {
             this->throwError(Messages::IllegalImportDeclaration);
@@ -4813,7 +4801,7 @@ public:
         MetaNode node = this->createNode();
         this->expectKeyword(KeywordKind::ImportKeyword);
 
-        ASTNode src;
+        ASTNode src = nullptr;
 
         Script::ImportEntryVector importEntrys;
         ASTNodeVector specifiers;
@@ -4840,7 +4828,7 @@ public:
                 if (builder.isNodeGenerator()) {
                     Script::ImportEntry entry;
                     entry.m_importName = this->escargotContext->staticStrings().asciiTable[(unsigned char)'*'];
-                    entry.m_localName = ((ImportNamespaceSpecifierNode*)specifiers.back().get())->local()->name();
+                    entry.m_localName = specifiers.back()->asImportNamespaceSpecifier()->local()->name();
                     importEntrys.push_back(entry);
                 }
             } else if (this->isIdentifierName(&this->lookahead) && !this->matchKeyword(KeywordKind::DefaultKeyword)) {
@@ -4850,7 +4838,7 @@ public:
                 if (builder.isNodeGenerator()) {
                     Script::ImportEntry entry;
                     entry.m_importName = this->escargotContext->staticStrings().stringDefault;
-                    entry.m_localName = ((ImportDefaultSpecifierNode*)specifiers.back().get())->local()->name();
+                    entry.m_localName = specifiers.back()->asImportDefaultSpecifier()->local()->name();
                     importEntrys.push_back(entry);
                 }
 
@@ -4863,7 +4851,7 @@ public:
                         if (builder.isNodeGenerator()) {
                             Script::ImportEntry entry;
                             entry.m_importName = this->escargotContext->staticStrings().asciiTable[(unsigned char)'*'];
-                            entry.m_localName = ((ImportNamespaceSpecifierNode*)specifiers.back().get())->local()->name();
+                            entry.m_localName = specifiers.back()->asImportNamespaceSpecifier()->local()->name();
                             importEntrys.push_back(entry);
                         }
                     } else if (this->match(PunctuatorKind::LeftBrace)) {
@@ -4873,8 +4861,8 @@ public:
                         if (builder.isNodeGenerator()) {
                             for (size_t i = 0; i < v.size(); i++) {
                                 Script::ImportEntry entry;
-                                entry.m_importName = ((ImportSpecifierNode*)v[i].get())->imported()->name();
-                                entry.m_localName = ((ImportSpecifierNode*)v[i].get())->local()->name();
+                                entry.m_importName = v[i]->asImportSpecifier()->imported()->name();
+                                entry.m_localName = v[i]->asImportSpecifier()->local()->name();
                                 importEntrys.push_back(entry);
                             }
 
@@ -4911,12 +4899,11 @@ public:
 
     // ECMA-262 15.2.3 Exports
     template <class ASTBuilder>
-    ASTPassNode parseExportSpecifier(ASTBuilder& builder)
+    ASTNode parseExportSpecifier(ASTBuilder& builder)
     {
         MetaNode node = this->createNode();
 
-        ASTNode local;
-        local = this->parseIdentifierName(builder);
+        ASTNode local = this->parseIdentifierName(builder);
 
         ASTNode exported = local;
         if (this->matchContextualKeyword("as")) {
@@ -4973,7 +4960,7 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTPassNode parseExportDeclaration(ASTBuilder& builder)
+    ASTNode parseExportDeclaration(ASTBuilder& builder)
     {
         if (this->context->inFunctionBody) {
             this->throwError(Messages::IllegalExportDeclaration);
@@ -4986,7 +4973,7 @@ public:
         MetaNode node = this->createNode();
         this->expectKeyword(KeywordKind::ExportKeyword);
 
-        ASTNode exportDeclaration;
+        ASTNode exportDeclaration = nullptr;
         if (this->matchKeyword(KeywordKind::DefaultKeyword)) {
             // export default ...
 
@@ -5011,7 +4998,7 @@ public:
                 if (builder.isNodeGenerator()) {
                     Script::ExportEntry entry;
                     entry.m_exportName = this->escargotContext->staticStrings().stringDefault;
-                    entry.m_localName = classNode->asClassExpression()->classNode().id().get() ? classNode->asClassExpression()->classNode().id()->asIdentifier()->name() : this->escargotContext->staticStrings().stringStarDefaultStar;
+                    entry.m_localName = classNode->asClassExpression()->classNode().id() ? classNode->asClassExpression()->classNode().id()->asIdentifier()->name() : this->escargotContext->staticStrings().stringStarDefaultStar;
                     addDeclaredNameIntoContext(entry.m_localName.value(), this->lexicalBlockIndex, KeywordKind::LetKeyword);
                     addExportDeclarationEntry(entry);
 
@@ -5070,7 +5057,7 @@ public:
                 };
             }
             AtomicStringVector declaredName;
-            ASTNode declaration;
+            ASTNode declaration = nullptr;
             switch (this->lookahead.valueKeywordKind) {
             case KeywordKind::LetKeyword:
             case KeywordKind::ConstKeyword:
@@ -5096,7 +5083,7 @@ public:
             this->nameDeclaredCallback = oldNameCallback;
         } else {
             ASTNodeVector specifiers;
-            ASTNode source;
+            ASTNode source = nullptr;
             bool isExportFromIdentifier = false;
 
             this->expect(PunctuatorKind::LeftBrace);
@@ -5147,16 +5134,16 @@ public:
         return exportDeclaration;
     }
 
-    PassRefPtr<ProgramNode> parseProgram(NodeGenerator& builder)
+    ProgramNode* parseProgram(NodeGenerator& builder)
     {
         MetaNode startNode = this->createNode();
         pushScopeContext(new ASTFunctionScopeContext(this->context->strict));
         this->context->allowLexicalDeclaration = true;
-        RefPtr<StatementContainer> container = StatementContainer::create();
-        this->parseDirectivePrologues(builder, container.get());
+        StatementContainer* container = builder.createStatementContainer();
+        this->parseDirectivePrologues(builder, container);
         StatementNode* referNode = nullptr;
         while (this->startMarker.index < this->scanner->length) {
-            referNode = container->appendChild(this->parseStatementListItem(builder).get(), referNode);
+            referNode = container->appendChild(this->parseStatementListItem(builder), referNode);
         }
         this->currentScopeContext->m_bodyStartLOC.line = startNode.line;
         this->currentScopeContext->m_bodyStartLOC.column = startNode.column;
@@ -5168,38 +5155,38 @@ public:
         this->currentScopeContext->m_bodyEndLOC.column = endNode.column;
 #endif
         this->currentScopeContext->m_bodyEndLOC.index = endNode.index;
-        return this->finalize(startNode, new ProgramNode(container.get(), this->currentScopeContext, this->moduleData, std::move(this->numeralLiteralVector)));
+        return this->finalize(startNode, builder.createProgramNode(container, this->currentScopeContext, this->moduleData, std::move(this->numeralLiteralVector)));
     }
 
-    PassRefPtr<FunctionNode> parseScriptFunction(NodeGenerator& builder)
+    FunctionNode* parseScriptFunction(NodeGenerator& builder)
     {
         ASSERT(this->isParsingSingleFunction);
 
         MetaNode node = this->createNode();
-        RefPtr<StatementContainer> params = this->parseFunctionParameters(builder);
-        RefPtr<BlockStatementNode> body = this->parseFunctionBody(builder);
+        StatementContainer* params = this->parseFunctionParameters(builder);
+        BlockStatementNode* body = this->parseFunctionBody(builder);
 
-        return this->finalize(node, new FunctionNode(params.get(), body.get(), std::move(this->numeralLiteralVector)));
+        return this->finalize(node, builder.createFunctionNode(params, body, std::move(this->numeralLiteralVector)));
     }
 
-    PassRefPtr<FunctionNode> parseScriptArrowFunction(NodeGenerator& builder, bool hasArrowParameterPlaceHolder)
+    FunctionNode* parseScriptArrowFunction(NodeGenerator& builder, bool hasArrowParameterPlaceHolder)
     {
         ASSERT(this->isParsingSingleFunction);
 
         MetaNode node = this->createNode();
-        RefPtr<StatementContainer> params;
-        RefPtr<BlockStatementNode> body;
+        StatementContainer* params;
+        BlockStatementNode* body;
 
         // generate parameter statements
         if (hasArrowParameterPlaceHolder) {
             params = parseFunctionParameters(builder);
         } else {
-            RefPtr<Node> param = this->parseConditionalExpression(builder);
+            Node* param = this->parseConditionalExpression(builder);
             ASSERT(param->type() == Identifier);
-            params = StatementContainer::create();
-            RefPtr<InitializeParameterExpressionNode> init = this->finalize(node, new InitializeParameterExpressionNode(param.get(), 0));
-            RefPtr<Node> statement = this->finalize(node, new ExpressionStatementNode(init.get()));
-            params->appendChild(statement.get());
+            params = builder.createStatementContainer();
+            InitializeParameterExpressionNode* init = this->finalize(node, builder.createInitializeParameterExpressionNode(param, 0));
+            Node* statement = this->finalize(node, builder.createExpressionStatementNode(init));
+            params->appendChild(statement);
         }
         this->expect(Arrow);
         this->context->inArrowFunction = true;
@@ -5209,7 +5196,7 @@ public:
             body = parseFunctionBody(builder);
         } else {
             MetaNode nodeStart = this->createNode();
-            RefPtr<StatementContainer> container = StatementContainer::create();
+            StatementContainer* container = builder.createStatementContainer();
 
             auto previousLabelSet = this->context->labelSet;
             bool previousInIteration = this->context->inIteration;
@@ -5225,9 +5212,9 @@ public:
             bool previousAllowYield = this->context->allowYield;
             this->context->allowYield = true;
 
-            RefPtr<Node> expr = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<NodeGenerator, false>);
+            Node* expr = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<NodeGenerator, false>);
 
-            container->appendChild(this->finalize(nodeStart, new ReturnStatementNode(expr.get())), nullptr);
+            container->appendChild(this->finalize(nodeStart, builder.createReturnStatementNode(expr)), nullptr);
 
             /*
                if (this->context->strict && list.firstRestricted) {
@@ -5246,31 +5233,39 @@ public:
             this->context->inSwitch = previousInSwitch;
             this->context->inFunctionBody = previousInFunctionBody;
 
-            body = this->finalize(nodeStart, new BlockStatementNode(container.get()));
+            body = this->finalize(nodeStart, builder.createBlockStatementNode(container));
         }
 
-        return this->finalize(node, new FunctionNode(params.get(), body.get(), std::move(this->numeralLiteralVector)));
+        return this->finalize(node, builder.createFunctionNode(params, body, std::move(this->numeralLiteralVector)));
     }
 };
 
-RefPtr<ProgramNode> parseProgram(::Escargot::Context* ctx, StringView source, bool isModule, bool strictFromOutside, bool inWith, size_t stackRemain, bool allowSuperCallOutside, bool allowSuperPropertyOutside)
+ProgramNode* parseProgram(::Escargot::Context* ctx, StringView source, bool isModule, bool strictFromOutside, bool inWith, size_t stackRemain, bool allowSuperCallOutside, bool allowSuperPropertyOutside)
 {
+    // GC should be disabled during the parsing process
+    ASSERT(GC_is_disabled());
+    ASSERT(ctx->astAllocator().isInitialized());
+
     Parser parser(ctx, source, isModule, stackRemain);
-    NodeGenerator builder;
+    NodeGenerator builder(ctx->astAllocator());
 
     parser.context->strict = strictFromOutside;
     parser.context->inWith = inWith;
     parser.context->allowSuperCall = allowSuperCallOutside;
     parser.context->allowSuperProperty = allowSuperPropertyOutside;
 
-    RefPtr<ProgramNode> nd = parser.parseProgram(builder);
+    ProgramNode* nd = parser.parseProgram(builder);
     return nd;
 }
 
-RefPtr<FunctionNode> parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock* codeBlock, ASTFunctionScopeContext*& scopeContext, size_t stackRemain)
+FunctionNode* parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock* codeBlock, ASTFunctionScopeContext*& scopeContext, size_t stackRemain)
 {
+    // GC should be disabled during the parsing process
+    ASSERT(GC_is_disabled());
+    ASSERT(ctx->astAllocator().isInitialized());
+
     Parser parser(ctx, codeBlock->src(), false, stackRemain, codeBlock->sourceElementStart());
-    NodeGenerator builder;
+    NodeGenerator builder(ctx->astAllocator());
 
     parser.trackUsingNames = false;
     parser.context->allowLexicalDeclaration = true;

--- a/src/parser/esprima_cpp/esprima.h
+++ b/src/parser/esprima_cpp/esprima.h
@@ -61,8 +61,8 @@ struct Error : public gc {
 
 #define ESPRIMA_RECURSIVE_LIMIT 1024
 
-RefPtr<ProgramNode> parseProgram(::Escargot::Context* ctx, StringView source, bool isModule, bool strictFromOutside, bool inWith, size_t stackRemain, bool allowSuperCallOutside, bool allowSuperPropertyOutside);
-RefPtr<FunctionNode> parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock* codeBlock, ASTFunctionScopeContext*& scopeContext, size_t stackRemain);
+ProgramNode* parseProgram(::Escargot::Context* ctx, StringView source, bool isModule, bool strictFromOutside, bool inWith, size_t stackRemain, bool allowSuperCallOutside, bool allowSuperPropertyOutside);
+FunctionNode* parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock* codeBlock, ASTFunctionScopeContext*& scopeContext, size_t stackRemain);
 }
 }
 

--- a/src/runtime/Context.cpp
+++ b/src/runtime/Context.cpp
@@ -55,6 +55,7 @@ Context::Context(VMInstance* instance)
     , m_bumpPointerAllocator(instance->m_bumpPointerAllocator)
     , m_regexpCache(&instance->m_regexpCache)
     , m_toStringRecursionPreventer(&instance->m_toStringRecursionPreventer)
+    , m_astAllocator(*instance->m_astAllocator)
 {
     m_defaultStructureForObject = m_instance->m_defaultStructureForObject;
     m_defaultStructureForFunctionObject = m_instance->m_defaultStructureForFunctionObject;

--- a/src/runtime/Context.h
+++ b/src/runtime/Context.h
@@ -230,6 +230,11 @@ public:
         return m_loadedModules;
     }
 
+    ASTAllocator& astAllocator()
+    {
+        return m_astAllocator;
+    }
+
 private:
     VMInstance* m_instance;
 
@@ -264,6 +269,8 @@ private:
     ToStringRecursionPreventer* m_toStringRecursionPreventer;
     VirtualIdentifierCallback m_virtualIdentifierCallback;
     SecurityPolicyCheckCallback m_securityPolicyCheckCallback;
+
+    ASTAllocator& m_astAllocator;
     // public helper variable
     void* m_virtualIdentifierCallbackPublic;
     void* m_securityPolicyCheckCallbackPublic;

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -109,11 +109,21 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
         }
     }
 
+    GC_disable();
+
     try {
         srcToTest.appendString(") { }");
         String* cur = srcToTest.finalize(&state);
         esprima::parseProgram(state.context(), StringView(cur, 0, cur->length()), false, false, false, SIZE_MAX, false, false);
+
+        // reset ASTAllocator
+        state.context()->astAllocator().reset();
+        GC_enable();
     } catch (esprima::Error& orgError) {
+        // reset ASTAllocator
+        state.context()->astAllocator().reset();
+        GC_enable();
+
         ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "there is a script parse error in parameter name");
     }
 

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -23,6 +23,7 @@
 #include "ArrayObject.h"
 #include "StringObject.h"
 #include "JobQueue.h"
+#include "parser/ASTAllocator.h"
 
 namespace Escargot {
 
@@ -127,6 +128,7 @@ VMInstance::~VMInstance()
 #ifdef ENABLE_ICU
     delete m_timezone;
 #endif
+    delete m_astAllocator;
 }
 
 VMInstance::VMInstance(Platform* platform, const char* locale, const char* timezone)
@@ -136,6 +138,7 @@ VMInstance::VMInstance(Platform* platform, const char* locale, const char* timez
     , m_compiledByteCodeSize(0)
     , m_cachedUTC(nullptr)
     , m_platform(platform)
+    , m_astAllocator(new ASTAllocator())
 {
     GC_REGISTER_FINALIZER_NO_ORDER(this, [](void* obj, void*) {
         VMInstance* self = (VMInstance*)obj;

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -36,6 +36,7 @@ class SandBox;
 class CodeBlock;
 class JobQueue;
 class Job;
+class ASTAllocator;
 
 #define DEFINE_GLOBAL_SYMBOLS(F) \
     F(hasInstance)               \
@@ -255,6 +256,7 @@ private:
     DateObject* m_cachedUTC;
 
     Platform* m_platform;
+    ASTAllocator* m_astAllocator;
 
     // promise job queue
     JobQueue* m_jobQueue;

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -527,7 +527,8 @@ int main(int argc, char* argv[])
 
     Memory::setGCFrequency(24);
 
-    PersistentRefHolder<VMInstanceRef> instance = VMInstanceRef::create(new ShellPlatform());
+    ShellPlatform* platform = new ShellPlatform();
+    PersistentRefHolder<VMInstanceRef> instance = VMInstanceRef::create(platform);
     PersistentRefHolder<ContextRef> context = createEscargotContext(instance.get());
 
     bool runShell = true;
@@ -599,6 +600,8 @@ int main(int argc, char* argv[])
     instance.release();
 
     Globals::finalize();
+
+    delete platform;
 
     return 0;
 }

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "api/EscargotPublic.h"
+#include "malloc.h"
 
 #if defined(ESCARGOT_ENABLE_TEST)
 // these header & function below are used for Escargot internal development

--- a/src/util/Vector.h
+++ b/src/util/Vector.h
@@ -491,7 +491,7 @@ private:
 // Vector for special purpose
 // It has InlineStorage, so push_back operation is fast with InlineStorage
 template <unsigned int InlineStorageSize, typename T,
-          typename ExternalStoreageAllocator>
+          typename ExternalStorageAllocator>
 class VectorWithInlineStorage : public gc {
 public:
     VectorWithInlineStorage()
@@ -515,7 +515,7 @@ public:
     }
 
     VectorWithInlineStorage(VectorWithInlineStorage<InlineStorageSize, T,
-                                                    ExternalStoreageAllocator>&& src)
+                                                    ExternalStorageAllocator>&& src)
     {
         m_size = src.m_size;
         if (src.m_useExternalStorage) {
@@ -601,7 +601,7 @@ protected:
     bool m_useExternalStorage;
     size_t m_size;
     T m_inlineStorage[InlineStorageSize];
-    std::vector<T, ExternalStoreageAllocator> m_externalStorage;
+    std::vector<T, ExternalStorageAllocator> m_externalStorage;
 };
 
 


### PR DESCRIPTION
* AST Nodes are generated and used only for Bytecode generation. That is, created AST Nodes should be maintained until the bytecode generation finished and could be flushed after then. This patch implements AST memory pool for AST Node to allocate and flush memory area for AST Nodes. AST pool can also remove all reference-counted(RefPtr) overhead, thus make the startup time more faster.
* this patch also reduces memory operations in parsing, especially vector overhead during the scanning process. SyntaxNodeVector is newly added to mimic the operation of existing vector with minimal overhead. 

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>