### PR TITLE
Enable u+2028 and 2029 seperator characters

### DIFF
--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -1399,7 +1399,8 @@ void Scanner::scanStringLiteral(Scanner::ScannerResult* token)
                 }
                 this->lineStart = this->index;
             }
-        } else if (UNLIKELY(isLineTerminator(ch))) {
+        } else if (UNLIKELY(ch < 128 && (g_asciiRangeCharMap[ch] & LexerIsCharLineTerminator))) {
+            // while parsing string literal, we should not end parsing string token with 0x2028 or 0x2029
             break;
         }
     }

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -5355,10 +5355,6 @@
     <test id="language/literals/numeric/numeric-separators/numeric-separator-literal-oil-ods-nsl-ods"><reason>TODO</reason></test>
     <test id="language/literals/numeric/numeric-separators/numeric-separator-literal-sign-minus-dds-nsl-dd"><reason>TODO</reason></test>
     <test id="language/literals/numeric/numeric-separators/numeric-separator-literal-sign-plus-dds-nsl-dd"><reason>TODO</reason></test>
-    <test id="language/literals/string/line-separator"><reason>TODO</reason></test>
-    <test id="language/literals/string/line-separator-eval"><reason>TODO</reason></test>
-    <test id="language/literals/string/paragraph-separator"><reason>TODO</reason></test>
-    <test id="language/literals/string/paragraph-separator-eval"><reason>TODO</reason></test>
     <test id="language/module-code/eval-export-cls-semi"><reason>TODO</reason></test>
     <test id="language/module-code/eval-export-dflt-cls-anon"><reason>TODO</reason></test>
     <test id="language/module-code/eval-export-dflt-cls-anon-semi"><reason>TODO</reason></test>


### PR DESCRIPTION
Allowing U+2028 (LINE SEPARATOR) and U+2029
(PARAGRAPH SEPARATOR) in string literals
defined in ECMAScript 2019.