### PR TITLE
Improve performance

### DIFF
--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -102,6 +102,15 @@
 #endif
 #endif
 
+/* PREFETCH_READ */
+#ifndef PREFETCH_READ
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
+#define PREFETCH_READ(x) __builtin_prefetch((x), 0, 0)
+#else
+#define PREFETCH_READ(x)
+#endif
+#endif
+
 #ifndef NULLABLE
 #define NULLABLE
 #endif

--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -98,16 +98,18 @@ int getValidValueInInterpretedCodeBlock(void* ptr, GC_mark_custom_result* arr)
     arr[2].to = (GC_word*)current->m_identifierInfos.data();
     arr[3].from = (GC_word*)&current->m_parameterNames;
     arr[3].to = (GC_word*)current->m_parameterNames.data();
-    arr[4].from = (GC_word*)&current->m_parentCodeBlock;
-    arr[4].to = (GC_word*)current->m_parentCodeBlock;
-    arr[5].from = (GC_word*)&current->m_nextSibling;
-    arr[5].to = (GC_word*)current->m_nextSibling;
-    arr[6].from = (GC_word*)&current->m_firstChild;
-    arr[6].to = (GC_word*)current->m_firstChild;
-    arr[7].from = (GC_word*)&current->m_byteCodeBlock;
-    arr[7].to = (GC_word*)current->m_byteCodeBlock;
-    arr[8].from = (GC_word*)&current->m_blockInfos;
-    arr[8].to = (GC_word*)current->m_blockInfos.data();
+    arr[4].from = (GC_word*)&current->m_identifierInfoMap;
+    arr[4].to = (GC_word*)current->m_identifierInfoMap;
+    arr[5].from = (GC_word*)&current->m_parentCodeBlock;
+    arr[5].to = (GC_word*)current->m_parentCodeBlock;
+    arr[6].from = (GC_word*)&current->m_nextSibling;
+    arr[6].to = (GC_word*)current->m_nextSibling;
+    arr[7].from = (GC_word*)&current->m_firstChild;
+    arr[7].to = (GC_word*)current->m_firstChild;
+    arr[8].from = (GC_word*)&current->m_byteCodeBlock;
+    arr[8].to = (GC_word*)current->m_byteCodeBlock;
+    arr[9].from = (GC_word*)&current->m_blockInfos;
+    arr[9].to = (GC_word*)current->m_blockInfos.data();
     return 0;
 }
 
@@ -142,7 +144,7 @@ void initializeCustomAllocators()
                                                                       TRUE);
 
     s_gcKinds[HeapObjectKind::InterpretedCodeBlockKind] = GC_new_kind_enumerable(GC_new_free_list(),
-                                                                                 GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 9>), 0),
+                                                                                 GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 10>), 0),
                                                                                  FALSE,
                                                                                  TRUE);
 }

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -142,6 +142,24 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
 
     // generate common codes
     try {
+        AtomicString name = codeBlock->functionName();
+        if (name.string()->length()) {
+            if (UNLIKELY(codeBlock->isFunctionNameExplicitlyDeclared())) {
+                if (codeBlock->canUseIndexedVariableStorage()) {
+                    if (!codeBlock->isFunctionNameSaveOnHeap()) {
+                        auto r = ctx.getRegister();
+                        block->pushCode(LoadLiteral(ByteCodeLOC(0), r, Value()), &ctx, nullptr);
+                        block->pushCode(Move(ByteCodeLOC(0), r, REGULAR_REGISTER_LIMIT + 1), &ctx, nullptr);
+                        ctx.giveUpRegister();
+                    }
+                }
+            } else if (UNLIKELY(codeBlock->isFunctionNameSaveOnHeap() && !name.string()->equals("arguments"))) {
+                ctx.m_isVarDeclaredBindingInitialization = true;
+                IdentifierNode* id = new (alloca(sizeof(IdentifierNode))) IdentifierNode(codeBlock->functionName());
+                id->generateStoreByteCode(block, &ctx, REGULAR_REGISTER_LIMIT + 1, true);
+            }
+        }
+
         ast->generateStatementByteCode(block, &ctx);
     } catch (const ByteCodeGenerateError& err) {
         block->m_code.clear();

--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -79,6 +79,7 @@ struct ByteCodeGenerateContext {
         , m_isOutermostContext(true)
         , m_isWithScope(parserContextInformation.m_isWithScope)
         , m_isFunctionDeclarationBindingInitialization(false)
+        , m_isVarDeclaredBindingInitialization(false)
         , m_isLexicallyDeclaredBindingInitialization(false)
         , m_canSkipCopyToRegister(true)
         , m_keepNumberalLiteralsInRegisterFile(numeralLiteralData)
@@ -111,6 +112,7 @@ struct ByteCodeGenerateContext {
         , m_isOutermostContext(false)
         , m_isWithScope(contextBefore.m_isWithScope)
         , m_isFunctionDeclarationBindingInitialization(contextBefore.m_isFunctionDeclarationBindingInitialization)
+        , m_isVarDeclaredBindingInitialization(contextBefore.m_isVarDeclaredBindingInitialization)
         , m_isLexicallyDeclaredBindingInitialization(contextBefore.m_isLexicallyDeclaredBindingInitialization)
         , m_canSkipCopyToRegister(contextBefore.m_canSkipCopyToRegister)
         , m_keepNumberalLiteralsInRegisterFile(contextBefore.m_keepNumberalLiteralsInRegisterFile)
@@ -308,6 +310,7 @@ struct ByteCodeGenerateContext {
     bool m_isOutermostContext : 1;
     bool m_isWithScope : 1;
     bool m_isFunctionDeclarationBindingInitialization : 1;
+    bool m_isVarDeclaredBindingInitialization : 1;
     bool m_isLexicallyDeclaredBindingInitialization : 1;
     bool m_canSkipCopyToRegister : 1;
     bool m_keepNumberalLiteralsInRegisterFile : 1;

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -199,7 +199,6 @@ void ScriptParser::generateCodeBlockTreeFromASTWalkerPostProcess(InterpretedCode
         err->index = cb->m_sourceElementStart.index;
         throw * err;
     }
-    cb->m_astContext = nullptr;
 }
 
 ScriptParser::InitializeScriptResult ScriptParser::initializeScript(StringView scriptSource, String* fileName, bool isModule, InterpretedCodeBlock* parentCodeBlock, bool strictFromOutside, bool isEvalCodeInFunction, bool isEvalMode, bool inWithOperation, size_t stackSizeRemain, bool needByteCodeGeneration, bool allowSuperCall, bool allowSuperProperty)

--- a/src/parser/ast/IdentifierNode.h
+++ b/src/parser/ast/IdentifierNode.h
@@ -113,8 +113,10 @@ public:
     {
         bool isLexicallyDeclaredBindingInitialization = context->m_isLexicallyDeclaredBindingInitialization;
         bool isFunctionDeclarationBindingInitialization = context->m_isFunctionDeclarationBindingInitialization;
+        bool isVarDeclaredBindingInitialization = context->m_isVarDeclaredBindingInitialization;
         context->m_isLexicallyDeclaredBindingInitialization = false;
         context->m_isFunctionDeclarationBindingInitialization = false;
+        context->m_isVarDeclaredBindingInitialization = false;
 
         if (isLexicallyDeclaredBindingInitialization) {
             context->addLexicallyDeclaredNames(m_name);
@@ -135,7 +137,7 @@ public:
                         addressRegisterIndex = context->getLastRegisterIndex();
                         context->giveUpRegister();
                     }
-                    if (isLexicallyDeclaredBindingInitialization || isFunctionDeclarationBindingInitialization) {
+                    if (isLexicallyDeclaredBindingInitialization || isFunctionDeclarationBindingInitialization || isVarDeclaredBindingInitialization) {
                         codeBlock->pushCode(InitializeByName(ByteCodeLOC(m_loc.index), srcRegister, m_name, isLexicallyDeclaredBindingInitialization), context, this);
                     } else {
                         if (addressRegisterIndex != SIZE_MAX) {
@@ -152,7 +154,7 @@ public:
                     }
                 }
             } else {
-                if (info.m_type != InterpretedCodeBlock::IndexedIdentifierInfo::LexicallyDeclared) {
+                if (info.m_type != InterpretedCodeBlock::IndexedIdentifierInfo::LexicallyDeclared && !isVarDeclaredBindingInitialization) {
                     if (!info.m_isMutable) {
                         if (codeBlock->m_codeBlock->isStrict())
                             codeBlock->pushCode(ThrowStaticErrorOperation(ByteCodeLOC(m_loc.index), ErrorObject::TypeError, errorMessage_AssignmentToConstantVariable, m_name), context, this);
@@ -172,7 +174,7 @@ public:
                             codeBlock->pushCode(SetGlobalVariable(ByteCodeLOC(m_loc.index), srcRegister, codeBlock->m_codeBlock->context()->ensureGlobalVariableAccessCacheSlot(m_name)), context, this);
                         }
                     } else {
-                        if (isLexicallyDeclaredBindingInitialization) {
+                        if (isLexicallyDeclaredBindingInitialization || isVarDeclaredBindingInitialization) {
                             ASSERT(info.m_upperIndex == 0);
                             codeBlock->pushCode(InitializeByHeapIndex(ByteCodeLOC(m_loc.index), srcRegister, info.m_index), context, this);
                         } else {
@@ -188,7 +190,7 @@ public:
                 addressRegisterIndex = context->getLastRegisterIndex();
                 context->giveUpRegister();
             }
-            if (isLexicallyDeclaredBindingInitialization || isFunctionDeclarationBindingInitialization) {
+            if (isLexicallyDeclaredBindingInitialization || isFunctionDeclarationBindingInitialization || isVarDeclaredBindingInitialization) {
                 codeBlock->pushCode(InitializeByName(ByteCodeLOC(m_loc.index), srcRegister, m_name, isLexicallyDeclaredBindingInitialization), context, this);
             } else {
                 if (addressRegisterIndex != SIZE_MAX) {

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -46,6 +46,7 @@
 #include "parser/Lexer.h"
 #include "parser/Script.h"
 #include "parser/ASTBuilder.h"
+#include "util/BloomFilter.h"
 
 #define ALLOC_TOKEN(tokenName) Scanner::ScannerResult* tokenName = ALLOCA(sizeof(Scanner::ScannerResult), Scanner::ScannerResult, ec);
 
@@ -63,6 +64,8 @@
     this->subCodeBlockIndex = oldSubCodeBlockIndex;
 
 using namespace Escargot::EscargotLexer;
+
+typedef Escargot::BloomFilter<64> BlockUsingNameBloomFilter;
 
 namespace Escargot {
 namespace esprima {
@@ -159,12 +162,15 @@ public:
     size_t stackLimit;
     size_t subCodeBlockIndex;
 
+    ASTBlockScopeContext* currentBlockContext;
     LexicalBlockIndex lexicalBlockIndex;
     LexicalBlockIndex lexicalBlockCount;
 
     NumeralLiteralVector numeralLiteralVector;
 
     ASTFunctionScopeContext fakeContext;
+
+    AtomicString stringArguments;
 
     struct ParseFormalParametersResult {
         ParameterNodeVector params;
@@ -197,8 +203,10 @@ public:
         this->stackLimit = currentStackBase + stackRemain;
 #endif
         this->escargotContext = escargotContext;
-        this->lexicalBlockIndex = 0;
-        this->lexicalBlockCount = 0;
+        this->stringArguments = escargotContext->staticStrings().arguments;
+        this->currentBlockContext = nullptr;
+        this->lexicalBlockIndex = LEXICAL_BLOCK_INDEX_MAX;
+        this->lexicalBlockCount = LEXICAL_BLOCK_INDEX_MAX;
         this->subCodeBlockIndex = 0;
         this->lastPoppedScopeContext = &fakeContext;
         this->currentScopeContext = nullptr;
@@ -308,16 +316,77 @@ public:
         return parentContext;
     }
 
+    class TrackUsingNameBlocker {
+    public:
+        TrackUsingNameBlocker(Parser* parser)
+            : m_parser(parser)
+            , m_oldValue(parser->trackUsingNames)
+        {
+            parser->trackUsingNames = false;
+        }
+
+        ~TrackUsingNameBlocker()
+        {
+            m_parser->trackUsingNames = m_oldValue;
+        }
+
+    private:
+        Parser* m_parser;
+        bool m_oldValue;
+    };
+
     ALWAYS_INLINE void insertUsingName(AtomicString name)
     {
         if (this->isParsingSingleFunction) {
             return;
         }
+
         if (this->lastUsingName == name) {
             return;
         }
-        this->currentScopeContext->insertUsingName(name, this->lexicalBlockIndex);
         this->lastUsingName = name;
+
+        bool contains = false;
+        auto& v = this->currentBlockContext->m_usingNames;
+        size_t size = v.size();
+
+        if (UNLIKELY(size > 10)) {
+            for (size_t i = 0; i < size; i++) {
+                if (v[i] == name) {
+                    contains = true;
+                    break;
+                }
+            }
+        } else {
+            switch (size) {
+            case 10:
+                contains = v[9] == name;
+                FALLTHROUGH;
+#define TEST_ONCE(n)                             \
+    case n:                                      \
+        contains = contains || v[n - 1] == name; \
+        FALLTHROUGH;
+                TEST_ONCE(9)
+                TEST_ONCE(8)
+                TEST_ONCE(7)
+                TEST_ONCE(6)
+                TEST_ONCE(5)
+                TEST_ONCE(4)
+                TEST_ONCE(3)
+                TEST_ONCE(2)
+                TEST_ONCE(1)
+#undef TEST_ONCE
+            case 0:
+                break;
+            default:
+                ASSERT_NOT_REACHED();
+            }
+        }
+
+        ASSERT((VectorUtil::findInVector(this->currentBlockContext->m_usingNames, name) != VectorUtil::invalidIndex) == contains);
+        if (!contains) {
+            this->currentBlockContext->m_usingNames.push_back(name);
+        }
     }
 
     void extractNamesFromFunctionParams(ParseFormalParametersResult& paramsResult)
@@ -880,13 +949,13 @@ public:
         return result;
     }
 
-    template <class ASTBuilder, typename T>
-    ALWAYS_INLINE ASTNode isolateCoverGrammarWithFunctor(ASTBuilder& builder, T parseFunction)
+    template <class ASTBuilder, typename T, typename ArgType>
+    ALWAYS_INLINE ASTNode isolateCoverGrammar(ASTBuilder& builder, T parseFunction, const ArgType& arg)
     {
         IsolateCoverGrammarContext grammarContext;
         startCoverGrammar(&grammarContext);
 
-        ASTNode result = parseFunction();
+        ASTNode result = (this->*parseFunction)(builder, arg);
         endIsolateCoverGrammar(&grammarContext);
 
         return result;
@@ -1479,11 +1548,11 @@ public:
         case Token::BooleanLiteralToken:
         case Token::NullLiteralToken:
         case Token::KeywordToken: {
-            bool trackUsingNamesBefore = this->trackUsingNames;
-            this->trackUsingNames = false;
-            key = this->finalize(node, finishIdentifier(builder, token));
-            keyString = StringView(key->asIdentifier()->name().string());
-            this->trackUsingNames = trackUsingNamesBefore;
+            {
+                TrackUsingNameBlocker blocker(this);
+                key = this->finalize(node, finishIdentifier(builder, token));
+                keyString = StringView(key->asIdentifier()->name().string());
+            }
             break;
         }
         case Token::PunctuatorToken:
@@ -1520,6 +1589,7 @@ public:
         bool isProto = false;
 
         if (token->type == Token::IdentifierToken) {
+            TrackUsingNameBlocker blocker(this);
             this->nextToken();
             keyNode = this->finalize(node, finishIdentifier(builder, token));
         } else if (this->match(PunctuatorKind::Multiply)) {
@@ -1936,11 +2006,9 @@ public:
                     this->context->isBindingElement = false;
                     this->context->isAssignmentTarget = true;
                     this->nextToken();
-                    bool trackUsingNamesBefore = this->trackUsingNames;
-                    this->trackUsingNames = false;
+                    TrackUsingNameBlocker blocker(this);
                     ASTNode property = this->parseIdentifierName(builder);
                     exprNode = this->finalize(this->startNode(startToken), builder.createMemberExpressionNode(exprNode, property, true));
-                    this->trackUsingNames = trackUsingNamesBefore;
                 } else if (this->lookahead.valuePunctuatorKind == LeftParenthesis) {
                     this->context->isBindingElement = false;
                     this->context->isAssignmentTarget = false;
@@ -2017,11 +2085,9 @@ public:
                 this->context->isBindingElement = false;
                 this->context->isAssignmentTarget = true;
                 this->expect(Period);
-                bool trackUsingNamesBefore = this->trackUsingNames;
-                this->trackUsingNames = false;
+                TrackUsingNameBlocker blocker(this);
                 ASTNode property = this->parseIdentifierName(builder);
                 exprNode = this->finalize(node, builder.createMemberExpressionNode(exprNode, property, true));
-                this->trackUsingNames = trackUsingNamesBefore;
             } else if (this->lookahead.type == Token::TemplateToken && this->lookahead.valueTemplate->head) {
                 ASTNode quasi = this->parseTemplateLiteral(builder);
                 // FIXME convertTaggedTemplateExpressionToCallExpression
@@ -2566,12 +2632,17 @@ public:
                 } else {
                     LexicalBlockIndex lexicalBlockIndexBefore = this->lexicalBlockIndex;
                     LexicalBlockIndex lexicalBlockCountBefore = this->lexicalBlockCount;
-                    this->lexicalBlockIndex = 0;
-                    this->lexicalBlockCount = 0;
+                    this->lexicalBlockIndex = LEXICAL_BLOCK_INDEX_MAX;
+                    this->lexicalBlockCount = LEXICAL_BLOCK_INDEX_MAX;
+
+                    ParserBlockContext blockContext;
+                    openBlock(blockContext);
 
                     auto oldNameCallback = this->nameDeclaredCallback;
 
                     this->isolateCoverGrammar(newBuilder, &Parser::parseAssignmentExpression<SyntaxChecker, false>);
+
+                    closeBlock(blockContext);
 
                     this->lexicalBlockIndex = lexicalBlockIndexBefore;
                     this->lexicalBlockCount = lexicalBlockCountBefore;
@@ -2785,32 +2856,33 @@ public:
         size_t lexicalBlockIndexBefore;
         size_t childLexicalBlockIndex;
 
+        ASTBlockScopeContext* oldBlockScopeContext;
+
         ParserBlockContext()
             : lexicalBlockCountBefore(SIZE_MAX)
             , lexicalBlockIndexBefore(SIZE_MAX)
             , childLexicalBlockIndex(SIZE_MAX)
+            , oldBlockScopeContext(nullptr)
         {
         }
     };
 
-    ParserBlockContext openBlock()
+    void openBlock(ParserBlockContext& ctx)
     {
         if (UNLIKELY(this->lexicalBlockCount == LEXICAL_BLOCK_INDEX_MAX - 1)) {
             this->throwError("too many lexical blocks in script", String::emptyString, String::emptyString, ErrorObject::RangeError);
         }
 
         this->lastUsingName = AtomicString();
-        ParserBlockContext ctx;
         this->lexicalBlockCount++;
         ctx.lexicalBlockCountBefore = this->lexicalBlockCount;
         ctx.lexicalBlockIndexBefore = this->lexicalBlockIndex;
         ctx.childLexicalBlockIndex = this->lexicalBlockCount;
+        ctx.oldBlockScopeContext = this->currentBlockContext;
 
-        this->currentScopeContext->insertBlockScope(this->allocator, ctx.childLexicalBlockIndex, this->lexicalBlockIndex,
-                                                    ExtendedNodeLOC(this->lastMarker.lineNumber, this->lastMarker.index - this->lastMarker.lineStart + 1, this->lastMarker.index));
+        this->currentBlockContext = this->currentScopeContext->insertBlockScope(this->allocator, ctx.childLexicalBlockIndex, this->lexicalBlockIndex,
+                                                                                ExtendedNodeLOC(this->lastMarker.lineNumber, this->lastMarker.index - this->lastMarker.lineStart + 1, this->lastMarker.index));
         this->lexicalBlockIndex = ctx.childLexicalBlockIndex;
-
-        return ctx;
     }
 
     void closeBlock(ParserBlockContext& ctx)
@@ -2829,7 +2901,7 @@ public:
         } else {
             // if there is no new variable in this block, merge this block into parent block
             auto currentFunctionScope = this->currentScopeContext;
-            auto blockContext = currentFunctionScope->findBlockFromBackward(this->lexicalBlockIndex);
+            auto blockContext = this->currentBlockContext;
             if (this->lexicalBlockIndex != 0 && blockContext->m_names.size() == 0) {
                 const auto currentBlockIndex = this->lexicalBlockIndex;
                 LexicalBlockIndex parentBlockIndex = blockContext->m_parentBlockIndex;
@@ -2860,7 +2932,8 @@ public:
                         child = child->nextSibling();
                     }
 
-                    auto parentBlockContext = currentFunctionScope->findBlockFromBackward(parentBlockIndex);
+                    ASSERT(currentFunctionScope->findBlockFromBackward(parentBlockIndex) == ctx.oldBlockScopeContext);
+                    auto parentBlockContext = ctx.oldBlockScopeContext;
                     for (size_t i = 0; i < blockContext->m_usingNames.size(); i++) {
                         AtomicString name = blockContext->m_usingNames[i];
                         if (VectorUtil::findInVector(parentBlockContext->m_usingNames, name) == VectorUtil::invalidIndex) {
@@ -2879,7 +2952,7 @@ public:
                 }
             }
         }
-
+        this->currentBlockContext = ctx.oldBlockScopeContext;
         this->lexicalBlockIndex = ctx.lexicalBlockIndexBefore;
         this->lastUsingName = AtomicString();
     }
@@ -2890,7 +2963,8 @@ public:
         this->expect(LeftBrace);
         ASTNode referNode = nullptr;
 
-        ParserBlockContext blockContext = openBlock();
+        ParserBlockContext blockContext;
+        openBlock(blockContext);
 
         bool allowLexicalDeclarationBefore = this->context->allowLexicalDeclaration;
         this->context->allowLexicalDeclaration = true;
@@ -3018,10 +3092,19 @@ public:
             this->throwUnexpectedToken(*token);
         }
 
-        ASTNode id = finishIdentifier(builder, token);
-
+        ASTNode id;
         if (kind == KeywordKind::VarKeyword || kind == KeywordKind::LetKeyword || kind == KeywordKind::ConstKeyword) {
-            addDeclaredNameIntoContext(id->asIdentifier()->name(), this->lexicalBlockIndex, kind, isExplicitVariableDeclaration);
+            TrackUsingNameBlocker blocker(this);
+            id = finishIdentifier(builder, token);
+
+            AtomicString declName = id->asIdentifier()->name();
+
+            addDeclaredNameIntoContext(declName, this->lexicalBlockIndex, kind, isExplicitVariableDeclaration);
+            if (UNLIKELY(declName == stringArguments && !this->isParsingSingleFunction)) {
+                insertUsingName(stringArguments);
+            }
+        } else {
+            id = finishIdentifier(builder, token);
         }
 
         return this->finalize(node, id);
@@ -3289,7 +3372,8 @@ public:
         this->expectKeyword(ForKeyword);
         this->expect(LeftParenthesis);
 
-        ParserBlockContext headBlockContext = openBlock();
+        ParserBlockContext headBlockContext;
+        openBlock(headBlockContext);
 
         if (this->match(SemiColon)) {
             this->nextToken();
@@ -3410,7 +3494,7 @@ public:
         ParserBlockContext iterationBlockContext;
 
         if (type == statementTypeFor) {
-            iterationBlockContext = openBlock();
+            openBlock(iterationBlockContext);
             this->context->inLoop = true;
             if (!this->match(SemiColon)) {
                 test = this->parseExpression(builder);
@@ -3422,12 +3506,12 @@ public:
         } else if (type == statementTypeForIn) {
             ASSERT(left);
             right = this->parseExpression(builder);
-            iterationBlockContext = openBlock();
+            openBlock(iterationBlockContext);
         } else {
             ASSERT(type == statementTypeForOf);
             ASSERT(left);
             right = this->parseAssignmentExpression<ASTBuilder, false>(builder);
-            iterationBlockContext = openBlock();
+            openBlock(iterationBlockContext);
         }
 
         this->expect(RightParenthesis);
@@ -3444,8 +3528,7 @@ public:
         this->context->allowLexicalDeclaration = false;
         this->context->inIteration = true;
         ASTNode body = nullptr;
-        auto functor = std::bind(&Parser::parseStatement<ASTBuilder>, std::ref(*this), builder, false);
-        body = this->isolateCoverGrammarWithFunctor(builder, functor);
+        body = this->isolateCoverGrammar(builder, &Parser::parseStatement<ASTBuilder>, false);
 
         this->context->inIteration = previousInIteration;
         this->context->inLoop = prevInLoop;
@@ -3500,6 +3583,7 @@ public:
 
         AtomicString labelString;
         if (this->lookahead.type == IdentifierToken && !this->hasLineTerminator) {
+            TrackUsingNameBlocker blocker(this);
             ASTNode labelNode = this->parseVariableIdentifier(builder);
             labelString = labelNode->asIdentifier()->name();
 
@@ -3535,6 +3619,7 @@ public:
 
         AtomicString labelString;
         if (this->lookahead.type == IdentifierToken && !this->hasLineTerminator) {
+            TrackUsingNameBlocker blocker(this);
             ASTNode labelNode = this->parseVariableIdentifier(builder);
             labelString = labelNode->asIdentifier()->name();
 
@@ -3761,7 +3846,8 @@ public:
             this->throwUnexpectedToken(this->lookahead);
         }
 
-        ParserBlockContext catchBlockContext = openBlock();
+        ParserBlockContext catchBlockContext;
+        openBlock(catchBlockContext);
 
         SmallScannerResultVector params;
         ASTNode param = this->parsePattern(builder, params, KeywordKind::LetKeyword);
@@ -4047,8 +4133,10 @@ public:
         auto oldNameCallback = this->nameDeclaredCallback;
 
         this->context->allowLexicalDeclaration = true;
-        this->lexicalBlockIndex = 0;
-        this->lexicalBlockCount = 0;
+        this->lexicalBlockIndex = LEXICAL_BLOCK_INDEX_MAX;
+        this->lexicalBlockCount = LEXICAL_BLOCK_INDEX_MAX;
+        ParserBlockContext blockContext;
+        openBlock(blockContext);
 
         bool oldInCatchClause = this->context->inCatchClause;
         this->context->inCatchClause = false;
@@ -4083,6 +4171,7 @@ public:
         this->context->inCatchClause = oldInCatchClause;
         this->context->catchClauseSimplyDeclaredVariableNames = std::move(oldCatchClauseSimplyDeclaredVariableNames);
 
+        closeBlock(blockContext);
         this->context->allowLexicalDeclaration = oldAllowLexicalDeclaration;
         this->lexicalBlockIndex = lexicalBlockIndexBefore;
         this->lexicalBlockCount = lexicalBlockCountBefore;
@@ -4122,6 +4211,7 @@ public:
         {
             ALLOC_TOKEN(token);
             *token = this->lookahead;
+            TrackUsingNameBlocker blocker(this);
             id = this->parseVariableIdentifier(builder);
 
             if (this->context->strict) {
@@ -4214,6 +4304,7 @@ public:
         if (!this->match(LeftParenthesis)) {
             ALLOC_TOKEN(token);
             *token = this->lookahead;
+            TrackUsingNameBlocker blocker(this);
             id = (!this->context->strict && !isGenerator && this->matchKeyword(YieldKeyword)) ? this->parseIdentifierName(builder) : this->parseVariableIdentifier(builder);
 
             if (this->context->strict) {
@@ -4243,9 +4334,9 @@ public:
         this->expect(LeftParenthesis);
 
         BEGIN_FUNCTION_SCANNING(fnName);
+
         if (id) {
             this->currentScopeContext->insertVarName(fnName, 0, false);
-            this->currentScopeContext->insertUsingName(fnName, 0);
         }
 
         this->currentScopeContext->m_paramsStartLOC.index = paramsStart.index;
@@ -4725,7 +4816,8 @@ public:
             superClass = this->isolateCoverGrammar(builder, &Parser::parseLeftHandSideExpressionAllowCall<ASTBuilder>);
         }
 
-        ParserBlockContext classBlockContext = openBlock();
+        ParserBlockContext classBlockContext;
+        openBlock(classBlockContext);
         if (id.string()->length()) {
             addDeclaredNameIntoContext(id, this->lexicalBlockIndex, KeywordKind::ConstKeyword);
         }
@@ -5180,6 +5272,10 @@ public:
     {
         MetaNode startNode = this->createNode();
         pushScopeContext(new (this->allocator) ASTFunctionScopeContext(this->allocator, this->context->strict));
+
+        ParserBlockContext blockContext;
+        openBlock(blockContext);
+
         this->context->allowLexicalDeclaration = true;
         StatementContainer* container = builder.createStatementContainer();
         this->parseDirectivePrologues(builder, container);
@@ -5187,6 +5283,8 @@ public:
         while (this->startMarker.index < this->scanner->length) {
             referNode = container->appendChild(this->parseStatementListItem(builder), referNode);
         }
+
+        closeBlock(blockContext);
 
         MetaNode endNode = this->createNode();
         this->currentScopeContext->m_bodyEndLOC.index = endNode.index;
@@ -5317,6 +5415,9 @@ FunctionNode* parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock
     scopeContext = new (ctx->astAllocator()) ASTFunctionScopeContext(ctx->astAllocator(), codeBlock->isStrict());
     parser.pushScopeContext(scopeContext);
     parser.context->allowYield = !codeBlock->isGenerator();
+
+    Parser::ParserBlockContext blockContext;
+    parser.openBlock(blockContext);
 
     if (codeBlock->isArrowFunctionExpression()) {
         return parser.parseScriptArrowFunction(builder, codeBlock->hasArrowParameterPlaceHolder());

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -206,6 +206,7 @@ template <>
 struct hash<Escargot::AtomicString> {
     size_t operator()(Escargot::AtomicString const& x) const
     {
+        // return x.string()->hashValue();
         return std::hash<size_t*>{}((size_t*)x.string());
     }
 };

--- a/src/runtime/FunctionObjectInlines.h
+++ b/src/runtime/FunctionObjectInlines.h
@@ -161,27 +161,6 @@ public:
 
         // binding function name
         stackStorage[1] = self;
-        if (UNLIKELY(codeBlock->isFunctionNameSaveOnHeap())) {
-            if (codeBlock->canUseIndexedVariableStorage()) {
-                ASSERT(record->isFunctionEnvironmentRecordOnHeap());
-                ((FunctionEnvironmentRecordOnHeap<canBindThisValueOnEnvironment, hasNewTargetOnEnvironment>*)record)->heapStorage()[0] = self;
-            } else {
-                record->initializeBinding(state, codeBlock->functionName(), self);
-            }
-        }
-
-        if (UNLIKELY(codeBlock->isFunctionNameExplicitlyDeclared())) {
-            if (codeBlock->canUseIndexedVariableStorage()) {
-                if (UNLIKELY(codeBlock->isFunctionNameSaveOnHeap())) {
-                    ASSERT(record->isFunctionEnvironmentRecordOnHeap());
-                    ((FunctionEnvironmentRecordOnHeap<canBindThisValueOnEnvironment, hasNewTargetOnEnvironment>*)record)->heapStorage()[0] = Value();
-                } else {
-                    stackStorage[1] = Value();
-                }
-            } else {
-                record->initializeBinding(state, codeBlock->functionName(), Value());
-            }
-        }
 
         // initialize identifiers by undefined value
         for (size_t i = 2; i < identifierOnStackCount; i++) {

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -82,7 +82,11 @@ struct StringBufferAccessData {
 #else
     size_t length : 62;
 #endif
-    const void* buffer;
+    union {
+        const void* buffer;
+        const char* bufferAs8Bit;
+        const char16_t* bufferAs16Bit;
+    };
 
     COMPILE_ASSERT(STRING_MAXIMUM_LENGTH < (std::numeric_limits<size_t>::max() >> 2), "");
 

--- a/src/util/BloomFilter.h
+++ b/src/util/BloomFilter.h
@@ -1,28 +1,4 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- */
-/*
  * Copyright (c) 2019-present Samsung Electronics Co., Ltd
  *
  *  This library is free software; you can redistribute it and/or
@@ -43,136 +19,53 @@
 #ifndef __EscargotBloomFilter__
 #define __EscargotBloomFilter__
 
+#include <bitset>
 #include "runtime/AtomicString.h"
 
 namespace Escargot {
 
-// Counting bloom filter with k=2 and 8 bit counters. Uses 2^keyBits bytes of
-// memory.
-// False positive rate is approximately (1-e^(-2n/m))^2, where n is the number
-// of unique
-// keys and m is the table size (==2^keyBits).
-template <unsigned keyBits>
+template <unsigned tableSizeInBit>
 class BloomFilter {
 public:
-    static_assert(keyBits <= 16, "");
-
-    static const size_t tableSize = 1 << keyBits;
-    static const unsigned keyMask = (1 << keyBits) - 1;
-    static uint8_t maximumCount()
-    {
-        return std::numeric_limits<uint8_t>::max();
-    }
+    static const long long keyMask = tableSizeInBit - 1;
 
     BloomFilter()
     {
-        clear();
     }
 
-    void add(unsigned hash);
-    void remove(unsigned hash);
-
-    // The filter may give false positives (claim it may contain a key it
-    // doesn't)
-    // but never false negatives (claim it doesn't contain a key it does).
+    void add(unsigned hash)
+    {
+        m_table[hash & keyMask] = true;
+        m_table[(hash >> 16) & keyMask] = true;
+    }
     bool mayContain(unsigned hash) const
     {
-        return firstSlot(hash) && secondSlot(hash);
+        return m_table[hash & keyMask] && m_table[(hash >> 16) & keyMask];
     }
 
-    // The filter must be cleared before reuse even if all keys are removed.
-    // Otherwise overflowed keys will stick around.
-    void clear();
-
-    void add(AtomicString string)
+    void clear()
     {
-        add(string.string()->hashValue());
-    }
-    void remove(AtomicString string)
-    {
-        remove(string.string()->hashValue());
+        m_table.reset();
     }
 
-    bool mayContain(AtomicString string) const
+    void add(const AtomicString& string)
     {
-        return mayContain(string.string()->hashValue());
+        add(hashValue(string));
     }
-
-    // Slow.
-    bool likelyEmpty() const;
-    bool isClear() const;
+    bool mayContain(const AtomicString& string) const
+    {
+        return mayContain(hashValue(string));
+    }
 
 private:
-    uint8_t& firstSlot(unsigned hash)
+    static unsigned hashValue(const AtomicString& s)
     {
-        return m_table[hash & keyMask];
-    }
-    uint8_t& secondSlot(unsigned hash)
-    {
-        return m_table[(hash >> 16) & keyMask];
-    }
-    const uint8_t& firstSlot(unsigned hash) const
-    {
-        return m_table[hash & keyMask];
-    }
-    const uint8_t& secondSlot(unsigned hash) const
-    {
-        return m_table[(hash >> 16) & keyMask];
+        std::hash<Escargot::AtomicString> hasher;
+        return hasher(s);
     }
 
-    uint8_t m_table[tableSize];
+    std::bitset<tableSizeInBit> m_table;
 };
-
-template <unsigned keyBits>
-inline void BloomFilter<keyBits>::add(unsigned hash)
-{
-    uint8_t& first = firstSlot(hash);
-    uint8_t& second = secondSlot(hash);
-    if (LIKELY(first < maximumCount()))
-        ++first;
-    if (LIKELY(second < maximumCount()))
-        ++second;
-}
-
-template <unsigned keyBits>
-inline void BloomFilter<keyBits>::remove(unsigned hash)
-{
-    uint8_t& first = firstSlot(hash);
-    uint8_t& second = secondSlot(hash);
-    ASSERT(first);
-    ASSERT(second);
-    // In case of an overflow, the slot sticks in the table until clear().
-    if (LIKELY(first < maximumCount()))
-        --first;
-    if (LIKELY(second < maximumCount()))
-        --second;
-}
-
-template <unsigned keyBits>
-inline void BloomFilter<keyBits>::clear()
-{
-    memset(m_table, 0, tableSize);
-}
-
-template <unsigned keyBits>
-bool BloomFilter<keyBits>::likelyEmpty() const
-{
-    for (size_t n = 0; n < tableSize; ++n) {
-        if (m_table[n] && m_table[n] != maximumCount())
-            return false;
-    }
-    return true;
-}
-
-template <unsigned keyBits>
-bool BloomFilter<keyBits>::isClear() const
-{
-    for (size_t n = 0; n < tableSize; ++n) {
-        if (m_table[n])
-            return false;
-    }
-    return true;
-}
 }
 
 #endif


### PR DESCRIPTION
* Initialize function name binding in interpreter
* If there are so many var variables on function, we should make hash map for finding var fast

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>