### PR TITLE
Implement compress CompressibleStrings on GC reclaim end event

### DIFF
--- a/build/config.cmake
+++ b/build/config.cmake
@@ -98,6 +98,10 @@ IF (${ESCARGOT_HOST} STREQUAL "android")
     SET (ESCARGOT_LIBICU_SUPPORT OFF)
 ENDIF()
 
+#######################################################
+# FLAGS FOR ADDITIONAL FUNCTION
+#######################################################
+
 FIND_PACKAGE (PkgConfig REQUIRED)
 IF (${ESCARGOT_LIBICU_SUPPORT} STREQUAL "ON")
     IF (${ESCARGOT_LIBICU_SUPPORT_WITH_DLOPEN} STREQUAL "ON")
@@ -126,6 +130,8 @@ IF (${ESCARGOT_HOST} STREQUAL "tizen_obs")
     SET (ESCARGOT_INCDIRS ${ESCARGOT_INCDIRS} ${DLOG_INCLUDE_DIRS})
     SET (ESCARGOT_CXXFLAGS ${ESCARGOT_CXXFLAGS} ${DLOG_CFLAGS_OTHER})
 ENDIF()
+
+SET (ESCARGOT_DEFINITIONS ${ESCARGOT_DEFINITIONS} -DENABLE_COMPRESSIBLE_STRING)
 
 #######################################################
 # flags for $(MODE) : debug/release

--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -328,16 +328,101 @@ StringRef* StringRef::createExternalFromUTF16(const char16_t* s, size_t len)
     return toRef(new UTF16String(s, len, String::FromExternalMemory));
 }
 
-#if defined(ENABLE_SOURCE_COMPRESSION)
-StringRef* StringRef::createFromUTF8ToCompressibleString(const char* s, size_t len)
+bool StringRef::isCompressibleStringEnabled()
 {
-    return toRef(String::fromUTF8ToCompressibleString(s, len));
+#if defined(ENABLE_COMPRESSIBLE_STRING)
+    return true;
+#else
+    return false;
+#endif
 }
 
-StringRef* StringRef::createCompressibleString(const unsigned char* s, size_t len)
+#if defined(ENABLE_COMPRESSIBLE_STRING)
+StringRef* StringRef::createFromUTF8ToCompressibleString(ContextRef* context, const char* s, size_t len)
 {
-    return toRef(new CompressibleString(s, len));
+    return toRef(String::fromUTF8ToCompressibleString(toImpl(context), s, len));
 }
+
+StringRef* StringRef::createFromUTF16ToCompressibleString(ContextRef* context, const char16_t* s, size_t len)
+{
+    return toRef(new CompressibleString(toImpl(context), s, len));
+}
+
+StringRef* StringRef::createFromASCIIToCompressibleString(ContextRef* context, const char* s, size_t len)
+{
+    return toRef(new CompressibleString(toImpl(context), s, len));
+}
+
+StringRef* StringRef::createFromLatin1ToCompressibleString(ContextRef* context, const unsigned char* s, size_t len)
+{
+    return toRef(new CompressibleString(toImpl(context), s, len));
+}
+
+void* StringRef::allocateStringDataBufferForCompressibleString(size_t byteLength)
+{
+    return CompressibleString::allocateStringDataBuffer(byteLength);
+}
+
+void StringRef::deallocateStringDataBufferForCompressibleString(void* ptr)
+{
+    CompressibleString::deallocateStringDataBuffer(ptr);
+}
+
+StringRef* StringRef::createFromAlreadyAllocatedBufferToCompressibleString(ContextRef* context, void* buffer, size_t stringLen, bool is8Bit)
+{
+    return toRef(new CompressibleString(toImpl(context), buffer, stringLen, is8Bit));
+}
+
+#else
+StringRef* StringRef::createFromUTF8ToCompressibleString(ContextRef* context, const char* s, size_t len)
+{
+    ESCARGOT_LOG_ERROR("If you want to use this function, you should enable source compression");
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+StringRef* StringRef::createCompressibleString(ContextRef* context, const unsigned char* s, size_t len)
+{
+    ESCARGOT_LOG_ERROR("If you want to use this function, you should enable source compression");
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+StringRef* StringRef::createFromASCIIToCompressibleString(ContextRef* context, const char* s, size_t len)
+{
+    ESCARGOT_LOG_ERROR("If you want to use this function, you should enable source compression");
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+StringRef* StringRef::createFromLatin1ToCompressibleString(ContextRef* context, const unsigned char* s, size_t len)
+{
+    ESCARGOT_LOG_ERROR("If you want to use this function, you should enable source compression");
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void* StringRef::allocateStringDataBufferForCompressibleString(size_t byteLength)
+{
+    ESCARGOT_LOG_ERROR("If you want to use this function, you should enable source compression");
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void StringRef::deallocateStringDataBufferForCompressibleString(void* ptr)
+{
+    ESCARGOT_LOG_ERROR("If you want to use this function, you should enable source compression");
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+StringRef* StringRef::createFromAlreadyAllocatedBufferToCompressibleString(ContextRef* context, void* buffer, size_t stringLen, bool is8Bit)
+{
+    ESCARGOT_LOG_ERROR("If you want to use this function, you should enable source compression");
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
 #endif
 
 StringRef* StringRef::emptyString()

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -774,10 +774,16 @@ public:
     static StringRef* createExternalFromLatin1(const unsigned char* s, size_t len);
     static StringRef* createExternalFromUTF16(const char16_t* s, size_t len);
 
-#if defined(ENABLE_SOURCE_COMPRESSION)
-    static StringRef* createFromUTF8ToCompressibleString(const char* s, size_t len);
-    static StringRef* createCompressibleString(const unsigned char* s, size_t len);
-#endif
+    // you can use these functions only if you enabled source compression
+    // you don't need to use CompressibleString when string is small(~128KB)
+    static bool isCompressibleStringEnabled();
+    static StringRef* createFromUTF8ToCompressibleString(ContextRef* context, const char* s, size_t len);
+    static StringRef* createFromUTF16ToCompressibleString(ContextRef* context, const char16_t* s, size_t len);
+    static StringRef* createFromASCIIToCompressibleString(ContextRef* context, const char* s, size_t len);
+    static StringRef* createFromLatin1ToCompressibleString(ContextRef* context, const unsigned char* s, size_t len);
+    static void* allocateStringDataBufferForCompressibleString(size_t byteLength);
+    static void deallocateStringDataBufferForCompressibleString(void* ptr);
+    static StringRef* createFromAlreadyAllocatedBufferToCompressibleString(ContextRef* context, void* buffer, size_t stringLen, bool is8Bit /* is ASCII or Latin1 */);
 
     static StringRef* emptyString();
 
@@ -789,7 +795,7 @@ public:
 
     std::string toStdUTF8String();
 
-    // don't store this sturct
+    // don't store this sturct or string buffer
     // this is only for temporary access
     struct StringBufferAccessDataRef {
         bool has8BitContent;

--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -20,6 +20,8 @@
 #ifndef __EscargotASTBuilder__
 #define __EscargotASTBuilder__
 
+#include "parser/ParserStringView.h"
+
 namespace Escargot {
 
 #define FOR_EACH_TARGET_NODE(F)               \
@@ -565,12 +567,12 @@ public:
         return SyntaxNode(CallExpression);
     }
 
-    void setValueStringLiteral(const StringView& string)
+    void setValueStringLiteral(const ParserStringView& string)
     {
         m_valueStringLiteral = string;
     }
 
-    StringView& getValueStringLiteral()
+    const ParserStringView& valueStringLiteral()
     {
         return m_valueStringLiteral;
     }
@@ -581,14 +583,14 @@ public:
         if (key.type() == Identifier) {
             return key.name() == value;
         } else if (key.type() == Literal) {
-            return getValueStringLiteral().equals(value);
+            return valueStringLiteral().equals(value);
         }
 
         return false;
     }
 
 private:
-    StringView m_valueStringLiteral; // for StringLiteralNode (valueStringLiteral method)
+    ParserStringView m_valueStringLiteral; // for StringLiteralNode (valueStringLiteral method)
 };
 
 class NodeGenerator {
@@ -753,7 +755,7 @@ public:
         return new (m_allocator) CallExpressionNode(taggedTemplateExpression->expr(), args);
     }
 
-    void setValueStringLiteral(const StringView& string)
+    void setValueStringLiteral(const ParserStringView& string)
     {
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/src/runtime/AtomicString.cpp
+++ b/src/runtime/AtomicString.cpp
@@ -112,6 +112,15 @@ void AtomicString::init(AtomicStringMap* ec, String* name)
 
     auto iter = ec->find(name);
     if (ec->end() == iter) {
+        if (name->isStringView()) {
+            auto buffer = name->bufferAccessData();
+            if (buffer.has8BitContent) {
+                name = new Latin1String((const char*)buffer.buffer, buffer.length);
+            } else {
+                name = new UTF16String((const char16_t*)buffer.buffer, buffer.length);
+            }
+        }
+        ASSERT(!name->isStringView());
         ec->insert(name);
         ASSERT(ec->find(name) != ec->end());
         m_string = name;

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -88,7 +88,7 @@ public:
         return true;
     }
 
-    const StringBufferAccessData& bufferAccessData() const
+    StringBufferAccessData bufferAccessData() const
     {
         return m_string->bufferAccessData();
     }

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -52,6 +52,7 @@ struct ObjectRareData : public PointerValue {
     bool m_isSpreadArrayObject : 1;
     bool m_shouldUpdateEnumerateObject : 1; // used only for Array Object when ArrayObject::deleteOwnProperty called
     bool m_hasNonWritableLastIndexRegexpObject : 1;
+    uint8_t m_arrayObjectFastModeBufferExpandCount : 8;
     void* m_extraData;
     Object* m_prototype;
     union {

--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -110,20 +110,23 @@ void* RegExpObject::operator new(size_t size)
 
 static String* escapeSlashInPattern(String* patternStr)
 {
-    if (patternStr->length() == 0)
+    if (patternStr->length() == 0) {
         return patternStr;
+    }
 
-    size_t len = patternStr->length();
+    auto accessData = patternStr->bufferAccessData();
+
+    const size_t& len = accessData.length;
     bool slashFlag = false;
     size_t i, start = 0;
     StringBuilder builder;
     while (true) {
         for (i = 0; start + i < len; i++) {
-            if (UNLIKELY(patternStr->charAt(start + i) == '/') && i > 0) {
+            if (UNLIKELY(accessData.charAt(start + i) == '/') && i > 0) {
                 size_t backSlashCount = 0;
                 size_t s = start + i - 1;
                 while (true) {
-                    if (patternStr->charAt(s) == '\\') {
+                    if (accessData.charAt(s) == '\\') {
                         backSlashCount++;
                         if (s == 0) {
                             break;
@@ -153,10 +156,11 @@ static String* escapeSlashInPattern(String* patternStr)
             break;
         }
     }
-    if (!slashFlag)
+    if (!slashFlag) {
         return patternStr;
-    else
+    } else {
         return builder.finalize();
+    }
 }
 
 void RegExpObject::internalInit(ExecutionState& state, String* source)
@@ -224,8 +228,9 @@ void RegExpObject::parseOption(ExecutionState& state, const String* optionString
 {
     this->m_option = RegExpObject::Option::None;
 
-    for (size_t i = 0; i < optionString->length(); i++) {
-        switch (optionString->charAt(i)) {
+    auto bufferAccessData = optionString->bufferAccessData();
+    for (size_t i = 0; i < bufferAccessData.length; i++) {
+        switch (bufferAccessData.charAt(i)) {
         case 'g':
             if (this->m_option & Option::Global)
                 ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "RegExp has multiple 'g' flags");

--- a/src/runtime/RopeString.h
+++ b/src/runtime/RopeString.h
@@ -32,10 +32,10 @@ public:
         : String()
     {
         m_left = String::emptyString;
-        m_bufferAccessData.has8BitContent = true;
-        m_bufferAccessData.hasSpecialImpl = true;
-        m_bufferAccessData.length = 0;
-        m_bufferAccessData.buffer = nullptr;
+        m_bufferData.has8BitContent = true;
+        m_bufferData.hasSpecialImpl = true;
+        m_bufferData.length = 0;
+        m_bufferData.buffer = nullptr;
     }
 
     // this function not always create RopeString.
@@ -44,40 +44,38 @@ public:
     // provide ExecutionState if you need limit of string length(exception can be thrown only in ExecutionState area)
     static String* createRopeString(String* lstr, String* rstr, ExecutionState* state = nullptr);
 
-    virtual char16_t charAt(const size_t idx) const
-    {
-        return bufferAccessData().charAt(idx);
-    }
-    virtual UTF16StringData toUTF16StringData() const;
-    virtual UTF8StringData toUTF8StringData() const;
-    virtual UTF8StringDataNonGCStd toNonGCUTF8StringData() const;
+    virtual UTF16StringData toUTF16StringData() const override;
+    virtual UTF8StringData toUTF8StringData() const override;
+    virtual UTF8StringDataNonGCStd toNonGCUTF8StringData() const override;
 
-    virtual bool isRopeString()
+    virtual bool isRopeString() override
     {
         return true;
     }
 
-    virtual const LChar* characters8() const
+    virtual const LChar* characters8() const override
     {
         return (const LChar*)bufferAccessData().buffer;
     }
 
-    virtual const char16_t* characters16() const
+    virtual const char16_t* characters16() const override
     {
         return (const char16_t*)bufferAccessData().buffer;
-    }
-
-    virtual void bufferAccessDataSpecialImpl()
-    {
-        ASSERT(m_bufferAccessData.hasSpecialImpl);
-        flattenRopeString();
-        ASSERT(!m_bufferAccessData.hasSpecialImpl);
     }
 
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 
 protected:
+    virtual StringBufferAccessData bufferAccessDataSpecialImpl() override
+    {
+        ASSERT(m_bufferData.hasSpecialImpl);
+        flattenRopeString();
+        ASSERT(!m_bufferData.hasSpecialImpl);
+
+        return m_bufferData;
+    }
+
     template <typename ResultType>
     void flattenRopeStringWorker();
     void flattenRopeString();

--- a/src/runtime/StringView.cpp
+++ b/src/runtime/StringView.cpp
@@ -28,7 +28,7 @@ void* StringView::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(StringView)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringView, m_string));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringView, m_bufferData.bufferAsString));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(StringView));
         typeInited = true;
     }

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -37,6 +37,7 @@ class CodeBlock;
 class JobQueue;
 class Job;
 class ASTAllocator;
+class CompressibleString;
 
 #define DEFINE_GLOBAL_SYMBOLS(F) \
     F(hasInstance)               \
@@ -179,6 +180,18 @@ public:
         return m_compiledByteCodeSize;
     }
 
+#if defined(ENABLE_COMPRESSIBLE_STRING)
+    std::vector<CompressibleString*>& compressibleStrings()
+    {
+        return m_compressibleStrings;
+    }
+
+    size_t& compressibleStringsUncomressedBufferSize()
+    {
+        return m_compressibleStringsUncomressedBufferSize;
+    }
+#endif
+
     std::mt19937& randEngine()
     {
         return m_randEngine;
@@ -193,6 +206,17 @@ public:
     {
         return m_currentSandBox;
     }
+
+    void* stackStartAddress()
+    {
+        return m_stackStartAddress;
+    }
+
+    ASCIIString** regexpOptionStringCache()
+    {
+        return m_regexpOptionStringCache;
+    }
+
 
     void setOnDestroyCallback(void (*onVMInstanceDestroy)(VMInstance* instance, void* data), void* data)
     {
@@ -229,15 +253,26 @@ private:
     std::vector<ByteCodeBlock*> m_compiledByteCodeBlocks;
     size_t m_compiledByteCodeSize;
 
+#if defined(ENABLE_COMPRESSIBLE_STRING)
+    uint64_t m_lastCompressibleStringsTestTime;
+    size_t m_compressibleStringsUncomressedBufferSize;
+    std::vector<CompressibleString*> m_compressibleStrings;
+
+    NEVER_INLINE void compressStringsIfNeeds(uint64_t currentTickCount = fastTickCount());
+#endif
+
     static void gcEventCallback(GC_EventType t, void* data);
     void (*m_onVMInstanceDestroy)(VMInstance* instance, void* data);
     void* m_onVMInstanceDestroyData;
 
     ToStringRecursionPreventer m_toStringRecursionPreventer;
 
+    void* m_stackStartAddress;
+
     // regexp object data
     WTF::BumpPointerAllocator* m_bumpPointerAllocator;
     RegExpCacheMap* m_regexpCache;
+    ASCIIString** m_regexpOptionStringCache;
 
 // date object data
 #ifdef ENABLE_ICU

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -101,6 +101,17 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
 
 namespace Escargot {
 
+uint64_t fastTickCount()
+{
+#if defined(CLOCK_MONOTONIC_COARSE)
+    timespec ts;
+    clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
+    return ts.tv_sec * 1000UL + ts.tv_nsec / 1000000UL;
+#else
+    return tickCount();
+#endif
+}
+
 uint64_t tickCount()
 {
     struct timeval gettick;

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -46,6 +46,21 @@ inline void clearStack()
 #error
 #endif
 
+#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
+inline void* currentStackPointer()
+{
+    return __builtin_frame_address(0);
+}
+#elif defined(COMPILER_MSVC)
+inline void* currentStackPointer()
+{
+    volatile int temp;
+    return &temp;
+}
+#else
+#error
+#endif
+
 class StorePositiveIntergerAsOdd {
 public:
     StorePositiveIntergerAsOdd(const size_t& src = 0)
@@ -63,6 +78,7 @@ private:
     size_t m_data;
 };
 
+uint64_t fastTickCount(); // increase 1000 by 1 second(fast version. not super accurate)
 uint64_t tickCount(); // increase 1000 by 1 second
 uint64_t longTickCount(); // increase 1000000 by 1 second
 uint64_t timestamp(); // increase 1000 by 1 second

--- a/src/util/Vector.h
+++ b/src/util/Vector.h
@@ -69,15 +69,34 @@ struct ComputeReservedCapacityFunctionWithPercent {
     }
 };
 
-template <size_t glowFactor = 125, size_t maxGap = 256>
+template <size_t glowFactor = 125, size_t maxGap = 512>
 struct ComputeReservedCapacityFunctionWithPercentAndGap {
     size_t operator()(size_t newSize)
     {
         size_t newCapacity = newSize * (glowFactor / 100.f);
-        if (newCapacity - glowFactor > maxGap) {
+        if ((newCapacity - newSize) > maxGap) {
             newCapacity = newSize + maxGap;
         }
         return newCapacity;
+    }
+};
+
+template <size_t glowFactor = 125>
+struct ComputeReservedCapacityFunctionWithLog2AndPercent {
+    size_t operator()(size_t newSize)
+    {
+        if (newSize == 0) {
+            return 0;
+        }
+
+        if (newSize <= 32) {
+            ComputeReservedCapacityFunctionWithLog2<> f1;
+            return f1(newSize);
+        }
+
+        ComputeReservedCapacityFunctionWithLog2<> f1;
+        ComputeReservedCapacityFunctionWithPercentAndGap<> f2;
+        return std::min(f1(newSize), f2(newSize));
     }
 };
 

--- a/third_party/lz4/lz4.cpp
+++ b/third_party/lz4/lz4.cpp
@@ -32,7 +32,7 @@
     - LZ4 source repository : https://github.com/lz4/lz4
 */
 
-#if defined(ENABLE_SOURCE_COMPRESSION)
+#if defined(ENABLE_COMPRESSIBLE_STRING)
 
 /*-************************************
 *  Tuning parameters

--- a/third_party/lz4/lz4.h
+++ b/third_party/lz4/lz4.h
@@ -33,7 +33,7 @@
     - LZ4 source repository : https://github.com/lz4/lz4
 */
 
-#if defined(ENABLE_SOURCE_COMPRESSION)
+#if defined(ENABLE_COMPRESSIBLE_STRING)
 
 #if defined(__cplusplus)
 extern "C" {

--- a/third_party/runtime_icu_binder/RuntimeICUBinder.cpp
+++ b/third_party/runtime_icu_binder/RuntimeICUBinder.cpp
@@ -192,6 +192,28 @@ static char *timeValueFromFile(const char *filename, const char *tag, char *valu
 }
 #endif
 
+static std::string extractLocaleName(std::string input)
+{
+    if (input.find('.') != std::string::npos) {
+        input = input.substr(0, input.find('.'));
+    }
+    return input;
+}
+
+
+std::string ICU::findSystemLocale()
+{
+    char* c = getenv("LANG");
+    if (c && strlen(c)) {
+        return extractLocaleName(c);
+    }
+    c = setlocale(LC_CTYPE, "");
+    if (c && strlen(c)) {
+        return extractLocaleName(c);
+    }
+    return ICU::instance().uloc_getDefault();
+}
+
 std::string ICU::findSystemTimezoneName()
 {
 #if defined(OS_POSIX)

--- a/third_party/runtime_icu_binder/RuntimeICUBinder.h
+++ b/third_party/runtime_icu_binder/RuntimeICUBinder.h
@@ -167,6 +167,7 @@ private:
 
 public:
     static ICU& instance();
+    static std::string findSystemLocale();
     static std::string findSystemTimezoneName();
 
     enum Soname {


### PR DESCRIPTION
* Compress CompressibleStrings on GC reclaim end event
  - if there is reference about data of CompressibleString on stack, we should give up compressing.
    we don't need to search heap space because I redesigned StringView
    (we should not store string buffer data on heap without owner)
* Redesign StringView
  - Don't save string buffer address as its member. because buffer of CompressibleString can be deleted
  - If we don't save string buffer address on StringView, parser performance may dropped.
    becuase parser access string data a lot.
    so I introduce ParserStringView. it saves buffer address. we should ParserStringView on parser only.
    we can save string buffer address while parsing. because GC is disabled while parsing.

* Enable CompressibleString always
* Implement cache of RegExpOptionStrings
* Implement finding system locale function on RuntimeICUBinder avoiding call uloc_getDefault.

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>