### PR TITLE
Optimize parser to skip the scanning of the whole function

### DIFF
--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -161,6 +161,12 @@ public:
         return m_string;
     }
 
+    AtomicString& functionName()
+    {
+        ASSERT(m_nodeType == FunctionDeclaration || m_nodeType == FunctionExpression);
+        return m_string;
+    }
+
     AtomicString& assignmentPatternName()
     {
         ASSERT(m_nodeType == AssignmentPattern);
@@ -300,7 +306,7 @@ public:
         // dummy function for classNode() of ClassDeclarationNode
         // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
-        ClassNode* tempClassNode = new ClassNode();
+        ClassNode* tempClassNode;
         return *tempClassNode;
     }
 
@@ -317,7 +323,8 @@ public:
         // dummy function for imported() of ImportSpecifierNode
         // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
-        return new IdentifierNode();
+        IdentifierNode* identifier;
+        return identifier;
     }
 
     IdentifierNode* exported()
@@ -325,7 +332,8 @@ public:
         // dummy function for imported() of ExportSpecifierNode
         // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
-        return new IdentifierNode();
+        IdentifierNode* identifier;
+        return identifier;
     }
 
     IdentifierNode* local()
@@ -333,7 +341,8 @@ public:
         // dummy function for local() of Import/ExportSpecifierNode
         // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
-        return new IdentifierNode();
+        IdentifierNode* identifier;
+        return identifier;
     }
 
     ALWAYS_INLINE operator bool()
@@ -408,9 +417,7 @@ typedef VectorWithInlineStorage<16, SyntaxNode, std::allocator<SyntaxNode>> Para
 class SyntaxChecker {
 public:
     typedef SyntaxNode ASTNode;
-    typedef SyntaxNode ASTIdentifierNode;
     typedef SyntaxNode ASTStatementContainer;
-    typedef SyntaxNode* ASTStatementNodePtr;
     typedef SyntaxNodeVector ASTNodeVector;
 
     MAKE_STACK_ALLOCATED();
@@ -582,9 +589,7 @@ public:
 class NodeGenerator {
 public:
     typedef Node* ASTNode;
-    typedef IdentifierNode* ASTIdentifierNode;
     typedef StatementContainer* ASTStatementContainer;
-    typedef StatementNode* ASTStatementNodePtr;
     typedef std::vector<Node*> ASTNodeVector;
 
     MAKE_STACK_ALLOCATED();

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -189,10 +189,9 @@ void InterpretedCodeBlock::initBlockScopeInformation(ASTFunctionScopeContext* sc
     }
 }
 
-InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTFunctionScopeContext* scopeCtx, ExtendedNodeLOC sourceElementStart, bool isEvalCode, bool isEvalCodeInFunction)
+InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTFunctionScopeContext* scopeCtx, ExtendedNodeLOC paramsStartLOC, bool isEvalCode, bool isEvalCodeInFunction)
     : m_script(script)
     , m_src(src)
-    , m_sourceElementStart(sourceElementStart)
     , m_identifierOnStackCount(0)
     , m_identifierOnHeapCount(0)
     , m_lexicalBlockStackAllocatedIdentifierMaximumDepth(0)
@@ -200,8 +199,8 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     , m_parentCodeBlock(nullptr)
     , m_firstChild(nullptr)
     , m_nextSibling(nullptr)
+    , m_sourceElementStart(paramsStartLOC)
 #ifndef NDEBUG
-    , m_bodyStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
     , m_bodyEndLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
     , m_scopeContext(nullptr)
 #endif
@@ -263,12 +262,9 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     initBlockScopeInformation(scopeCtx);
 }
 
-InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTFunctionScopeContext* scopeCtx, ExtendedNodeLOC sourceElementStart, InterpretedCodeBlock* parentBlock, bool isEvalCode, bool isEvalCodeInFunction)
+InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTFunctionScopeContext* scopeCtx, ExtendedNodeLOC paramsStartLOC, InterpretedCodeBlock* parentBlock, bool isEvalCode, bool isEvalCodeInFunction)
     : m_script(script)
     , m_src(StringView(src, scopeCtx->m_paramsStartLOC.index, scopeCtx->m_bodyEndLOC.index))
-    // FIXME replace m_bodySrc by bodySrcLength
-    , m_bodySrc(StringView(src, scopeCtx->m_bodyStartLOC.index, scopeCtx->m_bodyEndLOC.index))
-    , m_sourceElementStart(sourceElementStart)
     , m_identifierOnStackCount(0)
     , m_identifierOnHeapCount(0)
     , m_lexicalBlockStackAllocatedIdentifierMaximumDepth(0)
@@ -276,8 +272,8 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     , m_parentCodeBlock(parentBlock)
     , m_firstChild(nullptr)
     , m_nextSibling(nullptr)
+    , m_sourceElementStart(paramsStartLOC)
 #ifndef NDEBUG
-    , m_bodyStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
     , m_bodyEndLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
     , m_scopeContext(nullptr)
 #endif

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -637,13 +637,9 @@ public:
         return m_src;
     }
 
-    const StringView& bodySrc()
-    {
-        return m_bodySrc;
-    }
-
     ExtendedNodeLOC sourceElementStart()
     {
+        // currently, sourceElementStart point to the start location of the parameter list
         return m_sourceElementStart;
     }
 
@@ -718,8 +714,6 @@ protected:
 
     Script* m_script;
     StringView m_src; // function source including parameters
-    StringView m_bodySrc; // function body source
-    ExtendedNodeLOC m_sourceElementStart;
 
     AtomicStringTightVector m_parameterNames;
     uint16_t m_identifierOnStackCount; // this member variable only count `var`
@@ -733,8 +727,8 @@ protected:
     InterpretedCodeBlock* m_firstChild;
     InterpretedCodeBlock* m_nextSibling;
 
+    ExtendedNodeLOC m_sourceElementStart; // point to the start position of the parameter list
 #ifndef NDEBUG
-    ExtendedNodeLOC m_bodyStartLOC;
     ExtendedNodeLOC m_bodyEndLOC;
     ASTFunctionScopeContext* m_scopeContext;
 #endif

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -49,7 +49,6 @@ InterpretedCodeBlock* ScriptParser::generateCodeBlockTreeFromASTWalker(Context* 
     isEvalCodeInFunction = false;
 
 #ifndef NDEBUG
-    codeBlock->m_bodyStartLOC = scopeCtx->m_bodyStartLOC;
     codeBlock->m_bodyEndLOC = scopeCtx->m_bodyEndLOC;
     codeBlock->m_scopeContext = scopeCtx;
 #endif
@@ -314,8 +313,8 @@ void ScriptParser::dumpCodeBlockTree(InterpretedCodeBlock* topCodeBlock)
         PRINT_TAB()
         printf("CodeBlock %p %s %s (%d:%d -> %d:%d, block %d)(%s, %s) (E:%d, W:%d, Y:%d, A:%d)\n", cb, cb->m_functionName.string()->toUTF8StringData().data(),
                cb->m_isStrict ? "Strict" : "",
-               (int)cb->m_bodyStartLOC.line,
-               (int)cb->m_bodyStartLOC.column,
+               (int)cb->m_sourceElementStart.line,
+               (int)cb->m_sourceElementStart.column,
                (int)cb->m_bodyEndLOC.line,
                (int)cb->m_bodyEndLOC.column,
                (int)cb->lexicalBlockIndexFunctionLocatedIn(),

--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -181,7 +181,6 @@ struct ASTFunctionScopeContext {
     ASTBlockScopeContextVector m_childBlockScopes;
 
     ExtendedNodeLOC m_paramsStartLOC;
-    ExtendedNodeLOC m_bodyStartLOC;
 #ifndef NDEBUG
     ExtendedNodeLOC m_bodyEndLOC;
 #else
@@ -424,7 +423,6 @@ struct ASTFunctionScopeContext {
         , m_firstChild(nullptr)
         , m_nextSibling(nullptr)
         , m_paramsStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
-        , m_bodyStartLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
 #ifndef NDEBUG
         , m_bodyEndLOC(SIZE_MAX, SIZE_MAX, SIZE_MAX)
 #else
@@ -432,7 +430,7 @@ struct ASTFunctionScopeContext {
 #endif
     {
         // function is first block context
-        insertBlockScope(allocator, 0, LEXICAL_BLOCK_INDEX_MAX, m_bodyStartLOC);
+        insertBlockScope(allocator, 0, LEXICAL_BLOCK_INDEX_MAX, m_paramsStartLOC);
     }
 };
 }

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -56,7 +56,7 @@ private:
 
 class ArrowFunctionExpressionNode : public ExpressionNode {
 public:
-    ArrowFunctionExpressionNode(ASTFunctionScopeContext* scopeContext, size_t subCodeBlockIndex)
+    ArrowFunctionExpressionNode(size_t subCodeBlockIndex)
         : m_subCodeBlockIndex(subCodeBlockIndex - 1)
     {
     }

--- a/src/parser/ast/FunctionDeclarationNode.h
+++ b/src/parser/ast/FunctionDeclarationNode.h
@@ -24,14 +24,14 @@ namespace Escargot {
 
 class FunctionDeclarationNode : public StatementNode {
 public:
-    FunctionDeclarationNode(ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t /*subCodeBlockIndex not used yet*/)
+    FunctionDeclarationNode(bool isGenerator, size_t /*subCodeBlockIndex not used yet*/, const AtomicString& functionName)
         : m_isGenerator(isGenerator)
-        , m_scopeContext(scopeContext)
+        , m_functionName(functionName)
     {
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::FunctionDeclaration; }
-    ASTFunctionScopeContext* scopeContext() { return m_scopeContext; }
+    AtomicString functionName() { return m_functionName; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
         // do nothing
@@ -44,7 +44,7 @@ public:
 
 private:
     bool m_isGenerator;
-    ASTFunctionScopeContext* m_scopeContext;
+    AtomicString m_functionName;
 };
 }
 

--- a/src/parser/ast/FunctionExpressionNode.h
+++ b/src/parser/ast/FunctionExpressionNode.h
@@ -24,15 +24,15 @@ namespace Escargot {
 
 class FunctionExpressionNode : public ExpressionNode {
 public:
-    FunctionExpressionNode(ASTFunctionScopeContext* scopeContext, bool isGenerator, size_t subCodeBlockIndex)
+    FunctionExpressionNode(bool isGenerator, size_t subCodeBlockIndex, const AtomicString& functionName)
         : m_isGenerator(isGenerator)
-        , m_scopeContext(scopeContext)
         , m_subCodeBlockIndex(subCodeBlockIndex - 1)
+        , m_functionName(functionName)
     {
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::FunctionExpression; }
-    ASTFunctionScopeContext* scopeContext() { return m_scopeContext; }
+    AtomicString functionName() { return m_functionName; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstIndex) override
     {
         CodeBlock* blk = context->m_codeBlock->asInterpretedCodeBlock()->childBlockAt(m_subCodeBlockIndex);
@@ -53,8 +53,8 @@ public:
 
 private:
     bool m_isGenerator;
-    ASTFunctionScopeContext* m_scopeContext;
     size_t m_subCodeBlockIndex;
+    AtomicString m_functionName;
     // defaults: [ Expression ];
     // rest: Identifier | null;
 };

--- a/src/parser/ast/StatementNode.h
+++ b/src/parser/ast/StatementNode.h
@@ -73,10 +73,8 @@ public:
     {
         return allocator.allocate(size);
     }
-    void* operator new(size_t)
-    {
-        RELEASE_ASSERT_NOT_REACHED();
-    }
+
+    void* operator new(size_t) = delete;
     void* operator new[](size_t) = delete;
     void operator delete(void*) = delete;
     void operator delete[](void*) = delete;


### PR DESCRIPTION
* parsing of function including parameter list and function body is skipped in scanner mode
* m_bodySrc in InterpretedCodeBlock is removed because it is no longer necessary
* some operator overloading in FreeableNode and DestructibleNode is fixed
* this patch also resolves #236 in a more general way

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>