### PR TITLE
Fix position settings in String.prototype.endsWith

### DIFF
--- a/src/runtime/GlobalObjectBuiltinString.cpp
+++ b/src/runtime/GlobalObjectBuiltinString.cpp
@@ -995,7 +995,7 @@ static Value builtinStringEndsWith(ExecutionState& state, Value thisValue, size_
     String* searchStr = searchString.toString(state);
     // If endPosition is undefined, let pos be len, else let pos be ? ToInteger(endPosition).
     double pos = 0;
-    if (argc >= 2) {
+    if (argc >= 2 && !argv[1].isUndefined()) {
         pos = argv[1].toInteger(state);
     } else {
         pos = len;

--- a/tools/test/v8/v8.mjsunit.status
+++ b/tools/test/v8/v8.mjsunit.status
@@ -654,7 +654,6 @@
   'es6/regexp-tostring' : [SKIP],
   'es6/rest-params' : [SKIP],
   'es6/sloppy-restrictive-block-function' : [SKIP],
-  'es6/string-endswith' : [SKIP],
   'es6/string-fromcodepoint' : [SKIP],
   'es6/string-includes' : [SKIP],
   'es6/string-startswith' : [SKIP],


### PR DESCRIPTION
If the second argument is undefined in endsWith() the position
should be set to the length of the string in question.

Enable corresponding v8 test: es6/string-endsWith

Signed-off-by: Bela Toth tbela@inf.u-szeged.hu