### PR TITLE
Optimize `function.apply(<any>, arguments)` case.

### DIFF
--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -429,14 +429,12 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_resultIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
             }
-            case CallEvalFunctionOpcode: {
-                CallEvalFunction* cd = (CallEvalFunction*)currentCode;
-                ASSIGN_STACKINDEX_IF_NEEDED(cd->m_argumentsStartIndex, stackBase, stackBaseWillBe, stackVariableSize);
-                ASSIGN_STACKINDEX_IF_NEEDED(cd->m_resultIndex, stackBase, stackBaseWillBe, stackVariableSize);
-                break;
-            }
-            case CallFunctionInWithScopeOpcode: {
-                CallFunctionInWithScope* cd = (CallFunctionInWithScope*)currentCode;
+            case CallFunctionComplexCaseOpcode: {
+                CallFunctionComplexCase* cd = (CallFunctionComplexCase*)currentCode;
+                if (cd->m_kind != CallFunctionComplexCase::InWithScope) {
+                    ASSIGN_STACKINDEX_IF_NEEDED(cd->m_receiverIndex, stackBase, stackBaseWillBe, stackVariableSize);
+                    ASSIGN_STACKINDEX_IF_NEEDED(cd->m_calleeIndex, stackBase, stackBaseWillBe, stackVariableSize);
+                }
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_argumentsStartIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_resultIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
@@ -555,14 +553,6 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_resultIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
             }
-            case CallFunctionWithSpreadElementOpcode: {
-                CallFunctionWithSpreadElement* cd = (CallFunctionWithSpreadElement*)currentCode;
-                ASSIGN_STACKINDEX_IF_NEEDED(cd->m_receiverIndex, stackBase, stackBaseWillBe, stackVariableSize);
-                ASSIGN_STACKINDEX_IF_NEEDED(cd->m_calleeIndex, stackBase, stackBaseWillBe, stackVariableSize);
-                ASSIGN_STACKINDEX_IF_NEEDED(cd->m_argumentsStartIndex, stackBase, stackBaseWillBe, stackVariableSize);
-                ASSIGN_STACKINDEX_IF_NEEDED(cd->m_resultIndex, stackBase, stackBaseWillBe, stackVariableSize);
-                break;
-            }
             case CreateClassOpcode: {
                 CreateClass* cd = (CreateClass*)currentCode;
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_classConstructorRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
@@ -587,12 +577,6 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_objectRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_loadRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_propertyNameIndex, stackBase, stackBaseWillBe, stackVariableSize);
-                break;
-            }
-            case CallSuperOpcode: {
-                CallSuper* cd = (CallSuper*)currentCode;
-                ASSIGN_STACKINDEX_IF_NEEDED(cd->m_argumentsStartIndex, stackBase, stackBaseWillBe, stackVariableSize);
-                ASSIGN_STACKINDEX_IF_NEEDED(cd->m_resultIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
             }
             case LoadThisBindingOpcode: {

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -36,14 +36,12 @@ struct GetObjectInlineCache;
 struct SetObjectInlineCache;
 struct GlobalVariableAccessCacheItem;
 class InitializeGlobalVariable;
-class CallFunctionInWithScope;
-class CallEvalFunction;
+class CallFunctionComplexCase;
 class CreateFunction;
 class CreateClass;
 class SuperReference;
 class SuperSetObjectOperation;
 class SuperGetObjectOperation;
-class CallSuper;
 class WithOperation;
 class BlockOperation;
 class ReplaceBlockLexicalEnvironmentOperation;
@@ -109,17 +107,15 @@ public:
 
     static void createFunctionOperation(ExecutionState& state, CreateFunction* createFunction, ByteCodeBlock* byteCodeBlock, Value* registerFile);
     static ArrayObject* createRestElementOperation(ExecutionState& state, ByteCodeBlock* byteCodeBlock);
-    static void evalOperation(ExecutionState& state, CallEvalFunction* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void classOperation(ExecutionState& state, CreateClass* code, Value* registerFile);
     static void superOperation(ExecutionState& state, SuperReference* code, Value* registerFile);
     static void superSetObjectOperation(ExecutionState& state, SuperSetObjectOperation* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static Value superGetObjectOperation(ExecutionState& state, SuperGetObjectOperation* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
-    static void callSuperOperation(ExecutionState& state, CallSuper* code, Value* registerFile);
     static Value withOperation(ExecutionState*& state, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
     static Value blockOperation(ExecutionState*& state, BlockOperation* code, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
     static void replaceBlockLexicalEnvironmentOperation(ExecutionState& state, size_t programCounter, ByteCodeBlock* byteCodeBlock);
     static bool binaryInOperation(ExecutionState& state, const Value& left, const Value& right);
-    static void callFunctionInWithScope(ExecutionState& state, CallFunctionInWithScope* code, Value* registerFile);
+    static void callFunctionComplexCase(ExecutionState& state, CallFunctionComplexCase* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void spreadFunctionArguments(ExecutionState& state, const Value* argv, const size_t argc, ValueVector& argVector);
 
     static EnumerateObject* createEnumerateObject(ExecutionState& state, Object* obj, bool isDestruction);

--- a/src/runtime/ArrayBufferObject.cpp
+++ b/src/runtime/ArrayBufferObject.cpp
@@ -46,6 +46,17 @@ void ArrayBufferObject::allocateBuffer(ExecutionState& state, size_t bytelength)
 {
     ASSERT(isDetachedBuffer());
 
+    const size_t ratio = std::max((size_t)GC_get_free_space_divisor() / 6, (size_t)1);
+    if (bytelength > (GC_get_heap_size() / ratio)) {
+        size_t n = 0;
+        size_t times = bytelength / (GC_get_heap_size() / ratio) / 3;
+        do {
+            GC_gcollect_and_unmap();
+            n += 1;
+        } while (n < times);
+        GC_invoke_finalizers();
+    }
+
     m_data = (uint8_t*)m_context->vmInstance()->platform()->onArrayBufferObjectDataBufferMalloc(m_context, this, bytelength);
     m_bytelength = bytelength;
 }

--- a/src/runtime/EnvironmentRecord.h
+++ b/src/runtime/EnvironmentRecord.h
@@ -755,6 +755,19 @@ public:
         return functionObject()->homeObject();
     }
 
+    Optional<ArgumentsObject*> argumentsObject()
+    {
+        if (m_argumentsObject->isArgumentsObject()) {
+            return m_argumentsObject;
+        }
+        return nullptr;
+    }
+
+    ArgumentsObject* uncheckedArgumentsObject()
+    {
+        return m_argumentsObject;
+    }
+
     FunctionObject* functionObject()
     {
         if (m_argumentsObject->isArgumentsObject()) {

--- a/src/runtime/ExecutionState.cpp
+++ b/src/runtime/ExecutionState.cpp
@@ -60,6 +60,18 @@ FunctionObject* ExecutionState::resolveCallee()
     return nullptr;
 }
 
+LexicalEnvironment* ExecutionState::mostNearestFunctionLexicalEnvironment()
+{
+    ExecutionState* es = this;
+    while (true) {
+        if (es->lexicalEnvironment()->record()->isDeclarativeEnvironmentRecord() && es->lexicalEnvironment()->record()->asDeclarativeEnvironmentRecord()->isFunctionEnvironmentRecord()) {
+            break;
+        }
+        es = es->parent();
+    }
+    return es->lexicalEnvironment();
+}
+
 LexicalEnvironment* ExecutionState::mostNearestHeapAllocatedLexicalEnvironment()
 {
     LexicalEnvironment* env = m_lexicalEnvironment;

--- a/src/runtime/ExecutionState.h
+++ b/src/runtime/ExecutionState.h
@@ -261,6 +261,7 @@ public:
         return m_argv;
     }
 
+    LexicalEnvironment* mostNearestFunctionLexicalEnvironment();
     LexicalEnvironment* mostNearestHeapAllocatedLexicalEnvironment();
 
     // http://www.ecma-international.org/ecma-262/6.0/#sec-getnewtarget

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -264,6 +264,10 @@ public:
     {
         return m_functionPrototype;
     }
+    FunctionObject* functionApply()
+    {
+        return m_functionApply;
+    }
 
     FunctionObject* error()
     {
@@ -701,6 +705,7 @@ private:
 
     FunctionObject* m_function;
     FunctionObject* m_functionPrototype;
+    FunctionObject* m_functionApply;
 
     Object* m_iteratorPrototype;
 

--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -226,8 +226,9 @@ void GlobalObject::installFunction(ExecutionState& state)
     m_functionPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().toString),
                                                           ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().toString, builtinFunctionToString, 0, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
+    m_functionApply = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().apply, builtinFunctionApply, 2, NativeFunctionInfo::Strict));
     m_functionPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().apply),
-                                                          ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().apply, builtinFunctionApply, 2, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
+                                                          ObjectPropertyDescriptor(m_functionApply, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_functionPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().call),
                                                           ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().call, builtinFunctionCall, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -170,12 +170,19 @@ static OptionalRef<StringRef> builtinHelperFileRead(OptionalRef<ExecutionStateRe
             }
         }
         fclose(fp);
-#if defined(ENABLE_COMPRESSIBLE_STRING)
-        if (state) {
-            if (hasNonLatin1Content) {
-                src = StringRef::createFromUTF8ToCompressibleString(state->context(), utf8Str.data(), utf8Str.length());
+        if (StringRef::isCompressibleStringEnabled()) {
+            if (state) {
+                if (hasNonLatin1Content) {
+                    src = StringRef::createFromUTF8ToCompressibleString(state->context(), utf8Str.data(), utf8Str.length());
+                } else {
+                    src = StringRef::createFromLatin1ToCompressibleString(state->context(), str.data(), str.length());
+                }
             } else {
-                src = StringRef::createFromLatin1ToCompressibleString(state->context(), str.data(), str.length());
+                if (hasNonLatin1Content) {
+                    src = StringRef::createFromUTF8(utf8Str.data(), utf8Str.length());
+                } else {
+                    src = StringRef::createFromLatin1(str.data(), str.length());
+                }
             }
         } else {
             if (hasNonLatin1Content) {
@@ -184,13 +191,6 @@ static OptionalRef<StringRef> builtinHelperFileRead(OptionalRef<ExecutionStateRe
                 src = StringRef::createFromLatin1(str.data(), str.length());
             }
         }
-#else
-        if (hasNonLatin1Content) {
-            src = StringRef::createFromUTF8(utf8Str.data(), utf8Str.length());
-        } else {
-            src = StringRef::createFromLatin1(str.data(), str.length());
-        }
-#endif
         return src;
     } else {
         char msg[1024];


### PR DESCRIPTION
* Many JS Frameworks or librarys use `function.apply(<any>, arguments)` pattern.
  but this statement generate arguments object. generateing arguments object is very expensive.
  we can optimize simple cases like `function() {  fn.apply(this, arguments); }`
* Merge many ByteCode opcodes into CallFunctionComplexCase.
* Do gc when allocate large ArrayBuferObject

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>