### PR TITLE
Fix some parsing bugs and minor issue in Value

### DIFF
--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -71,7 +71,7 @@ GC_word* getNextValidInValueVector(GC_word* ptr, GC_word** next_ptr)
     *next_ptr = ptr + 1;
 #endif
     GC_word* ret = NULL;
-    if (*current && current->isPointerValue()) {
+    if (current->isPointerValue()) {
         ret = (GC_word*)current->asPointerValue();
     }
     return ret;

--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -644,9 +644,13 @@ public:
             ObjectExpressionNode* object = expr->asObjectExpression();
             NodeList& properties = object->properties();
             for (SentinelNode* property = properties.begin(); property != properties.end(); property = property->next()) {
-                ASSERT(property->astNode()->type() == Property);
-                Node* value = this->reinterpretExpressionAsPattern(property->astNode()->asProperty()->value());
-                property->astNode()->asProperty()->setValue(value);
+                if (property->astNode()->type() == Property) {
+                    Node* value = this->reinterpretExpressionAsPattern(property->astNode()->asProperty()->value());
+                    property->astNode()->asProperty()->setValue(value);
+                } else {
+                    ASSERT(property->astNode()->type() == SpreadElement);
+                    property->setASTNode(this->reinterpretExpressionAsPattern(property->astNode()));
+                }
             }
             result = new (m_allocator) ObjectPatternNode(properties, object->m_loc);
             break;

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -110,7 +110,7 @@ CodeBlock::CodeBlock(Context* ctx, const NativeFunctionInfo& info)
     , m_isGenerator(false)
     , m_isAsync(false)
     , m_needsVirtualIDOperation(false)
-    , m_hasImplictFunctionName(false)
+    , m_hasImplicitFunctionName(false)
     , m_hasArrowParameterPlaceHolder(false)
     , m_hasParameterOtherThanIdentifier(false)
     , m_allowSuperCall(false)
@@ -150,7 +150,7 @@ CodeBlock::CodeBlock(Context* ctx, AtomicString name, size_t argc, bool isStrict
     , m_isGenerator(false)
     , m_isAsync(false)
     , m_needsVirtualIDOperation(false)
-    , m_hasImplictFunctionName(false)
+    , m_hasImplicitFunctionName(false)
     , m_hasArrowParameterPlaceHolder(false)
     , m_hasParameterOtherThanIdentifier(false)
     , m_allowSuperCall(false)
@@ -226,7 +226,7 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     m_hasWith = scopeCtx->m_hasWith;
     m_inWith = scopeCtx->m_inWith;
 
-    m_hasImplictFunctionName = scopeCtx->m_hasImplictFunctionName;
+    m_hasImplicitFunctionName = scopeCtx->m_hasImplicitFunctionName;
 
     m_isEvalCode = isEvalCode;
     m_isEvalCodeInFunction = isEvalCodeInFunction;
@@ -287,13 +287,13 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
 
     m_context = ctx;
     m_functionName = scopeCtx->m_functionName;
-    m_parameterCount = parameterNames.size();
+    m_parameterCount = scopeCtx->m_parameterCount;
     m_hasCallNativeFunctionCode = false;
     m_isStrict = scopeCtx->m_isStrict;
     m_hasEval = scopeCtx->m_hasEval;
     m_hasWith = scopeCtx->m_hasWith;
     m_inWith = scopeCtx->m_inWith;
-    m_hasImplictFunctionName = scopeCtx->m_hasImplictFunctionName;
+    m_hasImplicitFunctionName = scopeCtx->m_hasImplicitFunctionName;
     m_hasArrowParameterPlaceHolder = scopeCtx->m_hasArrowParameterPlaceHolder;
     m_hasParameterOtherThanIdentifier = scopeCtx->m_hasParameterOtherThanIdentifier;
 

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -217,9 +217,9 @@ public:
         return m_allowSuperProperty;
     }
 
-    bool hasImplictFunctionName()
+    bool hasImplicitFunctionName()
     {
-        return m_hasImplictFunctionName;
+        return m_hasImplicitFunctionName;
     }
 
     AtomicString functionName() const
@@ -333,7 +333,7 @@ protected:
     bool m_isGenerator : 1;
     bool m_isAsync : 1;
     bool m_needsVirtualIDOperation : 1;
-    bool m_hasImplictFunctionName : 1;
+    bool m_hasImplicitFunctionName : 1;
     bool m_hasArrowParameterPlaceHolder : 1;
     bool m_hasParameterOtherThanIdentifier : 1;
     bool m_allowSuperCall : 1;

--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -173,10 +173,11 @@ struct ASTFunctionScopeContext {
     bool m_hasArrowParameterPlaceHolder : 1;
     bool m_hasParameterOtherThanIdentifier : 1;
     bool m_needsToComputeLexicalBlockStuffs : 1;
-    bool m_hasImplictFunctionName : 1;
+    bool m_hasImplicitFunctionName : 1;
     bool m_allowSuperCall : 1;
     bool m_allowSuperProperty : 1;
     unsigned int m_nodeType : 2; // it is actually NodeType but used on FunctionExpression, ArrowFunctionExpression and FunctionDeclaration only
+    unsigned int m_parameterCount : 16;
     LexicalBlockIndex m_lexicalBlockIndexFunctionLocatedIn : 16;
     ASTFunctionScopeContextNameInfoVector m_varNames;
     FunctionContextVarMap *m_varNamesMap;
@@ -484,10 +485,11 @@ struct ASTFunctionScopeContext {
         , m_hasArrowParameterPlaceHolder(false)
         , m_hasParameterOtherThanIdentifier(false)
         , m_needsToComputeLexicalBlockStuffs(false)
-        , m_hasImplictFunctionName(false)
+        , m_hasImplicitFunctionName(false)
         , m_allowSuperCall(false)
         , m_allowSuperProperty(false)
         , m_nodeType(ASTNodeType::Program)
+        , m_parameterCount(0)
         , m_lexicalBlockIndexFunctionLocatedIn(LEXICAL_BLOCK_INDEX_MAX)
         , m_varNamesMap(nullptr)
         , m_firstChild(nullptr)

--- a/src/parser/ast/ObjectPatternNode.h
+++ b/src/parser/ast/ObjectPatternNode.h
@@ -47,11 +47,12 @@ public:
         , m_hasRestElement(false)
     {
         m_loc = loc;
-#ifndef NDEBUG
         for (SentinelNode* property = m_properties.begin(); property != m_properties.end(); property = property->next()) {
-            ASSERT(property->astNode()->isProperty());
+            ASSERT(property->astNode()->isProperty() || property->astNode()->type() == ASTNodeType::RestElement);
+            if (property->astNode()->type() == ASTNodeType::RestElement) {
+                m_hasRestElement = true;
+            }
         }
-#endif
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::ObjectPattern; }

--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -69,7 +69,7 @@ static Value builtinFunctionToString(ExecutionState& state, Value thisValue, siz
                     builder.appendString("async ");
                 }
                 builder.appendString("function ");
-                if (!fn->codeBlock()->hasImplictFunctionName()) {
+                if (!fn->codeBlock()->hasImplicitFunctionName()) {
                     builder.appendString(fn->codeBlock()->functionName().string());
                 }
             }

--- a/src/runtime/IntlNumberFormat.cpp
+++ b/src/runtime/IntlNumberFormat.cpp
@@ -277,7 +277,7 @@ void IntlNumberFormat::initialize(ExecutionState& state, Object* numberFormat, V
         // Let mnsd be the result of calling the GetNumberOption abstract operation with arguments options, "minimumSignificantDigits", 1, 21, and 1.
         mnsd = Value(getNumberOption(state, options.asObject(), String::fromASCII("minimumSignificantDigits"), 1, 21, 1));
         // Let mxsd be the result of calling the GetNumberOption abstract operation with arguments options, "maximumSignificantDigits", mnsd, 21, and 21.
-        mxsd = Value(getNumberOption(state, options.asObject(), String::fromASCII("maximumSignificantDigits"), mnsd, 21, 21));
+        mxsd = Value(getNumberOption(state, options.asObject(), String::fromASCII("maximumSignificantDigits"), mnsd.asNumber(), 21, 21));
         // Set the [[minimumSignificantDigits]] internal property of numberFormat to mnsd,
         // and the [[maximumSignificantDigits]] internal property of numberFormat to mxsd.
         numberFormat->internalSlot()->set(state, ObjectPropertyName(state, String::fromASCII("minimumSignificantDigits")), mnsd, numberFormat->internalSlot());

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -149,7 +149,6 @@ public:
     explicit Value(long long);
     explicit Value(unsigned long long);
 
-    inline operator bool() const;
     inline bool operator==(const Value& other) const;
     inline bool operator!=(const Value& other) const;
 

--- a/src/runtime/ValueInlines.h
+++ b/src/runtime/ValueInlines.h
@@ -178,11 +178,6 @@ inline Value::Value(int i)
     u.asBits.payload = i;
 }
 
-inline Value::operator bool() const
-{
-    return u.asInt64;
-}
-
 inline bool Value::operator==(const Value& other) const
 {
     return u.asInt64 == other.u.asInt64;
@@ -401,11 +396,6 @@ inline Value::Value(EncodeAsDoubleTag, double d)
 inline Value::Value(int i)
 {
     u.asInt64 = TagTypeNumber | static_cast<uint32_t>(i);
-}
-
-inline Value::operator bool() const
-{
-    return u.asInt64 != ValueEmpty;
 }
 
 inline bool Value::operator==(const Value& other) const

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -4359,7 +4359,6 @@
     <test id="language/expressions/array/spread-sngl-expr"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dflt-params-trailing-comma"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-arrow"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -4372,25 +4371,9 @@
     <test id="language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-arrow"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-cover"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-fn"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-gen"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/dflt-obj-ptrn-rest-getter"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/dflt-obj-ptrn-rest-skip-non-enumerable"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/dflt-obj-ptrn-rest-val-obj"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-arrow"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-cover"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-fn"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-gen"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/obj-ptrn-rest-getter"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/obj-ptrn-rest-skip-non-enumerable"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/obj-ptrn-rest-val-obj"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/length-dflt"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/params-trailing-comma-multiple"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/params-trailing-comma-single"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/scope-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -8198,7 +8181,6 @@
     <test id="language/expressions/exponentiation/order-of-evaluation"><reason>TODO</reason></test>
     <test id="language/expressions/function/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/function/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/function/dflt-params-trailing-comma"><reason>TODO</reason></test>
     <test id="language/expressions/function/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-arrow"><reason>TODO</reason></test>
     <test id="language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -8223,8 +8205,6 @@
     <test id="language/expressions/function/dstr/obj-ptrn-id-init-fn-name-gen"><reason>TODO</reason></test>
     <test id="language/expressions/function/length-dflt"><reason>TODO</reason></test>
     <test id="language/expressions/function/params-dflt-ref-arguments"><reason>TODO</reason></test>
-    <test id="language/expressions/function/params-trailing-comma-multiple"><reason>TODO</reason></test>
-    <test id="language/expressions/function/params-trailing-comma-single"><reason>TODO</reason></test>
     <test id="language/expressions/function/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/expressions/function/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/expressions/function/scope-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -13710,7 +13690,6 @@
     <test id="language/statements/for/tco-var-body"><reason>TODO</reason></test>
     <test id="language/statements/function/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/statements/function/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/statements/function/dflt-params-trailing-comma"><reason>TODO</reason></test>
     <test id="language/statements/function/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-arrow"><reason>TODO</reason></test>
     <test id="language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -13735,8 +13714,6 @@
     <test id="language/statements/function/dstr/obj-ptrn-id-init-fn-name-gen"><reason>TODO</reason></test>
     <test id="language/statements/function/length-dflt"><reason>TODO</reason></test>
     <test id="language/statements/function/params-dflt-ref-arguments"><reason>TODO</reason></test>
-    <test id="language/statements/function/params-trailing-comma-multiple"><reason>TODO</reason></test>
-    <test id="language/statements/function/params-trailing-comma-single"><reason>TODO</reason></test>
     <test id="language/statements/function/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/statements/function/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/statements/function/scope-param-rest-elem-var-close"><reason>TODO</reason></test>

--- a/tools/test/v8/v8.mjsunit.status
+++ b/tools/test/v8/v8.mjsunit.status
@@ -730,6 +730,7 @@
   'strict-mode': [SKIP],
   'regress/regress-1530': [SKIP],
   'regress/regress-2470': [SKIP],
+  'extra-commas': [SKIP],
 
   # Proxy
   'regress/regress-578775': [SKIP],


### PR DESCRIPTION
* Boolean operator overloading in Value checks if this Value is empty or not. There was a bug in the operator overloading for 32bit mode which just returns the entire value. This patch removed the operator overloading instead of fixing the bug because explicit check by isEmpty is more intuitive
* handle implicit function name in parameter list
* handle trailing-comma and also support the trailing-comma rule in setter function
* fix function length not to count parameter-forms other than simple identifier
* disable one wrong TC in v8 (trailing-comma)