### PR TITLE
Enable direct threading for clang compiler

### DIFF
--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -35,6 +35,10 @@
 #endif
 
 #if defined(COMPILER_CLANG)
+/* Check clang version */
+#if __clang_major__ < 6
+#error "Clang version is low (require clang version 6+)"
+#endif
 /* Keep strong enums turned off when building with clang-cl: We cannot yet build all of Blink without fallback to cl.exe, and strong enums are exposed at ABI boundaries. */
 #undef COMPILER_SUPPORTS_CXX_STRONG_ENUMS
 #else

--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -32,7 +32,7 @@ OpcodeTable g_opcodeTable;
 
 OpcodeTable::OpcodeTable()
 {
-#if defined(COMPILER_GCC)
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
     // Dummy bytecode execution to initialize the OpcodeTable.
     ByteCodeInterpreter::interpret(nullptr, nullptr, 0, nullptr);
 #endif

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -187,7 +187,7 @@ struct ByteCodeLOC {
 class ByteCode {
 public:
     ByteCode(Opcode code, const ByteCodeLOC& loc)
-#if defined(COMPILER_GCC)
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
         : m_opcodeInAddress((void*)code)
 #else
         : m_opcode(code)
@@ -202,18 +202,18 @@ public:
     void assignOpcodeInAddress()
     {
 #ifndef NDEBUG
-#if defined(COMPILER_GCC)
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
         m_orgOpcode = (Opcode)(size_t)m_opcodeInAddress;
 #else
         m_orgOpcode = m_opcode;
 #endif
 #endif
-#if defined(COMPILER_GCC)
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
         m_opcodeInAddress = g_opcodeTable.m_table[(Opcode)(size_t)m_opcodeInAddress];
 #endif
     }
 
-#if defined(COMPILER_GCC)
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
     void* m_opcodeInAddress;
 #else
     Opcode m_opcode;
@@ -2362,7 +2362,7 @@ public:
         }
 #endif
 
-#if defined(COMPILER_GCC)
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
         Opcode opcode = (Opcode)(size_t)code.m_opcodeInAddress;
 #else
         Opcode opcode = code.m_opcode;

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -205,7 +205,7 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
 
         while (code < end) {
             ByteCode* currentCode = (ByteCode*)code;
-#if defined(COMPILER_GCC)
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
             Opcode opcode = (Opcode)(size_t)currentCode->m_opcodeInAddress;
 #else
             Opcode opcode = currentCode->m_opcode;


### PR DESCRIPTION
* In our environment, clang version 6+ supports the direct threading in interpreter