### PR TITLE
Replace NodeVector by LinkedList

### DIFF
--- a/src/parser/ASTAllocator.cpp
+++ b/src/parser/ASTAllocator.cpp
@@ -32,7 +32,6 @@ ASTAllocator::ASTAllocator()
 ASTAllocator::~ASTAllocator()
 {
     ASSERT(m_astPools.size() == 0);
-    ASSERT(m_astDestructibleNodes.size() == 0);
 
     free(currentPool());
 }
@@ -43,11 +42,6 @@ void ASTAllocator::reset()
     ASSERT(GC_is_disabled());
     ASSERT(m_astPoolMemory != nullptr && m_astPoolEnd != nullptr);
     ASSERT(static_cast<size_t>(m_astPoolEnd - m_astPoolMemory) >= 0);
-
-    for (size_t i = 0; i < m_astDestructibleNodes.size(); i++) {
-        m_astDestructibleNodes[i]->~DestructibleNode();
-    }
-    m_astDestructibleNodes.clear();
 
     for (size_t i = 0; i < m_astPools.size(); i++) {
         free(m_astPools[i]);
@@ -69,15 +63,6 @@ void* ASTAllocator::allocate(size_t size)
     void* block = m_astPoolMemory;
     m_astPoolMemory += alignedSize;
     return block;
-}
-
-void* ASTAllocator::allocateDestructible(size_t size)
-{
-    void* ptr = allocate(size);
-    DestructibleNode* destructible = static_cast<DestructibleNode*>(ptr);
-    m_astDestructibleNodes.push_back(destructible);
-
-    return ptr;
 }
 
 void ASTAllocator::allocatePool()

--- a/src/parser/ASTAllocator.h
+++ b/src/parser/ASTAllocator.h
@@ -23,28 +23,26 @@
 namespace Escargot {
 
 
-typedef intptr_t ASTAllocAlignment;
-
 class Node;
-class DestructibleNode;
 
 class ASTAllocator {
 public:
+    typedef intptr_t ASTAllocAlignment;
+
     ASTAllocator();
     ~ASTAllocator();
 
     void reset();
     void* allocate(size_t size);
-    void* allocateDestructible(size_t size);
 
     bool isInitialized()
     {
         ASSERT(m_astPools.size() == 0);
-        ASSERT(m_astDestructibleNodes.size() == 0);
         return (m_astPoolMemory == currentPool());
     }
 
 private:
+    // default pool size is set to 128 KB
     static const size_t initialASTPoolSize = 1024 * 128;
 
     size_t alignSize(size_t size)
@@ -64,7 +62,6 @@ private:
     char* m_astPoolEnd;
 
     std::vector<void*> m_astPools;
-    std::vector<DestructibleNode*> m_astDestructibleNodes;
 };
 }
 #endif

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -24,34 +24,33 @@
 
 namespace Escargot {
 
-class ArrowParameterPlaceHolderNode : public Node, public DestructibleNode {
+class ArrowParameterPlaceHolderNode : public Node {
 public:
-    using DestructibleNode::operator new;
-    ArrowParameterPlaceHolderNode()
+    explicit ArrowParameterPlaceHolderNode()
         : Node()
     {
     }
 
-    explicit ArrowParameterPlaceHolderNode(Node* param)
+    explicit ArrowParameterPlaceHolderNode(ASTAllocator& allocator, Node* param)
         : Node()
     {
-        m_params.push_back(param);
+        m_params.append(allocator, param);
     }
 
-    explicit ArrowParameterPlaceHolderNode(NodeVector&& params)
+    explicit ArrowParameterPlaceHolderNode(NodeList& params)
         : Node()
-        , m_params(std::move(params))
+        , m_params(params)
     {
     }
 
-    NodeVector& params()
+    NodeList& params()
     {
         return m_params;
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::ArrowParameterPlaceHolder; }
 private:
-    NodeVector m_params;
+    NodeList m_params;
 };
 
 class ArrowFunctionExpressionNode : public ExpressionNode {

--- a/src/parser/ast/BinaryExpressionBitwiseXorNode.h
+++ b/src/parser/ast/BinaryExpressionBitwiseXorNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionBitwiseXorNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionBitwiseXor; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionDivisionNode.h
+++ b/src/parser/ast/BinaryExpressionDivisionNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionDivisionNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionDivision; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionEqualNode.h
+++ b/src/parser/ast/BinaryExpressionEqualNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionEqualNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionGreaterThanNode.h
+++ b/src/parser/ast/BinaryExpressionGreaterThanNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionGreaterThanNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionGreaterThan; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionGreaterThanOrEqualNode.h
+++ b/src/parser/ast/BinaryExpressionGreaterThanOrEqualNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionGreaterThanOrEqualNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionGreaterThanOrEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionInNode.h
+++ b/src/parser/ast/BinaryExpressionInNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionInNode()
-    {
-    }
-
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
         bool isSlow = !canUseDirectRegister(context, m_left, m_right);

--- a/src/parser/ast/BinaryExpressionInstanceOfNode.h
+++ b/src/parser/ast/BinaryExpressionInstanceOfNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionInstanceOfNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionInstanceOf; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionLeftShiftNode.h
+++ b/src/parser/ast/BinaryExpressionLeftShiftNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionLeftShiftNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLeftShift; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionLessThanNode.h
+++ b/src/parser/ast/BinaryExpressionLessThanNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionLessThanNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLessThan; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionLessThanOrEqualNode.h
+++ b/src/parser/ast/BinaryExpressionLessThanOrEqualNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionLessThanOrEqualNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLessThanOrEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionLogicalAndNode.h
+++ b/src/parser/ast/BinaryExpressionLogicalAndNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionLogicalAndNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLogicalAnd; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionLogicalOrNode.h
+++ b/src/parser/ast/BinaryExpressionLogicalOrNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionLogicalOrNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionLogicalOr; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionMinusNode.h
+++ b/src/parser/ast/BinaryExpressionMinusNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionMinusNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionMinus; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionModNode.h
+++ b/src/parser/ast/BinaryExpressionModNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionModNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionMod; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionMultiplyNode.h
+++ b/src/parser/ast/BinaryExpressionMultiplyNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionMultiplyNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionMultiply; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionNotEqualNode.h
+++ b/src/parser/ast/BinaryExpressionNotEqualNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionNotEqualNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionNotEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionNotStrictEqualNode.h
+++ b/src/parser/ast/BinaryExpressionNotStrictEqualNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionNotStrictEqualNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionNotStrictEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionPlusNode.h
+++ b/src/parser/ast/BinaryExpressionPlusNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionPlusNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionPlus; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionSignedRightShiftNode.h
+++ b/src/parser/ast/BinaryExpressionSignedRightShiftNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionSignedRightShiftNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionSignedRightShift; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionStrictEqualNode.h
+++ b/src/parser/ast/BinaryExpressionStrictEqualNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionStrictEqualNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionStrictEqual; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BinaryExpressionUnsignedRightShiftNode.h
+++ b/src/parser/ast/BinaryExpressionUnsignedRightShiftNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~BinaryExpressionUnsignedRightShiftNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BinaryExpressionUnsignedRightShift; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/BlockStatementNode.h
+++ b/src/parser/ast/BlockStatementNode.h
@@ -34,10 +34,6 @@ public:
     {
     }
 
-    virtual ~BlockStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BlockStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {

--- a/src/parser/ast/BreakLabelStatementNode.h
+++ b/src/parser/ast/BreakLabelStatementNode.h
@@ -32,10 +32,6 @@ public:
     {
     }
 
-    virtual ~BreakLabelStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::BreakLabelStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {

--- a/src/parser/ast/CatchClauseNode.h
+++ b/src/parser/ast/CatchClauseNode.h
@@ -41,10 +41,6 @@ public:
     {
     }
 
-    virtual ~CatchClauseNode()
-    {
-    }
-
     Node* param()
     {
         return m_param;

--- a/src/parser/ast/ClassBodyNode.h
+++ b/src/parser/ast/ClassBodyNode.h
@@ -28,10 +28,9 @@
 namespace Escargot {
 
 
-class ClassBodyNode : public Node, public DestructibleNode {
+class ClassBodyNode : public Node {
 public:
-    using DestructibleNode::operator new;
-    ClassBodyNode(NodeVector&& elementList, Node* constructor)
+    ClassBodyNode(NodeList& elementList, Node* constructor)
         : Node()
         , m_elementList(elementList)
         , m_constructor(constructor)
@@ -52,8 +51,8 @@ public:
     {
         size_t objIndex = context->m_classInfo.m_prototypeIndex;
 
-        for (unsigned i = 0; i < m_elementList.size(); i++) {
-            ClassElementNode* p = m_elementList[i]->asClassElement();
+        for (SentinelNode* element = m_elementList.begin(); element != m_elementList.end(); element = element->next()) {
+            ClassElementNode* p = element->astNode()->asClassElement();
 
             size_t destIndex = p->isStatic() ? classIndex : objIndex;
 
@@ -126,14 +125,14 @@ public:
             m_constructor->iterateChildren(fn);
         }
 
-        for (unsigned i = 0; i < m_elementList.size(); i++) {
-            ClassElementNode* p = m_elementList[i]->asClassElement();
+        for (SentinelNode* element = m_elementList.begin(); element != m_elementList.end(); element = element->next()) {
+            ClassElementNode* p = element->astNode()->asClassElement();
             p->iterateChildren(fn);
         }
     }
 
 private:
-    NodeVector m_elementList;
+    NodeList m_elementList;
     Node* m_constructor;
 };
 }

--- a/src/parser/ast/ConditionalExpressionNode.h
+++ b/src/parser/ast/ConditionalExpressionNode.h
@@ -33,9 +33,6 @@ public:
         , m_alternate(alternate)
     {
     }
-    virtual ~ConditionalExpressionNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::ConditionalExpression; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/DebuggerStatementNode.h
+++ b/src/parser/ast/DebuggerStatementNode.h
@@ -32,10 +32,6 @@ public:
     {
     }
 
-    virtual ~DebuggerStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::DebuggerStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock *codeBlock, ByteCodeGenerateContext *context) override
     {

--- a/src/parser/ast/DeclarationNode.h
+++ b/src/parser/ast/DeclarationNode.h
@@ -32,10 +32,6 @@ public:
     {
     }
 
-    virtual ~DeclarationNode()
-    {
-    }
-
 protected:
 };
 }

--- a/src/parser/ast/DirectiveNode.h
+++ b/src/parser/ast/DirectiveNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~DirectiveNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::Directive; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {

--- a/src/parser/ast/DoWhileStatementNode.h
+++ b/src/parser/ast/DoWhileStatementNode.h
@@ -34,10 +34,6 @@ public:
     {
     }
 
-    virtual ~DoWhileStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::DoWhileStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {

--- a/src/parser/ast/ExportDeclarationNode.h
+++ b/src/parser/ast/ExportDeclarationNode.h
@@ -31,10 +31,6 @@ public:
     {
     }
 
-    virtual ~ExportDeclarationNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::ExportDeclaration; }
 };
 }

--- a/src/parser/ast/ExportNamedDeclarationNode.h
+++ b/src/parser/ast/ExportNamedDeclarationNode.h
@@ -26,17 +26,12 @@
 
 namespace Escargot {
 
-class ExportNamedDeclarationNode : public ExportDeclarationNode, public DestructibleNode {
+class ExportNamedDeclarationNode : public ExportDeclarationNode {
 public:
-    using DestructibleNode::operator new;
-    ExportNamedDeclarationNode(Node* declaration, NodeVector&& specifiers, Node* source)
+    ExportNamedDeclarationNode(Node* declaration, NodeList& specifiers, Node* source)
         : m_declaration(declaration)
-        , m_specifiers(std::move(specifiers))
+        , m_specifiers(specifiers)
         , m_source(source)
-    {
-    }
-
-    virtual ~ExportNamedDeclarationNode()
     {
     }
 
@@ -49,8 +44,8 @@ public:
             m_declaration->iterateChildren(fn);
         }
 
-        for (size_t i = 0; i < m_specifiers.size(); i++) {
-            m_specifiers[i]->iterateChildren(fn);
+        for (SentinelNode* specifier = m_specifiers.begin(); specifier != m_specifiers.end(); specifier = specifier->next()) {
+            specifier->astNode()->iterateChildren(fn);
         }
 
         if (m_source) {
@@ -68,7 +63,7 @@ public:
 
 private:
     Node* m_declaration;
-    NodeVector m_specifiers;
+    NodeList m_specifiers;
     Node* m_source;
 };
 }

--- a/src/parser/ast/ExpressionNode.h
+++ b/src/parser/ast/ExpressionNode.h
@@ -34,10 +34,6 @@ public:
     {
     }
 
-    virtual ~ExpressionNode()
-    {
-    }
-
     virtual bool isExpression() override
     {
         return true;

--- a/src/parser/ast/ExpressionStatementNode.h
+++ b/src/parser/ast/ExpressionStatementNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~ExpressionStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::ExpressionStatement; }
     Node* expression() { return m_expression; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override

--- a/src/parser/ast/ForInOfStatementNode.h
+++ b/src/parser/ast/ForInOfStatementNode.h
@@ -40,10 +40,6 @@ public:
     {
     }
 
-    virtual ~ForInOfStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override
     {
         if (m_forIn) {

--- a/src/parser/ast/ForStatementNode.h
+++ b/src/parser/ast/ForStatementNode.h
@@ -41,10 +41,6 @@ public:
     {
     }
 
-    virtual ~ForStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override
     {
         return ASTNodeType::ForStatement;

--- a/src/parser/ast/FunctionNode.h
+++ b/src/parser/ast/FunctionNode.h
@@ -36,10 +36,6 @@ public:
     {
     }
 
-    virtual ~FunctionNode()
-    {
-    }
-
     NumeralLiteralVector& numeralLiteralVector() { return m_numeralLiteralVector; }
     virtual ASTNodeType type() override { return ASTNodeType::Function; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override

--- a/src/parser/ast/IfStatementNode.h
+++ b/src/parser/ast/IfStatementNode.h
@@ -34,10 +34,6 @@ public:
     {
     }
 
-    virtual ~IfStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::IfStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {

--- a/src/parser/ast/ImportDeclarationNode.h
+++ b/src/parser/ast/ImportDeclarationNode.h
@@ -25,16 +25,11 @@
 
 namespace Escargot {
 
-class ImportDeclarationNode : public StatementNode, public DestructibleNode {
+class ImportDeclarationNode : public StatementNode {
 public:
-    using DestructibleNode::operator new;
-    ImportDeclarationNode(NodeVector&& specifiers, Node* src)
+    ImportDeclarationNode(NodeList& specifiers, Node* src)
         : m_specifiers(specifiers)
         , m_src(src)
-    {
-    }
-
-    virtual ~ImportDeclarationNode()
     {
     }
 
@@ -43,8 +38,8 @@ public:
     {
         fn(this);
 
-        for (size_t i = 0; i < m_specifiers.size(); i++) {
-            m_specifiers[i]->iterateChildren(fn);
+        for (SentinelNode* specifier = m_specifiers.begin(); specifier != m_specifiers.end(); specifier = specifier->next()) {
+            specifier->astNode()->iterateChildren(fn);
         }
         m_src->iterateChildren(fn);
     }
@@ -54,7 +49,7 @@ public:
     }
 
 private:
-    NodeVector m_specifiers;
+    NodeList m_specifiers;
     Node* m_src;
 };
 }

--- a/src/parser/ast/InitializeParameterExpressionNode.h
+++ b/src/parser/ast/InitializeParameterExpressionNode.h
@@ -34,10 +34,6 @@ public:
     {
     }
 
-    virtual ~InitializeParameterExpressionNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::InitializeParameterExpression; }
     virtual void generateResultNotRequiredExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {

--- a/src/parser/ast/LabeledStatementNode.h
+++ b/src/parser/ast/LabeledStatementNode.h
@@ -33,10 +33,6 @@ public:
     {
     }
 
-    virtual ~LabeledStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::LabeledStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {

--- a/src/parser/ast/MemberExpressionNode.h
+++ b/src/parser/ast/MemberExpressionNode.h
@@ -37,10 +37,6 @@ public:
     {
     }
 
-    virtual ~MemberExpressionNode()
-    {
-    }
-
     Node* object()
     {
         return m_object;

--- a/src/parser/ast/ProgramNode.h
+++ b/src/parser/ast/ProgramNode.h
@@ -38,10 +38,6 @@ public:
     {
     }
 
-    virtual ~ProgramNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::Program; }
     ASTFunctionScopeContext* scopeContext() { return m_scopeContext; }
     Script::ModuleData* moduleData() { return m_moduleData; }

--- a/src/parser/ast/PropertyNode.h
+++ b/src/parser/ast/PropertyNode.h
@@ -43,10 +43,6 @@ public:
     {
     }
 
-    virtual ~PropertyNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::Property; }
     Node* key()
     {

--- a/src/parser/ast/RestElementNode.h
+++ b/src/parser/ast/RestElementNode.h
@@ -40,10 +40,6 @@ public:
         m_loc = loc;
     }
 
-    virtual ~RestElementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::RestElement; }
     Node* argument()
     {

--- a/src/parser/ast/ReturnStatementNode.h
+++ b/src/parser/ast/ReturnStatementNode.h
@@ -32,10 +32,6 @@ public:
     {
     }
 
-    virtual ~ReturnStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::ReturnStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {

--- a/src/parser/ast/SpreadElementNode.h
+++ b/src/parser/ast/SpreadElementNode.h
@@ -32,10 +32,6 @@ public:
     {
     }
 
-    virtual ~SpreadElementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return SpreadElement; }
     Node* argument()
     {

--- a/src/parser/ast/StatementNode.h
+++ b/src/parser/ast/StatementNode.h
@@ -34,10 +34,6 @@ public:
     {
     }
 
-    virtual ~StatementNode()
-    {
-    }
-
     virtual bool isStatement()
     {
         return true;

--- a/src/parser/ast/SwitchCaseNode.h
+++ b/src/parser/ast/SwitchCaseNode.h
@@ -34,10 +34,6 @@ public:
     {
     }
 
-    virtual ~SwitchCaseNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::SwitchCase; }
     bool isDefaultNode()
     {

--- a/src/parser/ast/SwitchStatementNode.h
+++ b/src/parser/ast/SwitchStatementNode.h
@@ -37,10 +37,6 @@ public:
     {
     }
 
-    virtual ~SwitchStatementNode()
-    {
-    }
-
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
         ByteCodeGenerateContext newContext(*context);

--- a/src/parser/ast/ThrowStatementNode.h
+++ b/src/parser/ast/ThrowStatementNode.h
@@ -32,9 +32,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~ThrowStatementNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::ThrowStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override

--- a/src/parser/ast/TryStatementNode.h
+++ b/src/parser/ast/TryStatementNode.h
@@ -35,9 +35,6 @@ public:
         , m_finalizer((BlockStatementNode *)finalizer)
     {
     }
-    virtual ~TryStatementNode()
-    {
-    }
 
     struct TryStatementByteCodeContext {
         size_t tryStartPosition;

--- a/src/parser/ast/UnaryExpressionBitwiseNotNode.h
+++ b/src/parser/ast/UnaryExpressionBitwiseNotNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UnaryExpressionBitwiseNotNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::UnaryExpressionBitwiseNot; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/UnaryExpressionDeleteNode.h
+++ b/src/parser/ast/UnaryExpressionDeleteNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UnaryExpressionDeleteNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::UnaryExpressionDelete; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/UnaryExpressionLogicalNotNode.h
+++ b/src/parser/ast/UnaryExpressionLogicalNotNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UnaryExpressionLogicalNotNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::UnaryExpressionLogicalNot; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/UnaryExpressionMinusNode.h
+++ b/src/parser/ast/UnaryExpressionMinusNode.h
@@ -31,10 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UnaryExpressionMinusNode()
-    {
-    }
-
 
     virtual ASTNodeType type() override { return ASTNodeType::UnaryExpressionMinus; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/UnaryExpressionPlusNode.h
+++ b/src/parser/ast/UnaryExpressionPlusNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UnaryExpressionPlusNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::UnaryExpressionPlus; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/UnaryExpressionTypeOfNode.h
+++ b/src/parser/ast/UnaryExpressionTypeOfNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UnaryExpressionTypeOfNode()
-    {
-    }
 
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {

--- a/src/parser/ast/UnaryExpressionVoidNode.h
+++ b/src/parser/ast/UnaryExpressionVoidNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UnaryExpressionVoidNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::UnaryExpressionVoid; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/UpdateExpressionDecrementPostfixNode.h
+++ b/src/parser/ast/UpdateExpressionDecrementPostfixNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UpdateExpressionDecrementPostfixNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::UpdateExpressionDecrementPostfix; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/UpdateExpressionDecrementPrefixNode.h
+++ b/src/parser/ast/UpdateExpressionDecrementPrefixNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UpdateExpressionDecrementPrefixNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::UpdateExpressionDecrementPrefix; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/UpdateExpressionIncrementPostfixNode.h
+++ b/src/parser/ast/UpdateExpressionIncrementPostfixNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UpdateExpressionIncrementPostfixNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::UpdateExpressionIncrementPostfix; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/UpdateExpressionIncrementPrefixNode.h
+++ b/src/parser/ast/UpdateExpressionIncrementPrefixNode.h
@@ -31,9 +31,6 @@ public:
         , m_argument(argument)
     {
     }
-    virtual ~UpdateExpressionIncrementPrefixNode()
-    {
-    }
 
     virtual ASTNodeType type() override { return ASTNodeType::UpdateExpressionIncrementPrefix; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override

--- a/src/parser/ast/VariableDeclaratorNode.h
+++ b/src/parser/ast/VariableDeclaratorNode.h
@@ -38,10 +38,6 @@ public:
     {
     }
 
-    virtual ~VariableDeclaratorNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::VariableDeclarator; }
     Node* id() { return m_id; }
     Node* init() { return m_init; }

--- a/src/parser/ast/WhileStatementNode.h
+++ b/src/parser/ast/WhileStatementNode.h
@@ -34,10 +34,6 @@ public:
     {
     }
 
-    virtual ~WhileStatementNode()
-    {
-    }
-
     virtual ASTNodeType type() override { return ASTNodeType::WhileStatement; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {


### PR DESCRIPTION
* replace NodeVector by NodeList to completely separate the parsing memory from the GC heap
* each node of NodeList is allocated in AST pool
* NodeList passed as lvalue reference
* remove redundant constructor of each Node

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>