### PR TITLE
Fix padStart and padEnd and enable test262 tests

### DIFF
--- a/src/runtime/GlobalObjectBuiltinString.cpp
+++ b/src/runtime/GlobalObjectBuiltinString.cpp
@@ -1149,7 +1149,7 @@ static Value builtinStringPadStart(ExecutionState& state, Value thisValue, size_
     // If fillString is undefined, let filler be a String consisting solely of the code unit 0x0020 (SPACE).
     // Else, let filler be ? ToString(fillString).
     String* filler;
-    if (argc >= 2) {
+    if (argc >= 2 && (!argv[1].isUndefined())) {
         filler = argv[1].toString(state);
     } else {
         filler = state.context()->staticStrings().asciiTable[0x20].string();
@@ -1203,7 +1203,7 @@ static Value builtinStringPadEnd(ExecutionState& state, Value thisValue, size_t 
     // If fillString is undefined, let filler be a String consisting solely of the code unit 0x0020 (SPACE).
     // Else, let filler be ? ToString(fillString).
     String* filler;
-    if (argc >= 2) {
+    if (argc >= 2 && (!argv[1].isUndefined())) {
         filler = argv[1].toString(state);
     } else {
         filler = state.context()->staticStrings().asciiTable[0x20].string();
@@ -1515,10 +1515,10 @@ void GlobalObject::installString(ExecutionState& state)
                                                         ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->trim, builtinStringTrim, 0, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_stringPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(strings->padStart),
-                                                        ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->trim, builtinStringPadStart, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
+                                                        ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->padStart, builtinStringPadStart, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_stringPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(strings->padEnd),
-                                                        ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->trim, builtinStringPadEnd, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
+                                                        ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->padEnd, builtinStringPadEnd, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     FunctionObject* trimStart = new NativeFunctionObject(state, NativeFunctionInfo(strings->trimStart, builtinStringTrimStart, 0, NativeFunctionInfo::Strict));
     FunctionObject* trimEnd = new NativeFunctionObject(state, NativeFunctionInfo(strings->trimEnd, builtinStringTrimEnd, 0, NativeFunctionInfo::Strict));

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -2413,10 +2413,6 @@
     <test id="built-ins/String/prototype/matchAll/regexp-prototype-matchAll-throws"><reason>TODO</reason></test>
     <test id="built-ins/String/prototype/matchAll/this-val-non-obj-coercible"><reason>TODO</reason></test>
     <test id="built-ins/String/prototype/matchAll/toString-this-val"><reason>TODO</reason></test>
-    <test id="built-ins/String/prototype/padEnd/fill-string-omitted"><reason>TODO</reason></test>
-    <test id="built-ins/String/prototype/padEnd/function-name"><reason>TODO</reason></test>
-    <test id="built-ins/String/prototype/padStart/fill-string-omitted"><reason>TODO</reason></test>
-    <test id="built-ins/String/prototype/padStart/function-name"><reason>TODO</reason></test>
     <test id="built-ins/String/prototype/search/cstm-search-invocation"><reason>TODO</reason></test>
     <test id="built-ins/String/prototype/split/cstm-split-invocation"><reason>TODO</reason></test>
     <test id="built-ins/String/prototype/Symbol.iterator/prop-desc"><reason>TODO</reason></test>


### PR DESCRIPTION
Enabled some tests from the updated test262 repository,
and fixed errors, that were corresponding to them.

Signed-off-by: Bela Toth tbela@inf.u-szeged.hu