### PR TITLE
Fix valueStringLiteral method in ScannerResult

### DIFF
--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -482,13 +482,20 @@ StringView Scanner::ScannerResult::relatedSource(const StringView& source)
     return StringView(source, this->start, this->end);
 }
 
-Value Scanner::ScannerResult::valueStringLiteralForAST(Scanner* scannerInstance)
+Value Scanner::ScannerResult::valueStringLiteralToValue(Scanner* scannerInstance)
 {
-    StringView sv = valueStringLiteral(scannerInstance);
-    if (!this->hasAllocatedString) {
-        return new StringView(sv);
+    if (this->type == Token::KeywordToken && !this->hasKeywordButUseString) {
+        return keywordToString(scannerInstance->escargotContext, this->valueKeywordKind).string();
     }
-    return sv.string();
+
+    if (this->hasAllocatedString) {
+        if (!this->valueStringLiteralData.m_stringIfNewlyAllocated) {
+            constructStringLiteral(scannerInstance);
+        }
+        return this->valueStringLiteralData.m_stringIfNewlyAllocated;
+    }
+
+    return new StringView(scannerInstance->source, this->valueStringLiteralData.m_start, this->valueStringLiteralData.m_end);
 }
 
 StringView Scanner::ScannerResult::valueStringLiteral(Scanner* scannerInstance)

--- a/src/parser/Lexer.h
+++ b/src/parser/Lexer.h
@@ -284,7 +284,7 @@ public:
 
         StringView relatedSource(const StringView& source);
         StringView valueStringLiteral(Scanner* scannerInstance);
-        Value valueStringLiteralForAST(Scanner* scannerInstance);
+        Value valueStringLiteralToValue(Scanner* scannerInstance);
         double valueNumberLiteral(Scanner* scannerInstance);
 
         inline operator bool() const


### PR DESCRIPTION
* remove unnecessary StringView allocation
* simplify parseObjectPropertyKey mothod

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>