### PR TITLE
Reduce memory usage

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -675,7 +675,7 @@ void VMInstanceRef::setOnVMInstanceDelete(OnVMInstanceDelete cb)
 void VMInstanceRef::clearCachesRelatedWithContext()
 {
     VMInstance* imp = toImpl(this);
-    imp->m_regexpCache.clear();
+    imp->m_regexpCache->clear();
     imp->m_cachedUTC = nullptr;
     imp->globalSymbolRegistry().clear();
 }
@@ -747,7 +747,7 @@ ScriptParserRef* ContextRef::scriptParser()
 
 ValueVectorRef* ValueVectorRef::create(size_t size)
 {
-    return toRef(new (GC) SmallValueVector(size));
+    return toRef(new SmallValueVector(size));
 }
 
 size_t ValueVectorRef::size()

--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -60,7 +60,7 @@ int getValidValueInArrayObject(void* ptr, GC_mark_custom_result* arr)
     arr[2].from = (GC_word*)&current->m_values;
     arr[2].to = (GC_word*)current->m_values.data();
     arr[3].from = (GC_word*)&current->m_fastModeData;
-    arr[3].to = (GC_word*)current->m_fastModeData.data();
+    arr[3].to = (GC_word*)current->m_fastModeData;
     return 0;
 }
 

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -189,7 +189,9 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
         // yield delegate + .next call can use yield * 2 at once
         block->m_code.reserve(block->m_code.size() + ctx.m_maxPauseStatementExtraDataLength * 2);
     } else {
-        block->m_code.shrinkToFit();
+        if (block->m_code.capacity() - block->m_code.size() > 1024 * 4) {
+            block->m_code.shrinkToFit();
+        }
     }
 
     {

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -47,10 +47,10 @@ Context* Script::context()
 
 static Optional<Script*> findLoadedModule(Context* context, Optional<Script*> referrer, String* src)
 {
-    const auto& lm = context->loadedModules();
+    const auto& lm = *context->loadedModules();
     for (size_t j = 0; j < lm.size(); j++) {
         if (lm[j].m_referrer == referrer && lm[j].m_src->equals(src)) {
-            return Optional<Script*>(context->loadedModules()[j].m_loadedModule);
+            return Optional<Script*>(lm[j].m_loadedModule);
         }
     }
 
@@ -64,8 +64,8 @@ static void registerToLoadedModuleIfNeeds(Context* context, Optional<Script*> re
         m.m_loadedModule = module;
         m.m_referrer = referrer;
         m.m_src = src;
-        auto& lm = context->loadedModules();
-        lm.push_back(m);
+        auto lm = context->loadedModules();
+        lm->push_back(m);
     }
 }
 
@@ -312,7 +312,7 @@ Value Script::executeModule(ExecutionState& state, Optional<Script*> referrer)
     // http://www.ecma-international.org/ecma-262/6.0/#sec-moduledeclarationinstantiation
     // ModuleDeclarationInstantiation( ) Concrete Method
     LexicalEnvironment* globalLexicalEnv = new LexicalEnvironment(
-        new GlobalEnvironmentRecord(state, nullptr, context()->globalObject(), &context()->globalDeclarativeRecord(), &context()->globalDeclarativeStorage()), nullptr);
+        new GlobalEnvironmentRecord(state, nullptr, context()->globalObject(), context()->globalDeclarativeRecord(), context()->globalDeclarativeStorage()), nullptr);
 
     ExecutionState newState(context(), state.stackLimit());
 
@@ -466,7 +466,7 @@ Value Script::execute(ExecutionState& state, bool isExecuteOnEvalFunction, bool 
     ExecutionState newState(context(), state.stackLimit());
     ExecutionState* codeExecutionState = &newState;
 
-    EnvironmentRecord* globalRecord = new GlobalEnvironmentRecord(state, m_topCodeBlock, context()->globalObject(), &context()->globalDeclarativeRecord(), &context()->globalDeclarativeStorage());
+    EnvironmentRecord* globalRecord = new GlobalEnvironmentRecord(state, m_topCodeBlock, context()->globalObject(), context()->globalDeclarativeRecord(), context()->globalDeclarativeStorage());
     LexicalEnvironment* globalLexicalEnvironment = new LexicalEnvironment(globalRecord, nullptr);
     newState.setLexicalEnvironment(globalLexicalEnvironment, m_topCodeBlock->isStrict());
 

--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -164,7 +164,7 @@ struct ASTBlockScopeContext {
     }
 };
 
-typedef Vector<ASTBlockScopeContext *, GCUtil::gc_malloc_atomic_allocator<ASTBlockScopeContext *>> ASTBlockScopeContextVector;
+typedef Vector<ASTBlockScopeContext *, GCUtil::gc_malloc_atomic_allocator<ASTBlockScopeContext *>, ComputeReservedCapacityFunctionWithLog2<>> ASTBlockScopeContextVector;
 typedef std::unordered_map<AtomicString, StorePositiveIntergerAsOdd, std::hash<AtomicString>, std::equal_to<AtomicString>,
                            GCUtil::gc_malloc_allocator<std::pair<AtomicString const, StorePositiveIntergerAsOdd>>>
     FunctionContextVarMap;

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -1845,7 +1845,7 @@ public:
         MetaNode node = this->createNode();
 
         ASTNodeList expressions;
-        TemplateElementVector* quasis = new (GC) TemplateElementVector;
+        TemplateElementVector* quasis = new TemplateElementVector;
         quasis->push_back(this->parseTemplateHead());
         while (!quasis->back()->tail) {
             expressions.append(this->allocator, this->parseExpression(builder));

--- a/src/runtime/Context.h
+++ b/src/runtime/Context.h
@@ -68,6 +68,10 @@ struct GlobalVariableAccessCacheItem : public gc {
     void* operator new[](size_t size) = delete;
 };
 
+typedef std::unordered_map<AtomicString, GlobalVariableAccessCacheItem*, std::hash<AtomicString>, std::equal_to<AtomicString>,
+                           GCUtil::gc_malloc_allocator<std::pair<AtomicString const, GlobalVariableAccessCacheItem*>>>
+    GlobalVariableAccessCache;
+
 class Context : public gc {
     friend class AtomicString;
     friend class SandBox;
@@ -143,11 +147,6 @@ public:
         return m_defaultStructureForClassConstructorFunctionObject;
     }
 
-    ObjectStructure* defaultStructureForArrayObject()
-    {
-        return m_defaultStructureForArrayObject;
-    }
-
     ObjectStructure* defaultStructureForStringObject()
     {
         return m_defaultStructureForStringObject;
@@ -208,19 +207,19 @@ public:
         return m_securityPolicyCheckCallback;
     }
 
-    IdentifierRecordVector& globalDeclarativeRecord()
+    IdentifierRecordVector* globalDeclarativeRecord()
     {
         return m_globalDeclarativeRecord;
     }
 
-    SmallValueVector& globalDeclarativeStorage()
+    SmallValueVector* globalDeclarativeStorage()
     {
         return m_globalDeclarativeStorage;
     }
 
     GlobalVariableAccessCacheItem* ensureGlobalVariableAccessCacheSlot(AtomicString as);
 
-    LoadedModuleVector& loadedModules()
+    LoadedModuleVector* loadedModules()
     {
         return m_loadedModules;
     }
@@ -239,12 +238,10 @@ private:
     StaticStrings& m_staticStrings;
     GlobalObject* m_globalObject;
     ScriptParser* m_scriptParser;
-    IdentifierRecordVector m_globalDeclarativeRecord;
-    SmallValueVector m_globalDeclarativeStorage;
-    std::unordered_map<AtomicString, GlobalVariableAccessCacheItem*, std::hash<AtomicString>, std::equal_to<AtomicString>,
-                       GCUtil::gc_malloc_allocator<std::pair<AtomicString const, GlobalVariableAccessCacheItem*>>>
-        m_globalVariableAccessCache;
-    LoadedModuleVector m_loadedModules;
+    IdentifierRecordVector* m_globalDeclarativeRecord;
+    SmallValueVector* m_globalDeclarativeStorage;
+    GlobalVariableAccessCache* m_globalVariableAccessCache;
+    LoadedModuleVector* m_loadedModules;
     WTF::BumpPointerAllocator* m_bumpPointerAllocator;
     RegExpCacheMap* m_regexpCache;
     ObjectStructure* m_defaultStructureForObject;
@@ -254,7 +251,6 @@ private:
     ObjectStructure* m_defaultStructureForFunctionPrototypeObject;
     ObjectStructure* m_defaultStructureForBoundFunctionObject;
     ObjectStructure* m_defaultStructureForClassConstructorFunctionObject;
-    ObjectStructure* m_defaultStructureForArrayObject;
     ObjectStructure* m_defaultStructureForStringObject;
     ObjectStructure* m_defaultStructureForSymbolObject;
     ObjectStructure* m_defaultStructureForRegExpObject;

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -157,7 +157,7 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
     Script* script = parser.initializeScript(StringView(scriptSource, 0, scriptSource->length()), new ASCIIString("Function Constructor input"), false, nullptr, false, false, false, false, SIZE_MAX, false, allowSuperCall, false, true).scriptThrowsExceptionIfParseError(state);
     InterpretedCodeBlock* cb = script->topCodeBlock()->firstChild();
     cb->updateSourceElementStart(3, 1);
-    LexicalEnvironment* globalEnvironment = new LexicalEnvironment(new GlobalEnvironmentRecord(state, script->topCodeBlock(), state.context()->globalObject(), &state.context()->globalDeclarativeRecord(), &state.context()->globalDeclarativeStorage()), nullptr);
+    LexicalEnvironment* globalEnvironment = new LexicalEnvironment(new GlobalEnvironmentRecord(state, script->topCodeBlock(), state.context()->globalObject(), state.context()->globalDeclarativeRecord(), state.context()->globalDeclarativeStorage()), nullptr);
 
     FunctionObject::FunctionSource fs;
     fs.script = script;

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -160,7 +160,7 @@ public:
         m_structure = m_structure->convertToNonTransitionStructure();
     }
 
-    virtual bool isGlobalObject() const
+    virtual bool isGlobalObject() const override
     {
         return true;
     }
@@ -231,7 +231,7 @@ public:
     Value eval(ExecutionState& state, const Value& arg);
     Value evalLocal(ExecutionState& state, const Value& arg, Value thisValue, InterpretedCodeBlock* parentCodeBlock, bool inWithOperation); // we get isInWithOperation as parameter because this affects bytecode
 
-    virtual const char* internalClassProperty()
+    virtual const char* internalClassProperty() override
     {
         return "global";
     }
@@ -676,13 +676,13 @@ public:
         return m_symbolProxyObject;
     }
 
-    virtual bool isInlineCacheable()
+    virtual bool isInlineCacheable() override
     {
         return false;
     }
 
-    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
-    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) override ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
+    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
 
     void* operator new(size_t size)
     {

--- a/src/runtime/GlobalObjectBuiltinArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinArray.cpp
@@ -33,7 +33,7 @@ namespace Escargot {
 Value builtinArrayConstructor(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
     bool interpretArgumentsAsElements = false;
-    size_t size = 0;
+    uint32_t size = 0;
     if (argc > 1) {
         size = argc;
         interpretArgumentsAsElements = true;
@@ -51,8 +51,7 @@ Value builtinArrayConstructor(ExecutionState& state, Value thisValue, size_t arg
         }
     }
 
-    ArrayObject* array = new ArrayObject(state);
-    array->setArrayLength(state, size);
+    ArrayObject* array = new ArrayObject(state, (uint64_t)size);
 
     if (interpretArgumentsAsElements) {
         Value val = argv[0];

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -91,9 +91,9 @@ ObjectRareData::ObjectRareData(Object* obj)
     m_isExtensible = true;
     m_isEverSetAsPrototypeObject = false;
     m_isFastModeArrayObject = true;
+    m_isArrayObjectLengthWritable = true;
     m_isSpreadArrayObject = false;
     m_shouldUpdateEnumerateObject = false;
-    m_isInArrayObjectDefineOwnProperty = false;
     m_hasNonWritableLastIndexRegexpObject = false;
     m_extraData = nullptr;
     m_internalSlot = nullptr;

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -174,7 +174,7 @@ private:
 
 typedef std::unordered_map<RegExpObject::RegExpCacheKey, RegExpObject::RegExpCacheEntry,
                            std::hash<RegExpObject::RegExpCacheKey>, std::equal_to<RegExpObject::RegExpCacheKey>,
-                           gc_allocator<std::pair<const RegExpObject::RegExpCacheKey, RegExpObject::RegExpCacheEntry>>>
+                           GCUtil::gc_malloc_allocator<std::pair<const RegExpObject::RegExpCacheKey, RegExpObject::RegExpCacheEntry>>>
     RegExpCacheMap;
 }
 

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -638,7 +638,6 @@ public:
 
     const size_t dtoaCacheSize; // 5;
     mutable Vector<std::pair<double, ::Escargot::String*>, GCUtil::gc_malloc_allocator<std::pair<double, ::Escargot::String*>>> dtoaCache;
-    //mutable std::list<std::pair<double, ::Escargot::String*>, GCUtil::gc_malloc_allocator<std::pair<double, ::Escargot::String*>>> dtoaCache;
 
     ::Escargot::String* dtoa(double d) const;
 };

--- a/src/runtime/StringBuilder.h
+++ b/src/runtime/StringBuilder.h
@@ -109,7 +109,7 @@ private:
     size_t m_piecesInlineStorageUsage;
     size_t m_contentLength;
     StringBuilderPiece m_piecesInlineStorage[STRING_BUILDER_INLINE_STORAGE_MAX];
-    Vector<StringBuilderPiece, GCUtil::gc_malloc_allocator<StringBuilderPiece>, 200> m_pieces;
+    Vector<StringBuilderPiece, GCUtil::gc_malloc_allocator<StringBuilderPiece>> m_pieces;
 };
 }
 

--- a/src/runtime/ToStringRecursionPreventer.h
+++ b/src/runtime/ToStringRecursionPreventer.h
@@ -28,6 +28,8 @@
 namespace Escargot {
 
 class ToStringRecursionPreventer : public gc {
+    friend class VMInstance;
+
 public:
     void pushItem(Object* obj)
     {

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -74,6 +74,9 @@ public:
     VMInstance(Platform* platform, const char* locale = nullptr, const char* timezone = nullptr);
     ~VMInstance();
 
+    void* operator new(size_t size);
+    void* operator new[](size_t size) = delete;
+
     void clearCaches();
 
     const GlobalSymbols& globalSymbols()
@@ -143,11 +146,6 @@ public:
     // [name, length] or [prototype, name, length]
     static Value functionPrototypeNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
     static bool functionPrototypeNativeSetter(ExecutionState& state, Object* self, SmallValue& privateDataFromObjectPrivateArea, const Value& setterInputData);
-
-    // array
-    // [length]
-    static Value arrayLengthNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
-    static bool arrayLengthNativeSetter(ExecutionState& state, Object* self, SmallValue& privateDataFromObjectPrivateArea, const Value& setterInputData);
 
     // string
     // [length]
@@ -238,7 +236,6 @@ private:
     ObjectStructure* m_defaultStructureForFunctionPrototypeObject;
     ObjectStructure* m_defaultStructureForBoundFunctionObject;
     ObjectStructure* m_defaultStructureForClassConstructorFunctionObject;
-    ObjectStructure* m_defaultStructureForArrayObject;
     ObjectStructure* m_defaultStructureForStringObject;
     ObjectStructure* m_defaultStructureForSymbolObject;
     ObjectStructure* m_defaultStructureForRegExpObject;
@@ -256,7 +253,7 @@ private:
 
     // regexp object data
     WTF::BumpPointerAllocator* m_bumpPointerAllocator;
-    RegExpCacheMap m_regexpCache;
+    RegExpCacheMap* m_regexpCache;
 
 // date object data
 #ifdef ENABLE_ICU

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -48,7 +48,7 @@ inline void clearStack()
 
 class StorePositiveIntergerAsOdd {
 public:
-    StorePositiveIntergerAsOdd(const size_t& src)
+    StorePositiveIntergerAsOdd(const size_t& src = 0)
     {
         ASSERT(src < std::numeric_limits<size_t>::max() / 2);
         m_data = (src << 1) | 0x1;


### PR DESCRIPTION
* Store array length property in its member variable not value vector
  - This can reduce one of GC_MALLOC call if there is not value in ArrayObject other than fastmode value
* Prevent memory leak from VMInstance, Context
* Change vector capacity reserve strategy

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>