### PR TITLE
Impement TrimString and it's variaties

### DIFF
--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -403,9 +403,13 @@ namespace Escargot {
     F(small)                      \
     F(strike)                     \
     F(sub)                        \
+    F(sup)                        \
     F(padStart)                   \
     F(padEnd)                     \
-    F(sup)
+    F(trimStart)                  \
+    F(trimEnd)                    \
+    F(trimRight)                  \
+    F(trimLeft)
 
 
 #define FOR_EACH_STATIC_NUMBER(F) \


### PR DESCRIPTION
Removed code from Trim, moved to TrimString, implemented
the calls from TrimStart, TrimEnd and Trim. Aliased
TrimRight and TrimLeft onto TrimEnd and TrimStart.

Signed-off-by: Bela Toth tbela@inf.u-szeged.hu