### PR TITLE
Remove dead code in test/test262-harness-py-test262.py

### DIFF
--- a/test/test262-harness-py-test262.py
+++ b/test/test262-harness-py-test262.py
@@ -17,14 +17,8 @@ import re
 import subprocess
 import sys
 import tempfile
-import time
 import xml.dom.minidom
-import datetime
-import shutil
-import json
-import stat
 import xml.etree.ElementTree as xmlj
-import unicodedata
 from collections import Counter
 
 


### PR DESCRIPTION
In my opinion, these modules do not seem to be used.