### PR TITLE
Improve execution performance

### DIFF
--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -20,6 +20,8 @@
 #ifndef ASTContext_h
 #define ASTContext_h
 
+#include "util/Util.h"
+
 namespace Escargot {
 
 class ASTFunctionScopeContextNameInfo {
@@ -149,26 +151,8 @@ struct ASTBlockScopeContext {
 };
 
 typedef Vector<ASTBlockScopeContext *, GCUtil::gc_malloc_atomic_allocator<ASTBlockScopeContext *>> ASTBlockScopeContextVector;
-
-class IndexAsOdd {
-public:
-    IndexAsOdd(const size_t &src)
-    {
-        ASSERT(src < std::numeric_limits<size_t>::max() / 2);
-        m_data = (src << 1) | 0x1;
-    }
-
-    operator size_t() const
-    {
-        return m_data >> 1;
-    }
-
-private:
-    size_t m_data;
-};
-
-typedef std::unordered_map<AtomicString, IndexAsOdd, std::hash<AtomicString>, std::equal_to<AtomicString>,
-                           GCUtil::gc_malloc_allocator<std::pair<AtomicString const, IndexAsOdd>>>
+typedef std::unordered_map<AtomicString, StorePositiveIntergerAsOdd, std::hash<AtomicString>, std::equal_to<AtomicString>,
+                           GCUtil::gc_malloc_allocator<std::pair<AtomicString const, StorePositiveIntergerAsOdd>>>
     FunctionContextVarMap;
 
 

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -122,7 +122,7 @@ private:
     ObjectGetResult getFastModeValue(ExecutionState& state, const ObjectPropertyName& P);
     bool setFastModeValue(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc);
 
-    VectorWithNoSize<SmallValue, GCUtil::gc_malloc_allocator<SmallValue>> m_fastModeData;
+    VectorWithNoSizeUseGCRealloc<SmallValue> m_fastModeData;
 };
 
 class ArrayObjectPrototype : public ArrayObject {

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -39,9 +39,7 @@ void FunctionObject::initStructureAndValues(ExecutionState& state, bool isConstr
         ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0 < m_structure->propertyCount());
         ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1 < m_structure->propertyCount());
         ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2 < m_structure->propertyCount());
-        auto prototype = new Object(state);
-        prototype->setPrototype(state, state.context()->globalObject()->generatorPrototype());
-        m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = (Value(prototype));
+        m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = SmallValue::EmptyValue; // lazy init on VMInstance::functionPrototypeNativeGetter
         m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(m_codeBlock->functionName().string()));
         m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2] = (Value(m_codeBlock->parameterCount()));
     } else {
@@ -50,7 +48,7 @@ void FunctionObject::initStructureAndValues(ExecutionState& state, bool isConstr
             ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0 < m_structure->propertyCount());
             ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1 < m_structure->propertyCount());
             ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2 < m_structure->propertyCount());
-            m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = (Value(Object::createFunctionPrototypeObject(state, this)));
+            m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = SmallValue::EmptyValue; // lazy init on VMInstance::functionPrototypeNativeGetter
             m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(m_codeBlock->functionName().string()));
             m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2] = (Value(m_codeBlock->parameterCount()));
         } else {

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -1022,7 +1022,7 @@ protected:
     }
     ObjectStructure* m_structure;
     Object* m_prototype;
-    TightVectorWithNoSize<SmallValue, GCUtil::gc_malloc_allocator<SmallValue>> m_values;
+    TightVectorWithNoSizeUseGCRealloc<SmallValue> m_values;
 
     COMPILE_ASSERT(sizeof(TightVectorWithNoSize<SmallValue, GCUtil::gc_malloc_allocator<SmallValue>>) == sizeof(size_t) * 1, "");
 

--- a/src/runtime/ScriptClassConstructorFunctionObject.cpp
+++ b/src/runtime/ScriptClassConstructorFunctionObject.cpp
@@ -35,10 +35,8 @@ ScriptClassConstructorFunctionObject::ScriptClassConstructorFunctionObject(Execu
 
     ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0 < m_structure->propertyCount());
     ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1 < m_structure->propertyCount());
-    auto prototype = new Object(state);
-    prototype->setPrototype(state, state.context()->globalObject()->generatorPrototype());
     m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = (Value(m_codeBlock->parameterCount()));
-    m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(Object::createFunctionPrototypeObject(state, this)));
+    m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = SmallValue::EmptyValue; // lazy init on VMInstance::functionPrototypeNativeGetter
 }
 
 Value ScriptClassConstructorFunctionObject::call(ExecutionState& state, const Value& thisValue, const size_t argc, NULLABLE Value* argv)

--- a/src/runtime/ScriptGeneratorFunctionObject.cpp
+++ b/src/runtime/ScriptGeneratorFunctionObject.cpp
@@ -19,10 +19,17 @@
 
 #include "Escargot.h"
 #include "ScriptGeneratorFunctionObject.h"
-
-#include "FunctionObjectInlines.h"
+#include "runtime/Context.h"
+#include "runtime/FunctionObjectInlines.h"
 
 namespace Escargot {
+
+Object* ScriptGeneratorFunctionObject::createFunctionPrototypeObject(ExecutionState& state)
+{
+    Object* prototype = new Object(state);
+    prototype->setPrototype(state, state.context()->globalObject()->generatorPrototype());
+    return prototype;
+}
 
 class ScriptGeneratorFunctionObjectThisValueBinder {
 public:

--- a/src/runtime/ScriptGeneratorFunctionObject.h
+++ b/src/runtime/ScriptGeneratorFunctionObject.h
@@ -50,6 +50,8 @@ public:
         return m_homeObject;
     }
 
+    virtual Object* createFunctionPrototypeObject(ExecutionState& state) override;
+
     friend class FunctionObjectProcessCallGenerator;
     // https://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist
     virtual Value call(ExecutionState& state, const Value& thisValue, const size_t argc, NULLABLE Value* argv) override;

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -39,7 +39,11 @@ bool VMInstance::undefinedNativeSetter(ExecutionState& state, Object* self, Smal
 Value VMInstance::functionPrototypeNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
     ASSERT(self->isFunctionObject());
-    return privateDataFromObjectPrivateArea;
+    if (privateDataFromObjectPrivateArea.isEmpty()) {
+        return self->asFunctionObject()->getFunctionPrototype(state);
+    } else {
+        return privateDataFromObjectPrivateArea;
+    }
 }
 
 bool VMInstance::functionPrototypeNativeSetter(ExecutionState& state, Object* self, SmallValue& privateDataFromObjectPrivateArea, const Value& setterInputData)

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -46,6 +46,22 @@ inline void clearStack()
 #error
 #endif
 
+class StorePositiveIntergerAsOdd {
+public:
+    StorePositiveIntergerAsOdd(const size_t& src)
+    {
+        ASSERT(src < std::numeric_limits<size_t>::max() / 2);
+        m_data = (src << 1) | 0x1;
+    }
+
+    operator size_t() const
+    {
+        return m_data >> 1;
+    }
+
+private:
+    size_t m_data;
+};
 
 uint64_t tickCount(); // increase 1000 by 1 second
 uint64_t longTickCount(); // increase 1000000 by 1 second


### PR DESCRIPTION
* Make ArgumentsObject light
* Implement lazy-creation of FunctionObject.prototype
* Don't copy ObjectStructor when executing Object::enumeration
* Use GC_REALLOC on Object, ArrayObject

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>