### PR TITLE
Fix bugs about arrow function parsing and toStringWithoutException

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -1723,7 +1723,9 @@ StringRef* ValueRef::toString(ExecutionStateRef* es)
 
 StringRef* ValueRef::toStringWithoutException(ContextRef* ctx)
 {
+    // declare temporal ExecutionState and SandBox
     ExecutionState state(toImpl(ctx));
+    SandBox sb(toImpl(ctx));
     return toRef(toImpl(this).toStringWithoutException(state));
 }
 

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -242,36 +242,23 @@ public:
         this->baseMarker.lineNumber = this->scanner->lineNumber;
         this->baseMarker.lineStart = 0;
 
-        this->startMarker.index = 0;
-        this->startMarker.lineNumber = this->scanner->lineNumber;
-        this->startMarker.lineStart = 0;
-
-        this->lastMarker.index = 0;
-        this->lastMarker.lineNumber = this->scanner->lineNumber;
-        this->lastMarker.lineStart = 0;
-
-        {
-            this->lastMarker.index = this->scanner->index;
-            this->lastMarker.lineNumber = this->scanner->lineNumber;
-            this->lastMarker.lineStart = this->scanner->lineStart;
-
-            this->collectComments();
-
-            this->startMarker.index = this->scanner->index;
-            this->startMarker.lineNumber = this->scanner->lineNumber;
-            this->startMarker.lineStart = this->scanner->lineStart;
-
-            Scanner::ScannerResult* next = &this->lookahead;
-            this->scanner->lex(next);
-            this->hasLineTerminator = false;
-
-            if (this->context->strict && next->type == Token::IdentifierToken && this->scanner->isStrictModeReservedWord(next->relatedSource(this->scanner->source))) {
-                next->type = Token::KeywordToken;
-            }
-        }
         this->lastMarker.index = this->scanner->index;
         this->lastMarker.lineNumber = this->scanner->lineNumber;
         this->lastMarker.lineStart = this->scanner->lineStart;
+
+        this->collectComments();
+
+        this->startMarker.index = this->scanner->index;
+        this->startMarker.lineNumber = this->scanner->lineNumber;
+        this->startMarker.lineStart = this->scanner->lineStart;
+
+        Scanner::ScannerResult* next = &this->lookahead;
+        this->scanner->lex(next);
+        this->hasLineTerminator = false;
+
+        if (this->context->strict && next->type == Token::IdentifierToken && this->scanner->isStrictModeReservedWord(next->relatedSource(this->scanner->source))) {
+            next->type = Token::KeywordToken;
+        }
     }
 
     void insertNumeralLiteral(Value v)


### PR DESCRIPTION
* fix a case that arrow function is located at the first of script
* fix a case that toStringWithoutException is called with no SandBox

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>