### PR TITLE
Minor fix in ProxyObject

### DIFF
--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -43,7 +43,7 @@ public:
     virtual bool set(ExecutionState& state, const ObjectPropertyName& propertyName, const Value& v, const Value& receiver) override;
     virtual bool setIndexedProperty(ExecutionState& state, const Value& property, const Value& value) override;
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Arguments";
     }

--- a/src/runtime/ArrayBufferObject.h
+++ b/src/runtime/ArrayBufferObject.h
@@ -45,7 +45,7 @@ class ArrayBufferObject : public Object {
 public:
     explicit ArrayBufferObject(ExecutionState& state);
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "ArrayBuffer";
     }

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -95,7 +95,7 @@ public:
     static bool arrayLengthNativeSetter(ExecutionState& state, Object* self, const Value& newData);
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Array";
     }
@@ -165,7 +165,7 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Array Iterator";
     }

--- a/src/runtime/AsyncGeneratorObject.h
+++ b/src/runtime/AsyncGeneratorObject.h
@@ -52,7 +52,7 @@ public:
     AsyncGeneratorObject(ExecutionState& state);
     AsyncGeneratorObject(ExecutionState& state, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk, const Value& prototype);
 
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "AsyncGenerator";
     }

--- a/src/runtime/BooleanObject.h
+++ b/src/runtime/BooleanObject.h
@@ -44,7 +44,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "Boolean";
     }

--- a/src/runtime/BoundFunctionObject.h
+++ b/src/runtime/BoundFunctionObject.h
@@ -49,7 +49,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Function";
     }

--- a/src/runtime/DataViewObject.h
+++ b/src/runtime/DataViewObject.h
@@ -45,7 +45,7 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "DataView";
     }

--- a/src/runtime/DateObject.h
+++ b/src/runtime/DateObject.h
@@ -122,7 +122,7 @@ public:
 
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "Date";
     }
@@ -196,7 +196,7 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Object";
     }

--- a/src/runtime/ErrorObject.h
+++ b/src/runtime/ErrorObject.h
@@ -138,7 +138,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "Error";
     }

--- a/src/runtime/FunctionObject.h
+++ b/src/runtime/FunctionObject.h
@@ -123,7 +123,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Function";
     }

--- a/src/runtime/GeneratorObject.h
+++ b/src/runtime/GeneratorObject.h
@@ -48,7 +48,7 @@ public:
     GeneratorObject(ExecutionState& state);
     GeneratorObject(ExecutionState& state, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk, const Value& prototype);
 
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Generator";
     }

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -240,7 +240,7 @@ public:
     Value eval(ExecutionState& state, const Value& arg);
     Value evalLocal(ExecutionState& state, const Value& arg, Value thisValue, InterpretedCodeBlock* parentCodeBlock, bool inWithOperation); // we get isInWithOperation as parameter because this affects bytecode
 
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "global";
     }

--- a/src/runtime/GlobalObjectBuiltinError.cpp
+++ b/src/runtime/GlobalObjectBuiltinError.cpp
@@ -114,7 +114,7 @@ public:
     {
     }
 
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Object";
     }

--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -95,7 +95,7 @@ static Value builtinObjectToString(ExecutionState& state, Value thisValue, size_
         if (toStringTag.isString()) {
             builder.appendString(toStringTag.asString());
         } else {
-            builder.appendString(thisObject->internalClassProperty());
+            builder.appendString(thisObject->internalClassProperty(state));
         }
     }
 

--- a/src/runtime/GlobalObjectBuiltinRegExp.cpp
+++ b/src/runtime/GlobalObjectBuiltinRegExp.cpp
@@ -605,7 +605,7 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Object";
     }

--- a/src/runtime/GlobalObjectBuiltinTypedArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinTypedArray.cpp
@@ -1638,7 +1638,7 @@ static Value builtinTypedArrayToStringTagGetter(ExecutionState& state, Value thi
         return Value();
     }
     if (O.asObject() && O.asObject()->isTypedArrayObject()) {
-        return Value(String::fromASCII(O.asObject()->internalClassProperty()));
+        return Value(String::fromASCII(O.asObject()->internalClassProperty(state)));
     }
     return Value();
 }

--- a/src/runtime/IteratorObject.h
+++ b/src/runtime/IteratorObject.h
@@ -65,7 +65,7 @@ public:
 
     Value next(ExecutionState& state);
 
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "Iterator";
     }

--- a/src/runtime/MapObject.h
+++ b/src/runtime/MapObject.h
@@ -40,7 +40,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Map";
     }
@@ -81,7 +81,7 @@ public:
     {
         return true;
     }
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Map Iterator";
     }

--- a/src/runtime/NumberObject.h
+++ b/src/runtime/NumberObject.h
@@ -60,7 +60,7 @@ public:
     static char* toStringWithRadix(ExecutionState& state, RadixBuffer& buffer, double number, unsigned radix);
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "Number";
     }

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -970,7 +970,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "Object";
     }

--- a/src/runtime/PromiseObject.h
+++ b/src/runtime/PromiseObject.h
@@ -87,7 +87,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "Promise";
     }

--- a/src/runtime/ProxyObject.h
+++ b/src/runtime/ProxyObject.h
@@ -24,6 +24,7 @@
 #include "runtime/Object.h"
 #include "runtime/FunctionObject.h"
 #include "runtime/NativeFunctionObject.h"
+#include "runtime/Context.h"
 
 namespace Escargot {
 
@@ -76,9 +77,12 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
-        return "Proxy";
+        if (!m_target) {
+            ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Proxy.string(), false, String::emptyString, "%s: \'target\' argument of Proxy cannot be null");
+        }
+        return m_target->internalClassProperty(state);
     }
 
     virtual Context* getFunctionRealm(ExecutionState& state) override;

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -141,7 +141,7 @@ public:
     void pushBackToRegExpMatchedArray(ExecutionState& state, ArrayObject* array, size_t& index, const size_t limit, const RegexMatchResult& result, String* str);
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "RegExp";
     }

--- a/src/runtime/SetObject.h
+++ b/src/runtime/SetObject.h
@@ -40,7 +40,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Set";
     }
@@ -93,7 +93,7 @@ public:
     {
         return true;
     }
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Set Iterator";
     }

--- a/src/runtime/StringObject.h
+++ b/src/runtime/StringObject.h
@@ -57,7 +57,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "String";
     }
@@ -79,7 +79,7 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty() override
+    virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "String Iterator";
     }

--- a/src/runtime/TypedArrayObject.cpp
+++ b/src/runtime/TypedArrayObject.cpp
@@ -31,7 +31,7 @@ namespace Escargot {
         setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->type##ArrayPrototype()); \
     }                                                                                                           \
     template <>                                                                                                 \
-    const char* TypedArrayObject<Type##Adaptor, siz>::internalClassProperty()                                   \
+    const char* TypedArrayObject<Type##Adaptor, siz>::internalClassProperty(ExecutionState& state)              \
     {                                                                                                           \
         return #Type "Array";                                                                                   \
     }

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -280,7 +280,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty() override;
+    virtual const char* internalClassProperty(ExecutionState& state) override;
 
     virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override
     {

--- a/src/runtime/WeakMapObject.h
+++ b/src/runtime/WeakMapObject.h
@@ -42,7 +42,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "WeakMap";
     }

--- a/src/runtime/WeakSetObject.h
+++ b/src/runtime/WeakSetObject.h
@@ -44,7 +44,7 @@ public:
     }
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty(ExecutionState& state)
     {
         return "WeakSet";
     }


### PR DESCRIPTION
Changes has been made in ProxyObject::internalClassProperty,
since if we use toString method on a ProxyObject the current output would be
[object Type] where the Type can be Object,Array,Function, etc. But before the
changes the output was Proxy ( [object Proxy] ) regardless of the target's type.

Signed-off-by: bence gabor kis <kisbg@inf.u-szeged.hu>