### PR TITLE
Refactor ObjectStructure

### DIFF
--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -111,6 +111,15 @@
 #endif
 #endif
 
+/* LOG2 */
+#ifndef FAST_LOG2_UINT
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
+#define FAST_LOG2_UINT(x) ((unsigned)(8 * sizeof(unsigned long long) - __builtin_clzll((x)) - 1))
+#else
+#define FAST_LOG2_UINT(x) log2l(x)
+#endif
+#endif
+
 #ifndef NULLABLE
 #define NULLABLE
 #endif

--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -1024,6 +1024,32 @@ bool ObjectRef::setPrototype(ExecutionStateRef* state, ValueRef* value)
     return toImpl(this)->setPrototype(*toImpl(state), toImpl(value));
 }
 
+OptionalRef<ContextRef> ObjectRef::creationContext()
+{
+    Optional<Object*> o = toImpl(this);
+
+    while (true) {
+        if (!o) {
+            break;
+        }
+
+        if (o->isFunctionObject()) {
+            return toRef(o->asFunctionObject()->codeBlock()->context());
+        }
+
+        auto ctor = o->readConstructorSlotWithoutState();
+        if (ctor) {
+            if (ctor.value().isFunction()) {
+                return toRef(ctor.value().asFunction()->codeBlock()->context());
+            }
+        }
+
+        o = o->rawInternalPrototypeObject();
+    }
+
+    return OptionalRef<ContextRef>();
+}
+
 ValueVectorRef* ObjectRef::ownPropertyKeys(ExecutionStateRef* state)
 {
     ValueVector v = toImpl(this)->ownPropertyKeys(*toImpl(state));

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -962,6 +962,8 @@ public:
     OptionalRef<ObjectRef> getPrototypeObject(ExecutionStateRef* state); // if __proto__ is not object(undefined or null), this function returns nullptr instead of orginal value.
     bool setPrototype(ExecutionStateRef* state, ValueRef* value);
 
+    OptionalRef<ContextRef> creationContext();
+
     ValueVectorRef* ownPropertyKeys(ExecutionStateRef* state);
 
     void enumerateObjectOwnProperies(ExecutionStateRef* state, const std::function<bool(ExecutionStateRef* state, ValueRef* propertyName, bool isWritable, bool isEnumerable, bool isConfigurable)>& cb);

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -95,7 +95,7 @@ bool ArrayObject::defineOwnProperty(ExecutionState& state, const ObjectPropertyN
     }
 
     uint64_t idx = P.tryToUseAsArrayIndex();
-    auto oldLenDesc = structure()->readProperty(state, (size_t)0);
+    auto oldLenDesc = structure()->readProperty((size_t)0);
     uint32_t oldLen = getArrayLength(state);
 
     if (idx != Value::InvalidArrayIndexValue) {
@@ -271,9 +271,7 @@ void ArrayObject::convertIntoNonFastMode(ExecutionState& state)
     if (!isFastModeArray())
         return;
 
-    if (!structure()->isStructureWithFastAccess()) {
-        m_structure = structure()->convertToWithFastAccess(state);
-    }
+    m_structure = structure()->convertToNonTransitionStructure();
 
     ensureObjectRareData()->m_isFastModeArrayObject = false;
 
@@ -298,7 +296,7 @@ bool ArrayObject::setArrayLength(ExecutionState& state, const uint64_t newLength
 
     if (LIKELY(isFastModeArray())) {
         auto oldSize = getArrayLength(state);
-        auto oldLenDesc = structure()->readProperty(state, (size_t)0);
+        auto oldLenDesc = structure()->readProperty((size_t)0);
         m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER] = Value(newLength);
         m_fastModeData.resize(oldSize, newLength, Value(Value::EmptyValue));
 
@@ -308,7 +306,7 @@ bool ArrayObject::setArrayLength(ExecutionState& state, const uint64_t newLength
         return true;
     } else {
         if (!isInArrayObjectDefineOwnProperty()) {
-            auto oldLenDesc = structure()->readProperty(state, (size_t)0);
+            auto oldLenDesc = structure()->readProperty((size_t)0);
 
             int64_t oldLen = length(state);
             int64_t newLen = newLength;

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -206,7 +206,6 @@ template <>
 struct hash<Escargot::AtomicString> {
     size_t operator()(Escargot::AtomicString const& x) const
     {
-        // return x.string()->hashValue();
         return std::hash<size_t*>{}((size_t*)x.string());
     }
 };

--- a/src/runtime/EnvironmentRecord.cpp
+++ b/src/runtime/EnvironmentRecord.cpp
@@ -134,7 +134,7 @@ void GlobalEnvironmentRecord::initializeBinding(ExecutionState& state, const Ato
     if (t == SIZE_MAX) {
         m_globalObject->defineOwnPropertyThrowsException(state, name, ObjectPropertyDescriptor(V, ObjectPropertyDescriptor::AllPresent));
     } else {
-        auto desc = m_globalObject->structure()->readProperty(state, t).m_descriptor;
+        auto desc = m_globalObject->structure()->readProperty(t).m_descriptor;
         if (desc.isDataProperty()) {
             if (desc.isConfigurable() || !desc.isEnumerable()) {
                 m_globalObject->defineOwnPropertyThrowsException(state, name, ObjectPropertyDescriptor(V, ObjectPropertyDescriptor::AllPresent));

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -154,7 +154,7 @@ public:
         m_objectPrototype->markThisObjectDontNeedStructureTransitionTable(state);
         Object::setPrototype(state, m_objectPrototype);
 
-        m_structure = m_structure->convertToWithFastAccess(state);
+        m_structure = m_structure->convertToNonTransitionStructure();
     }
 
     virtual bool isGlobalObject() const

--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -286,7 +286,6 @@ static Value builtinObjectFreeze(ExecutionState& state, Value thisValue, size_t 
     }
 
     Object* O = argv[0].asObject();
-    //O->markThisObjectDontNeedStructureTransitionTable(state);
 
     // For each named own property name P of O,
     std::vector<std::pair<ObjectPropertyName, ObjectStructurePropertyDescriptor>> descriptors;

--- a/src/runtime/ObjectStructurePropertyDescriptor.h
+++ b/src/runtime/ObjectStructurePropertyDescriptor.h
@@ -152,6 +152,11 @@ public:
         return m_descriptorData.nativeGetterSetterData();
     }
 
+    size_t rawValue() const
+    {
+        return m_descriptorData.m_data;
+    }
+
 protected:
     enum ObjectStructurePropertyDescriptorMode {
         PlainDataMode,

--- a/src/runtime/PropertyName.h
+++ b/src/runtime/PropertyName.h
@@ -41,8 +41,9 @@ public:
     PropertyName(ExecutionState& state, const Value& value);
     size_t hashValue() const
     {
-        if (hasAtomicString()) {
-            return ((String*)(m_data - PROPERTY_NAME_ATOMIC_STRING_VIAS))->hashValue();
+        if (LIKELY(hasAtomicString())) {
+            std::hash<Escargot::AtomicString> hasher;
+            return hasher(asAtomicString());
         } else if (hasSymbol()) {
             return m_data;
         }
@@ -168,7 +169,7 @@ ALWAYS_INLINE bool operator==(const PropertyName& a, const PropertyName& b)
     } else {
         bool sa = !aa && a.hasSymbol();
         bool sb = !ab && b.hasSymbol();
-        if (sa && sb) { // a, b both are symbol
+        if (UNLIKELY(sa && sb)) { // a, b both are symbol
             return a.m_data == b.m_data;
         } else if (!sa && !sb) { // a, b both are string
             return a.plainString()->equals(b.plainString());
@@ -183,7 +184,7 @@ ALWAYS_INLINE bool operator!=(const PropertyName& a, const PropertyName& b)
     return !operator==(a, b);
 }
 
-typedef std::unordered_map<PropertyName, size_t, std::hash<PropertyName>, std::equal_to<PropertyName>, gc_allocator<std::pair<const PropertyName, size_t>>> PropertyNameMap;
+typedef std::unordered_map<PropertyName, size_t, std::hash<PropertyName>, std::equal_to<PropertyName>, GCUtil::gc_malloc_allocator<std::pair<const PropertyName, size_t>>> PropertyNameMap;
 }
 
 namespace std {

--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -206,7 +206,7 @@ bool RegExpObject::defineOwnProperty(ExecutionState& state, const ObjectProperty
 {
     bool returnValue = Object::defineOwnProperty(state, P, desc);
     if (!P.isUIntType() && returnValue && P.propertyName() == PropertyName(state.context()->staticStrings().lastIndex)) {
-        if (!structure()->readProperty(state, (size_t)ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER).m_descriptor.isWritable()) {
+        if (!structure()->readProperty((size_t)ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER).m_descriptor.isWritable()) {
             ensureObjectRareData()->m_hasNonWritableLastIndexRegexpObject = true;
         } else {
             ensureObjectRareData()->m_hasNonWritableLastIndexRegexpObject = false;

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -706,7 +706,7 @@ struct equal_to<Escargot::String*> {
 #include "runtime/StringView.h"
 
 namespace Escargot {
-typedef std::unordered_map<String*, String*, std::hash<String*>, std::equal_to<String*>, gc_allocator<std::pair<String* const, String*>>> StringMapStd;
+typedef std::unordered_map<String*, String*, std::hash<String*>, std::equal_to<String*>, GCUtil::gc_malloc_allocator<std::pair<String* const, String*>>> StringMapStd;
 class StringMap : public StringMapStd, public gc {
 public:
     String* at(String* s) const

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -83,7 +83,7 @@ bool VMInstance::arrayLengthNativeSetter(ExecutionState& state, Object* self, Sm
     }
 
     bool ret;
-    if (UNLIKELY(!isPrimitiveValue && !self->structure()->readProperty(state, (size_t)0).m_descriptor.isWritable())) {
+    if (UNLIKELY(!isPrimitiveValue && !self->structure()->readProperty((size_t)0).m_descriptor.isWritable())) {
         ret = false;
     } else {
         ret = self->asArrayObject()->setArrayLength(state, newLen);
@@ -194,66 +194,66 @@ VMInstance::VMInstance(Platform* platform, const char* locale, const char* timez
 
     ExecutionState stateForInit((Context*)nullptr);
 
-    m_defaultStructureForObject = new ObjectStructure(stateForInit);
+    m_defaultStructureForObject = new ObjectStructureWithTransition(ObjectStructureItemTightVector(), false);
 
-    m_defaultStructureForFunctionObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.prototype,
+    m_defaultStructureForFunctionObject = m_defaultStructureForObject->addProperty(m_staticStrings.prototype,
                                                                                    ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&functionPrototypeNativeGetterSetterData));
 
-    m_defaultStructureForFunctionObject = m_defaultStructureForFunctionObject->addProperty(stateForInit, m_staticStrings.name,
+    m_defaultStructureForFunctionObject = m_defaultStructureForFunctionObject->addProperty(m_staticStrings.name,
                                                                                            ObjectStructurePropertyDescriptor::createDataDescriptor(ObjectStructurePropertyDescriptor::ConfigurablePresent));
 
-    m_defaultStructureForFunctionObject = m_defaultStructureForFunctionObject->addProperty(stateForInit, m_staticStrings.length,
+    m_defaultStructureForFunctionObject = m_defaultStructureForFunctionObject->addProperty(m_staticStrings.length,
                                                                                            ObjectStructurePropertyDescriptor::createDataDescriptor(ObjectStructurePropertyDescriptor::ConfigurablePresent));
 
-    m_defaultStructureForBuiltinFunctionObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.prototype,
+    m_defaultStructureForBuiltinFunctionObject = m_defaultStructureForObject->addProperty(m_staticStrings.prototype,
                                                                                           ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&builtinFunctionPrototypeNativeGetterSetterData));
 
-    m_defaultStructureForBuiltinFunctionObject = m_defaultStructureForBuiltinFunctionObject->addProperty(stateForInit, m_staticStrings.name,
+    m_defaultStructureForBuiltinFunctionObject = m_defaultStructureForBuiltinFunctionObject->addProperty(m_staticStrings.name,
                                                                                                          ObjectStructurePropertyDescriptor::createDataDescriptor(ObjectStructurePropertyDescriptor::ConfigurablePresent));
 
-    m_defaultStructureForBuiltinFunctionObject = m_defaultStructureForBuiltinFunctionObject->addProperty(stateForInit, m_staticStrings.length,
+    m_defaultStructureForBuiltinFunctionObject = m_defaultStructureForBuiltinFunctionObject->addProperty(m_staticStrings.length,
                                                                                                          ObjectStructurePropertyDescriptor::createDataDescriptor(ObjectStructurePropertyDescriptor::ConfigurablePresent));
 
-    m_defaultStructureForNotConstructorFunctionObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.name,
+    m_defaultStructureForNotConstructorFunctionObject = m_defaultStructureForObject->addProperty(m_staticStrings.name,
                                                                                                  ObjectStructurePropertyDescriptor::createDataDescriptor(ObjectStructurePropertyDescriptor::ConfigurablePresent));
 
-    m_defaultStructureForNotConstructorFunctionObject = m_defaultStructureForNotConstructorFunctionObject->addProperty(stateForInit, m_staticStrings.length,
+    m_defaultStructureForNotConstructorFunctionObject = m_defaultStructureForNotConstructorFunctionObject->addProperty(m_staticStrings.length,
                                                                                                                        ObjectStructurePropertyDescriptor::createDataDescriptor(ObjectStructurePropertyDescriptor::ConfigurablePresent));
 
-    m_defaultStructureForBoundFunctionObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.length,
+    m_defaultStructureForBoundFunctionObject = m_defaultStructureForObject->addProperty(m_staticStrings.length,
                                                                                         ObjectStructurePropertyDescriptor::createDataDescriptor(ObjectStructurePropertyDescriptor::ConfigurablePresent));
 
-    m_defaultStructureForBoundFunctionObject = m_defaultStructureForBoundFunctionObject->addProperty(stateForInit, m_staticStrings.name,
+    m_defaultStructureForBoundFunctionObject = m_defaultStructureForBoundFunctionObject->addProperty(m_staticStrings.name,
                                                                                                      ObjectStructurePropertyDescriptor::createDataDescriptor(ObjectStructurePropertyDescriptor::ConfigurablePresent));
 
-    m_defaultStructureForFunctionPrototypeObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.constructor,
+    m_defaultStructureForFunctionPrototypeObject = m_defaultStructureForObject->addProperty(m_staticStrings.constructor,
                                                                                             ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
 
-    m_defaultStructureForClassConstructorFunctionObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.length,
+    m_defaultStructureForClassConstructorFunctionObject = m_defaultStructureForObject->addProperty(m_staticStrings.length,
                                                                                                    ObjectStructurePropertyDescriptor::createDataDescriptor(ObjectStructurePropertyDescriptor::ConfigurablePresent));
 
-    m_defaultStructureForClassConstructorFunctionObject = m_defaultStructureForClassConstructorFunctionObject->addProperty(stateForInit, m_staticStrings.prototype,
+    m_defaultStructureForClassConstructorFunctionObject = m_defaultStructureForClassConstructorFunctionObject->addProperty(m_staticStrings.prototype,
                                                                                                                            ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&builtinFunctionPrototypeNativeGetterSetterData));
 
 
-    m_defaultStructureForArrayObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.length,
+    m_defaultStructureForArrayObject = m_defaultStructureForObject->addProperty(m_staticStrings.length,
                                                                                 ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&arrayLengthGetterSetterData));
 
-    m_defaultStructureForStringObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.length, ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&stringLengthGetterSetterData));
+    m_defaultStructureForStringObject = m_defaultStructureForObject->addProperty(m_staticStrings.length, ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&stringLengthGetterSetterData));
 
     m_defaultStructureForSymbolObject = m_defaultStructureForObject;
 
-    m_defaultStructureForRegExpObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.lastIndex,
+    m_defaultStructureForRegExpObject = m_defaultStructureForObject->addProperty(m_staticStrings.lastIndex,
                                                                                  ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpLastIndexGetterSetterData));
 
-    m_defaultStructureForMappedArgumentsObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.length, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
-    m_defaultStructureForMappedArgumentsObject = m_defaultStructureForMappedArgumentsObject->addProperty(stateForInit, PropertyName(stateForInit, globalSymbols().iterator), ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
-    m_defaultStructureForMappedArgumentsObject = m_defaultStructureForMappedArgumentsObject->addProperty(stateForInit, m_staticStrings.callee, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
+    m_defaultStructureForMappedArgumentsObject = m_defaultStructureForObject->addProperty(m_staticStrings.length, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
+    m_defaultStructureForMappedArgumentsObject = m_defaultStructureForMappedArgumentsObject->addProperty(PropertyName(stateForInit, globalSymbols().iterator), ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
+    m_defaultStructureForMappedArgumentsObject = m_defaultStructureForMappedArgumentsObject->addProperty(m_staticStrings.callee, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
 
-    m_defaultStructureForUnmappedArgumentsObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.length, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
-    m_defaultStructureForUnmappedArgumentsObject = m_defaultStructureForUnmappedArgumentsObject->addProperty(stateForInit, PropertyName(stateForInit, globalSymbols().iterator), ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
-    m_defaultStructureForUnmappedArgumentsObject = m_defaultStructureForUnmappedArgumentsObject->addProperty(stateForInit, m_staticStrings.caller, ObjectStructurePropertyDescriptor::createAccessorDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::NotPresent)));
-    m_defaultStructureForUnmappedArgumentsObject = m_defaultStructureForUnmappedArgumentsObject->addProperty(stateForInit, m_staticStrings.callee, ObjectStructurePropertyDescriptor::createAccessorDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::NotPresent)));
+    m_defaultStructureForUnmappedArgumentsObject = m_defaultStructureForObject->addProperty(m_staticStrings.length, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
+    m_defaultStructureForUnmappedArgumentsObject = m_defaultStructureForUnmappedArgumentsObject->addProperty(PropertyName(stateForInit, globalSymbols().iterator), ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
+    m_defaultStructureForUnmappedArgumentsObject = m_defaultStructureForUnmappedArgumentsObject->addProperty(m_staticStrings.caller, ObjectStructurePropertyDescriptor::createAccessorDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::NotPresent)));
+    m_defaultStructureForUnmappedArgumentsObject = m_defaultStructureForUnmappedArgumentsObject->addProperty(m_staticStrings.callee, ObjectStructurePropertyDescriptor::createAccessorDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::NotPresent)));
 
     m_jobQueue = new JobQueue();
 }

--- a/src/util/TightVector.h
+++ b/src/util/TightVector.h
@@ -246,7 +246,7 @@ public:
         }
     }
 
-private:
+protected:
     T* m_buffer;
     size_t m_size;
 };
@@ -350,7 +350,7 @@ public:
         return m_buffer;
     }
 
-private:
+protected:
     T* m_buffer;
 };
 
@@ -445,7 +445,7 @@ public:
         return m_buffer;
     }
 
-private:
+protected:
     T* m_buffer;
 };
 }

--- a/src/util/Vector.h
+++ b/src/util/Vector.h
@@ -113,8 +113,8 @@ public:
     Vector(const Vector<T, Allocator, glowFactor>& other, const T& newItem)
     {
         m_size = other.size() + 1;
-        m_capacity = other.m_capacity + 1;
-        m_buffer = Allocator().allocate(m_size);
+        m_capacity = computeAllocateSize(m_size);
+        m_buffer = Allocator().allocate(m_capacity);
         VectorCopier<T>::copy(m_buffer, other.data(), other.size());
 
         m_buffer[other.size()] = newItem;
@@ -126,7 +126,7 @@ public:
             Allocator().deallocate(m_buffer, m_capacity);
     }
 
-    void assign(T* start, T* end)
+    void assign(const T* start, const T* end)
     {
         clear();
 
@@ -369,12 +369,11 @@ protected:
         if (newSize == 0) {
             return 1;
         }
-        size_t base = log2l(newSize);
+        size_t base = FAST_LOG2_UINT(newSize);
         size_t capacity = 1 << (base + 1);
         return capacity * glowFactor / 100.f;
     }
 
-private:
     T* m_buffer;
     size_t m_capacity;
     size_t m_size;
@@ -478,12 +477,11 @@ protected:
         if (siz == 0) {
             return 1;
         }
-        size_t base = log2l(siz);
+        size_t base = FAST_LOG2_UINT(siz);
         size_t capacity = 1 << (base + 1);
         return capacity * glowFactor / 100.f;
     }
 
-private:
     T* m_buffer;
     size_t m_capacity;
 };
@@ -579,12 +577,11 @@ protected:
         if (siz == 0) {
             return 1;
         }
-        size_t base = log2l(siz);
+        size_t base = FAST_LOG2_UINT(siz);
         size_t capacity = 1 << (base + 1);
         return capacity * glowFactor / 100.f;
     }
 
-private:
     T* m_buffer;
     size_t m_capacity;
 };


### PR DESCRIPTION
* Divide ObjectStructure into 3 types
* Add transition look up hash map into ObjectStructureWithTransition
* Use faster version of log2 on Vector

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>