### PR TITLE
Update Iterator Binding

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -122,6 +122,7 @@ struct GlobalVariableAccessCacheItem;
     F(GetIterator, 1, 0)                                    \
     F(IteratorStep, 1, 0)                                   \
     F(IteratorClose, 1, 0)                                  \
+    F(IteratorBind, 1, 0)                                   \
     F(LoadRegexp, 1, 0)                                     \
     F(WithOperation, 0, 0)                                  \
     F(ObjectDefineGetterSetter, 0, 0)                       \
@@ -2099,6 +2100,32 @@ public:
 #endif
 
     ByteCodeRegisterIndex m_iterRegisterIndex;
+};
+
+class IteratorBind : public ByteCode {
+public:
+    explicit IteratorBind(const ByteCodeLOC& loc)
+        : ByteCode(Opcode::IteratorBindOpcode, loc)
+    {
+        m_registerIndex = m_iterRegisterIndex = REGISTER_LIMIT;
+    }
+
+    explicit IteratorBind(const ByteCodeLOC& loc, size_t dstIndex, size_t iterIndex)
+        : ByteCode(Opcode::IteratorBindOpcode, loc)
+        , m_registerIndex(dstIndex)
+        , m_iterRegisterIndex(iterIndex)
+    {
+    }
+
+    ByteCodeRegisterIndex m_registerIndex;
+    ByteCodeRegisterIndex m_iterRegisterIndex;
+
+#ifndef NDEBUG
+    void dump(const char* byteCodeStart)
+    {
+        printf("iterator bind(r%d) -> r%d", (int)m_iterRegisterIndex, (int)m_registerIndex);
+    }
+#endif
 };
 
 class LoadRegexp : public ByteCode {

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -504,6 +504,11 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_iterRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
             }
+            case IteratorBindOpcode: {
+                IteratorBind* cd = (IteratorBind*)currentCode;
+                ASSIGN_STACKINDEX_IF_NEEDED(cd->m_iterRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
+                break;
+            }
             case BindingRestElementOpcode: {
                 BindingRestElement* cd = (BindingRestElement*)currentCode;
                 ASSIGN_STACKINDEX_IF_NEEDED(cd->m_iterOrEnumIndex, stackBase, stackBaseWillBe, stackVariableSize);

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -2832,7 +2832,7 @@ NEVER_INLINE Value ByteCodeInterpreter::executionPauseOperation(ExecutionState& 
     } else if (code->m_reason == ExecutionPause::YieldDelegate) {
         // http://www.ecma-international.org/ecma-262/6.0/#sec-generator-function-definitions-runtime-semantics-evaluation
         const Value iteratorRecord = registerFile[code->m_yieldDelegateData.m_iterIntex];
-        Object* iterator = iteratorRecord.asPointerValue()->asIteratorRecord()->iterator().toObject(state);
+        Object* iterator = iteratorRecord.asObject()->getOwnProperty(state, state.context()->staticStrings().iterator).value(state, iteratorRecord).asObject();
         GeneratorState resultState = GeneratorState::SuspendedYield;
         Value nextResult;
         bool done = true;
@@ -3289,7 +3289,7 @@ NEVER_INLINE void ByteCodeInterpreter::iteratorCloseOperation(ExecutionState& st
 {
     bool exceptionWasThrown = state.hasRareData() && state.rareData()->m_controlFlowRecord && state.rareData()->m_controlFlowRecord->back() && state.rareData()->m_controlFlowRecord->back()->reason() == ControlFlowRecord::NeedsThrow;
     const Value& iteratorRecord = registerFile[code->m_iterRegisterIndex];
-    Object* iterator = iteratorRecord.asPointerValue()->asIteratorRecord()->iterator().asObject();
+    Object* iterator = iteratorRecord.asObject()->getOwnProperty(state, state.context()->staticStrings().iterator).value(state, iteratorRecord).asObject();
     Value returnFunction = iterator->get(state, ObjectPropertyName(state.context()->staticStrings().stringReturn)).value(state, iterator);
     if (returnFunction.isUndefined()) {
         return;

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -68,12 +68,15 @@ class SetObjectOperation;
 class GetIterator;
 class IteratorStep;
 class IteratorClose;
+class IteratorBind;
 class EnumerateObject;
 class CheckLastEnumerateKey;
 
 class ByteCodeInterpreter {
 public:
     static Value interpret(ExecutionState* state, ByteCodeBlock* byteCodeBlock, size_t programCounter, Value* registerFile);
+
+private:
     static Value loadByName(ExecutionState& state, LexicalEnvironment* env, const AtomicString& name, bool throwException = true);
     static EnvironmentRecord* getBindedEnvironmentRecordByName(ExecutionState& state, LexicalEnvironment* env, const AtomicString& name, Value& bindedValue, bool throwException = true);
     static void storeByName(ExecutionState& state, LexicalEnvironment* env, const AtomicString& name, const Value& value);
@@ -149,6 +152,8 @@ public:
     static void getIteratorOperation(ExecutionState& state, GetIterator* code, Value* registerFile);
     static void iteratorStepOperation(ExecutionState& state, size_t& programCounter, Value* registerFile, char* codeBuffer);
     static void iteratorCloseOperation(ExecutionState& state, IteratorClose* code, Value* registerFile);
+    static void iteratorBindOperation(ExecutionState& state, size_t& programCounter, Value* registerFile);
+    static Object* restBindOperation(ExecutionState& state, Value& iteratorRecord);
 
     static void ensureArgumentsObjectOperation(ExecutionState& state, ByteCodeBlock* byteCodeBlock, Value* registerFile);
 };

--- a/src/parser/ast/ArrayPatternNode.h
+++ b/src/parser/ast/ArrayPatternNode.h
@@ -22,6 +22,8 @@
 
 #include "Node.h"
 #include "LiteralNode.h"
+#include "TryStatementNode.h"
+#include "runtime/Context.h"
 
 namespace Escargot {
 
@@ -43,36 +45,54 @@ public:
     {
         // store each element by iterator
         bool isLexicallyDeclaredBindingInitialization = context->m_isLexicallyDeclaredBindingInitialization;
+        size_t baseCountBefore = context->m_registerStack->size();
 
         // set m_isLexicallyDeclaredBindingInitialization to false for the case of empty array pattern
         context->m_isLexicallyDeclaredBindingInitialization = false;
 
-        size_t iteratorIndex = context->getRegister();
+        size_t iteratorRecordIndex = context->getRegister();
         size_t iteratorValueIndex = context->getRegister();
 
-        codeBlock->pushCode(GetIterator(ByteCodeLOC(m_loc.index), srcRegister, iteratorIndex), context, this);
+        codeBlock->pushCode(GetIterator(ByteCodeLOC(m_loc.index), srcRegister, iteratorRecordIndex), context, this);
 
+        TryStatementNode::TryStatementByteCodeContext iteratorBindingContext;
+
+        TryStatementNode::generateTryStatementStartByteCode(codeBlock, context, this, iteratorBindingContext);
         for (SentinelNode* element = m_elements.begin(); element != m_elements.end(); element = element->next()) {
             if (element->astNode()) {
                 // enable lexical declaration only if each element exists
                 context->m_isLexicallyDeclaredBindingInitialization = isLexicallyDeclaredBindingInitialization;
                 if (LIKELY(element->astNode()->type() != RestElement)) {
-                    codeBlock->pushCode(IteratorStep(ByteCodeLOC(m_loc.index), iteratorValueIndex, iteratorIndex), context, this);
+                    codeBlock->pushCode(IteratorBind(ByteCodeLOC(m_loc.index), iteratorValueIndex, iteratorRecordIndex), context, this);
                     element->astNode()->generateResolveAddressByteCode(codeBlock, context);
                     element->astNode()->generateStoreByteCode(codeBlock, context, iteratorValueIndex, false);
                 } else {
-                    element->astNode()->generateStoreByteCode(codeBlock, context, iteratorIndex, true);
+                    element->astNode()->generateStoreByteCode(codeBlock, context, iteratorRecordIndex, true);
                 }
             } else {
-                codeBlock->pushCode(IteratorStep(ByteCodeLOC(m_loc.index), iteratorValueIndex, iteratorIndex), context, this);
+                codeBlock->pushCode(IteratorBind(ByteCodeLOC(m_loc.index), iteratorValueIndex, iteratorRecordIndex), context, this);
             }
         }
+        context->giveUpRegister(); // for drop iteratorValueIndex
+
+        TryStatementNode::generateTryStatementBodyEndByteCode(codeBlock, context, this, iteratorBindingContext);
+        TryStatementNode::generateTryFinalizerStatementStartByteCode(codeBlock, context, this, iteratorBindingContext, true);
+        // If iteratorRecord.[[Done]] is false, return ? IteratorClose(iteratorRecord, result).
+        size_t doneIndex = context->getRegister();
+        codeBlock->pushCode(GetObjectPreComputedCase(ByteCodeLOC(m_loc.index), iteratorRecordIndex, doneIndex, codeBlock->m_codeBlock->context()->staticStrings().done), context, this);
+        codeBlock->pushCode(JumpIfTrue(ByteCodeLOC(m_loc.index), doneIndex), context, this);
+        size_t jumpPos = codeBlock->lastCodePosition<JumpIfTrue>();
+        codeBlock->pushCode(IteratorClose(ByteCodeLOC(m_loc.index), iteratorRecordIndex), context, this);
+        codeBlock->peekCode<JumpIfTrue>(jumpPos)->m_jumpPosition = codeBlock->currentCodeSize();
+        TryStatementNode::generateTryFinalizerStatementEndByteCode(codeBlock, context, this, iteratorBindingContext, true);
 
         ASSERT(!context->m_isLexicallyDeclaredBindingInitialization);
-        context->giveUpRegister(); // for drop iteratorValueIndex
-        context->giveUpRegister(); // for drop iteratorIndex
+        context->giveUpRegister(); // for drop doneIndex
+        context->giveUpRegister(); // for drop iteratorRecordIndex
 
         codeBlock->m_shouldClearStack = true;
+
+        ASSERT(context->m_registerStack->size() == baseCountBefore);
     }
 
     virtual void iterateChildrenIdentifier(const std::function<void(AtomicString name, bool isAssignment)>& fn) override

--- a/src/parser/ast/ForInOfStatementNode.h
+++ b/src/parser/ast/ForInOfStatementNode.h
@@ -143,7 +143,7 @@ public:
 
         size_t exit1Pos, exit2Pos, exit3Pos, continuePosition;
         // for-of only
-        TryStatementNode::TryStatementByteCodeContext forOfTryStatmentContext;
+        TryStatementNode::TryStatementByteCodeContext forOfTryStatementContext;
         ByteCodeRegisterIndex finishCheckRegisterIndex = REGISTER_LIMIT, iteratorDataRegisterIndex = REGISTER_LIMIT;
         size_t forOfEndCheckRegisterHeadStartPosition = SIZE_MAX;
         size_t forOfEndCheckRegisterHeadEndPosition = SIZE_MAX;
@@ -212,7 +212,7 @@ public:
             codeBlock->peekCode<GetEnumerateKey>(enumerateObjectKeyPos)->m_dataRegisterIndex = dataRegisterIndex;
         } else {
             // for-of statement
-            TryStatementNode::generateTryStatementStartByteCode(codeBlock, &newContext, this, forOfTryStatmentContext);
+            TryStatementNode::generateTryStatementStartByteCode(codeBlock, &newContext, this, forOfTryStatementContext);
 
             auto oldRequiredRegisterFileSizeInValueSize = codeBlock->m_requiredRegisterFileSizeInValueSize;
             codeBlock->m_requiredRegisterFileSizeInValueSize = 0;
@@ -296,15 +296,15 @@ public:
         newContext.m_positionToContinue = continuePosition;
 
         if (!m_forIn) {
-            TryStatementNode::generateTryStatementBodyEndByteCode(codeBlock, &newContext, this, forOfTryStatmentContext);
-            TryStatementNode::generateTryFinalizerStatementStartByteCode(codeBlock, &newContext, this, forOfTryStatmentContext, true);
+            TryStatementNode::generateTryStatementBodyEndByteCode(codeBlock, &newContext, this, forOfTryStatementContext);
+            TryStatementNode::generateTryFinalizerStatementStartByteCode(codeBlock, &newContext, this, forOfTryStatementContext, true);
 
             size_t exceptionThrownCheckStartJumpPos = codeBlock->currentCodeSize();
             codeBlock->pushCode(JumpIfTrue(ByteCodeLOC(m_loc.index), finishCheckRegisterIndex, SIZE_MAX), &newContext, this);
             codeBlock->pushCode(IteratorClose(ByteCodeLOC(m_loc.index), iteratorDataRegisterIndex), &newContext, this);
 
             codeBlock->peekCode<JumpIfTrue>(exceptionThrownCheckStartJumpPos)->m_jumpPosition = codeBlock->currentCodeSize();
-            TryStatementNode::generateTryFinalizerStatementEndByteCode(codeBlock, &newContext, this, forOfTryStatmentContext, true);
+            TryStatementNode::generateTryFinalizerStatementEndByteCode(codeBlock, &newContext, this, forOfTryStatementContext, true);
 
             codeBlock->peekCode<LoadLiteral>(forOfEndCheckRegisterHeadStartPosition)->m_registerIndex = finishCheckRegisterIndex;
             codeBlock->peekCode<LoadLiteral>(forOfEndCheckRegisterHeadEndPosition)->m_registerIndex = finishCheckRegisterIndex;

--- a/src/runtime/GlobalObjectBuiltinPromise.cpp
+++ b/src/runtime/GlobalObjectBuiltinPromise.cpp
@@ -107,14 +107,14 @@ static Value builtinPromiseAll(ExecutionState& state, Value thisValue, size_t ar
                 next = IteratorObject::iteratorStep(state, iteratorRecord);
             } catch (const Value& e) {
                 // If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-                iteratorRecord.asPointerValue()->asIteratorRecord()->setDone(true);
+                iteratorRecord.asObject()->setThrowsException(state, ObjectPropertyName(strings->done), Value(true), iteratorRecord);
                 // ReturnIfAbrupt(next).
                 state.throwException(e);
             }
             // If next is false,
             if (next.isFalse()) {
                 // set iteratorRecord.[[done]] to true.
-                iteratorRecord.asPointerValue()->asIteratorRecord()->setDone(true);
+                iteratorRecord.asObject()->setThrowsException(state, ObjectPropertyName(strings->done), Value(true), iteratorRecord);
                 // Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
                 int64_t remainingElements = remainingElementsCount->getOwnProperty(state, strings->value).value(state, remainingElementsCount).asNumber();
                 remainingElementsCount->setThrowsException(state, strings->value, Value(remainingElements - 1), remainingElementsCount);
@@ -135,8 +135,8 @@ static Value builtinPromiseAll(ExecutionState& state, Value thisValue, size_t ar
                 nextValue = IteratorObject::iteratorValue(state, next);
             } catch (const Value& e) {
                 // If next is an abrupt completion, set iteratorRecord.[[done]] to true.
-                iteratorRecord.asPointerValue()->asIteratorRecord()->setDone(true);
-                // ReturnIfAbrupt(next).
+                iteratorRecord.asObject()->setThrowsException(state, ObjectPropertyName(strings->done), Value(true), iteratorRecord);
+                // ReturnIfAbrupt(nextValue).
                 state.throwException(e);
             }
             // Append undefined to values.
@@ -180,7 +180,7 @@ static Value builtinPromiseAll(ExecutionState& state, Value thisValue, size_t ar
         // If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
         // IfAbruptRejectPromise(result, promiseCapability).
         try {
-            if (!iteratorRecord.asPointerValue()->asIteratorRecord()->done()) {
+            if (iteratorRecord.asObject()->getOwnProperty(state, strings->done).value(state, iteratorRecord).isFalse()) {
                 result = IteratorObject::iteratorClose(state, iteratorRecord, exceptionValue, true);
             }
         } catch (const Value& v) {
@@ -239,13 +239,13 @@ static Value builtinPromiseRace(ExecutionState& state, Value thisValue, size_t a
             } catch (const Value& e) {
                 // If next is an abrupt completion, set iteratorRecord.[[done]] to true.
                 // ReturnIfAbrupt(next).
-                iteratorRecord.asPointerValue()->asIteratorRecord()->setDone(true);
+                iteratorRecord.asObject()->setThrowsException(state, ObjectPropertyName(strings->done), Value(true), iteratorRecord);
                 state.throwException(e);
             }
             // If next is false, then
             if (next.isFalse()) {
                 // Set iteratorRecord.[[done]] to true.
-                iteratorRecord.asPointerValue()->asIteratorRecord()->setDone(true);
+                iteratorRecord.asObject()->setThrowsException(state, ObjectPropertyName(strings->done), Value(true), iteratorRecord);
                 // Return resultCapability.[[Promise]].
                 result = promiseCapability.m_promise;
                 break;
@@ -257,7 +257,7 @@ static Value builtinPromiseRace(ExecutionState& state, Value thisValue, size_t a
                 nextValue = IteratorObject::iteratorValue(state, next);
             } catch (const Value& e) {
                 // If next is an abrupt completion, set iteratorRecord.[[done]] to true.
-                iteratorRecord.asPointerValue()->asIteratorRecord()->setDone(true);
+                iteratorRecord.asObject()->setThrowsException(state, ObjectPropertyName(strings->done), Value(true), iteratorRecord);
                 // ReturnIfAbrupt(next).
                 state.throwException(e);
             }
@@ -275,7 +275,7 @@ static Value builtinPromiseRace(ExecutionState& state, Value thisValue, size_t a
         // If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
         // IfAbruptRejectPromise(result, promiseCapability).
         try {
-            if (!iteratorRecord.asPointerValue()->asIteratorRecord()->done()) {
+            if (iteratorRecord.asObject()->getOwnProperty(state, strings->done).value(state, iteratorRecord).isFalse()) {
                 result = IteratorObject::iteratorClose(state, iteratorRecord, exceptionValue, true);
             }
         } catch (const Value& v) {

--- a/src/runtime/IteratorObject.h
+++ b/src/runtime/IteratorObject.h
@@ -30,43 +30,6 @@ class MapIteratorObject;
 class SetIteratorObject;
 class IteratorObject;
 
-class IteratorRecord : public PointerValue {
-    friend class IteratorObject;
-
-public:
-    explicit IteratorRecord(const Value& iterator, const Value& nextMethod, const bool done)
-        : m_iterator(iterator)
-        , m_nextMethod(nextMethod)
-        , m_done(done)
-    {
-    }
-
-    virtual bool isIteratorRecord() const
-    {
-        return true;
-    }
-
-    bool done() const
-    {
-        return m_done;
-    }
-
-    Value iterator() const
-    {
-        return m_iterator;
-    }
-
-    void setDone(bool done)
-    {
-        m_done = done;
-    }
-
-private:
-    SmallValue m_iterator;
-    SmallValue m_nextMethod;
-    bool m_done;
-};
-
 class IteratorObject : public Object {
 public:
     explicit IteratorObject(ExecutionState& state);

--- a/src/runtime/PointerValue.h
+++ b/src/runtime/PointerValue.h
@@ -56,7 +56,6 @@ class SetObject;
 class WeakMapObject;
 class WeakSetObject;
 class GeneratorObject;
-class IteratorRecord;
 
 #define POINTER_VALUE_STRING_TAG_IN_DATA 0x1
 #define POINTER_VALUE_SYMBOL_TAG_IN_DATA 0x2
@@ -326,11 +325,6 @@ public:
         return false;
     }
 
-    virtual bool isIteratorRecord() const
-    {
-        return false;
-    }
-
     virtual bool isGeneratorObject() const
     {
         return false;
@@ -547,12 +541,6 @@ public:
     {
         ASSERT(isGeneratorObject());
         return (GeneratorObject*)this;
-    }
-
-    IteratorRecord* asIteratorRecord()
-    {
-        ASSERT(isIteratorRecord());
-        return (IteratorRecord*)this;
     }
 
     bool hasTag(const size_t tag) const

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -368,6 +368,7 @@ namespace Escargot {
     F(has)                        \
     F(done)                       \
     F(next)                       \
+    F(nextMethod)                 \
     F(MapIterator)                \
     F(ArrayIterator)              \
     F(StringIterator)             \

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <excludeList>
-    <!-- exclude test dir -->
-    <test id="language/statements/for/dstr"><reason>TODO</reason></test>
-
     <!-- exclude each test file -->
     <test id="built-ins/decodeURI/S15.1.3.1_A2.5_T1"><reason>TOO SLOW</reason></test>
     <test id="built-ins/decodeURI/S15.1.3.1_A2.5_T1"><reason>TOO SLOW</reason></test>
@@ -4014,9 +4011,7 @@
     <test id="language/expressions/addition/coerce-bigint-to-string"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dstr/dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -4033,25 +4028,11 @@
     <test id="language/expressions/assignment/dstr/array-elem-init-fn-name-cover"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-init-fn-name-fn"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-init-fn-name-gen"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-iter-nrml-close-err"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-iter-nrml-close-null"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-iter-nrml-close"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-iter-rtrn-close-err"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-iter-rtrn-close-null"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-iter-rtrn-close"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-iter-thrw-close-err"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-iter-thrw-close"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-put-obj-literal-prop-ref-init-active"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-put-obj-literal-prop-ref-init"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-elision-iter-nrml-close-err"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-elision-iter-nrml-close-null"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-elision-iter-nrml-close"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-list-nrml-close-err"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-list-nrml-close-null"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-list-nrml-close"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-list-rtrn-close-err"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-list-rtrn-close-null"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-list-rtrn-close"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-list-thrw-close-err"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-list-thrw-close"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-rest-rtrn-close-err"><reason>TODO</reason></test>
@@ -4059,12 +4040,6 @@
     <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-rest-rtrn-close"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-rest-thrw-close-err"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-elem-trlg-iter-rest-thrw-close"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elision-iter-nrml-close-err"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elision-iter-nrml-close-null"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-elision-iter-nrml-close"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-empty-iter-close-err"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-empty-iter-close-null"><reason>TODO</reason></test>
-    <test id="language/expressions/assignment/dstr/array-empty-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-rest-iter-rtrn-close-err"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-rest-iter-rtrn-close-null"><reason>TODO</reason></test>
     <test id="language/expressions/assignment/dstr/array-rest-iter-rtrn-close"><reason>TODO</reason></test>
@@ -5467,7 +5442,6 @@
     <test id="language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-rest-getter"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-rest-skip-non-enumerable"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-rest-val-obj"><reason>TODO</reason></test>
-    <test id="language/expressions/class/dstr/gen-meth-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -5481,7 +5455,6 @@
     <test id="language/expressions/class/dstr/gen-meth-ary-ptrn-rest-id-elision-next-err"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-ary-ptrn-rest-id-iter-step-err"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-ary-ptrn-rest-id-iter-val-err"><reason>TODO</reason></test>
-    <test id="language/expressions/class/dstr/gen-meth-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-dflt-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -5523,7 +5496,6 @@
     <test id="language/expressions/class/dstr/gen-meth-obj-ptrn-prop-id-init-unresolvable"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-obj-ptrn-prop-obj-value-null"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-obj-ptrn-prop-obj-value-undef"><reason>TODO</reason></test>
-    <test id="language/expressions/class/dstr/gen-meth-static-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -5537,7 +5509,6 @@
     <test id="language/expressions/class/dstr/gen-meth-static-ary-ptrn-rest-id-elision-next-err"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-ary-ptrn-rest-id-iter-step-err"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-ary-ptrn-rest-id-iter-val-err"><reason>TODO</reason></test>
-    <test id="language/expressions/class/dstr/gen-meth-static-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-dflt-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -5579,15 +5550,11 @@
     <test id="language/expressions/class/dstr/gen-meth-static-obj-ptrn-prop-id-init-unresolvable"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-obj-ptrn-prop-obj-value-null"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/gen-meth-static-obj-ptrn-prop-obj-value-undef"><reason>TODO</reason></test>
-    <test id="language/expressions/class/dstr/meth-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/expressions/class/dstr/meth-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/meth-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/expressions/class/dstr/meth-static-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/expressions/class/dstr/meth-static-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/class/dstr/meth-static-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -7644,9 +7611,7 @@
     <test id="language/expressions/exponentiation/bigint-zero-base-zero-exponent"><reason>TODO</reason></test>
     <test id="language/expressions/function/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/function/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/function/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/expressions/function/dstr/dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/function/dstr/dflt-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/function/dstr/obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -7659,7 +7624,6 @@
     <test id="language/expressions/generators/dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/generators/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dstr/ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dstr/ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -7673,7 +7637,6 @@
     <test id="language/expressions/generators/dstr/ary-ptrn-rest-id-elision-next-err"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dstr/ary-ptrn-rest-id-iter-step-err"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dstr/ary-ptrn-rest-id-iter-val-err"><reason>TODO</reason></test>
-    <test id="language/expressions/generators/dstr/dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dstr/dflt-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dstr/dflt-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/expressions/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -7962,7 +7925,6 @@
     <test id="language/expressions/object/dstr/async-gen-meth-obj-ptrn-rest-getter"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/async-gen-meth-obj-ptrn-rest-skip-non-enumerable"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/async-gen-meth-obj-ptrn-rest-val-obj"><reason>TODO</reason></test>
-    <test id="language/expressions/object/dstr/gen-meth-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -7976,7 +7938,6 @@
     <test id="language/expressions/object/dstr/gen-meth-ary-ptrn-rest-id-elision-next-err"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-ary-ptrn-rest-id-iter-step-err"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-ary-ptrn-rest-id-iter-val-err"><reason>TODO</reason></test>
-    <test id="language/expressions/object/dstr/gen-meth-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-dflt-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -8018,9 +7979,7 @@
     <test id="language/expressions/object/dstr/gen-meth-obj-ptrn-prop-id-init-unresolvable"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-obj-ptrn-prop-obj-value-null"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-obj-ptrn-prop-obj-value-undef"><reason>TODO</reason></test>
-    <test id="language/expressions/object/dstr/meth-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/meth-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/expressions/object/dstr/meth-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/meth-dflt-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/meth-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -9791,7 +9750,6 @@
     <test id="language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-rest-getter"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-rest-skip-non-enumerable"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-rest-val-obj"><reason>TODO</reason></test>
-    <test id="language/statements/class/dstr/gen-meth-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -9805,7 +9763,6 @@
     <test id="language/statements/class/dstr/gen-meth-ary-ptrn-rest-id-elision-next-err"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-ary-ptrn-rest-id-iter-step-err"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-ary-ptrn-rest-id-iter-val-err"><reason>TODO</reason></test>
-    <test id="language/statements/class/dstr/gen-meth-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-dflt-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -9847,7 +9804,6 @@
     <test id="language/statements/class/dstr/gen-meth-obj-ptrn-prop-id-init-unresolvable"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-obj-ptrn-prop-obj-value-null"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-obj-ptrn-prop-obj-value-undef"><reason>TODO</reason></test>
-    <test id="language/statements/class/dstr/gen-meth-static-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -9861,7 +9817,6 @@
     <test id="language/statements/class/dstr/gen-meth-static-ary-ptrn-rest-id-elision-next-err"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-ary-ptrn-rest-id-iter-step-err"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-ary-ptrn-rest-id-iter-val-err"><reason>TODO</reason></test>
-    <test id="language/statements/class/dstr/gen-meth-static-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-dflt-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -9903,15 +9858,11 @@
     <test id="language/statements/class/dstr/gen-meth-static-obj-ptrn-prop-id-init-unresolvable"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-obj-ptrn-prop-obj-value-null"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/gen-meth-static-obj-ptrn-prop-obj-value-undef"><reason>TODO</reason></test>
-    <test id="language/statements/class/dstr/meth-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/statements/class/dstr/meth-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/meth-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/statements/class/dstr/meth-static-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/statements/class/dstr/meth-static-dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/meth-static-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -11470,7 +11421,6 @@
     <test id="language/statements/class/static-method-length-dflt"><reason>TODO</reason></test>
     <test id="language/statements/class/subclass/class-definition-null-proto-this"><reason>TODO</reason></test>
     <test id="language/statements/class/super/in-constructor-superproperty-evaluation"><reason>TODO</reason></test>
-    <test id="language/statements/const/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/const/dstr/obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/const/fn-name-class"><reason>TODO</reason></test>
@@ -12689,6 +12639,12 @@
     <test id="language/statements/for/cptn-decl-expr-no-iter"><reason>TODO</reason></test>
     <test id="language/statements/for/cptn-expr-expr-iter"><reason>TODO</reason></test>
     <test id="language/statements/for/cptn-expr-expr-no-iter"><reason>TODO</reason></test>
+    <test id="language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
+    <test id="language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
+    <test id="language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
+    <test id="language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
+    <test id="language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
+    <test id="language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/for/head-init-expr-check-empty-inc-empty-completion"><reason>TODO</reason></test>
     <test id="language/statements/for/head-init-var-check-empty-inc-empty-completion"><reason>TODO</reason></test>
     <test id="language/statements/for/head-lhs-let"><reason>TODO</reason></test>
@@ -12720,26 +12676,12 @@
     <test id="language/statements/for-of/dstr/array-elem-init-fn-name-cover"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-init-fn-name-fn"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-init-fn-name-gen"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-iter-nrml-close-err"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-iter-nrml-close-null"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-iter-nrml-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-iter-rtrn-close-err"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-iter-rtrn-close-null"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-iter-rtrn-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-iter-thrw-close-err"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-iter-thrw-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-nested-obj-yield-expr"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-put-obj-literal-prop-ref-init-active"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-put-obj-literal-prop-ref-init"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-trlg-iter-elision-iter-nrml-close-err"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-trlg-iter-elision-iter-nrml-close-null"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-trlg-iter-elision-iter-nrml-close"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-trlg-iter-list-nrml-close-err"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-trlg-iter-list-nrml-close-null"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-trlg-iter-list-nrml-close"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-trlg-iter-list-rtrn-close-err"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-trlg-iter-list-rtrn-close-null"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elem-trlg-iter-list-rtrn-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-trlg-iter-list-thrw-close-err"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-trlg-iter-list-thrw-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-trlg-iter-rest-rtrn-close-err"><reason>TODO</reason></test>
@@ -12747,12 +12689,6 @@
     <test id="language/statements/for-of/dstr/array-elem-trlg-iter-rest-rtrn-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-trlg-iter-rest-thrw-close-err"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-elem-trlg-iter-rest-thrw-close"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elision-iter-nrml-close-err"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elision-iter-nrml-close-null"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-elision-iter-nrml-close"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-empty-iter-close-err"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-empty-iter-close-null"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/array-empty-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-rest-iter-rtrn-close-err"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-rest-iter-rtrn-close-null"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-rest-iter-rtrn-close"><reason>TODO</reason></test>
@@ -12760,13 +12696,9 @@
     <test id="language/statements/for-of/dstr/array-rest-iter-thrw-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-rest-lref-err"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/array-rest-nested-obj-yield-expr"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/const-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/const-ary-ptrn-elision-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/let-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/let-ary-ptrn-elision-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/obj-id-init-fn-name-arrow"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/obj-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -12789,9 +12721,7 @@
     <test id="language/statements/for-of/dstr/obj-prop-put-prop-ref-user-err"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/obj-rest-computed-property-no-strict"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/obj-rest-computed-property"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/var-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/statements/for-of/dstr/var-ary-ptrn-elision-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/for-of/head-var-bound-names-let"><reason>TODO</reason></test>
     <test id="language/statements/for-of/let-block-with-newline"><reason>TODO</reason></test>
@@ -12804,9 +12734,7 @@
     <test id="language/statements/for/tco-var-body"><reason>TODO</reason></test>
     <test id="language/statements/function/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/statements/function/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/statements/function/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
-    <test id="language/statements/function/dstr/dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/function/dstr/obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -12819,7 +12747,6 @@
     <test id="language/statements/generators/dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/statements/generators/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/statements/generators/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/statements/generators/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/generators/dstr/ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/statements/generators/dstr/ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -12833,7 +12760,6 @@
     <test id="language/statements/generators/dstr/ary-ptrn-rest-id-elision-next-err"><reason>TODO</reason></test>
     <test id="language/statements/generators/dstr/ary-ptrn-rest-id-iter-step-err"><reason>TODO</reason></test>
     <test id="language/statements/generators/dstr/ary-ptrn-rest-id-iter-val-err"><reason>TODO</reason></test>
-    <test id="language/statements/generators/dstr/dflt-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/generators/dstr/dflt-ary-init-iter-get-err"><reason>TODO</reason></test>
     <test id="language/statements/generators/dstr/dflt-ary-ptrn-elem-ary-val-null"><reason>TODO</reason></test>
     <test id="language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
@@ -12894,7 +12820,6 @@
     <test id="language/statements/labeled/let-block-with-newline"><reason>TODO</reason></test>
     <test id="language/statements/labeled/let-identifier-with-newline"><reason>TODO</reason></test>
     <test id="language/statements/labeled/tco"><reason>TODO</reason></test>
-    <test id="language/statements/let/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/let/dstr/obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/let/fn-name-arrow"><reason>TODO</reason></test>
@@ -12918,7 +12843,6 @@
     <test id="language/statements/try/cptn-finally-skip-catch"><reason>TODO</reason></test>
     <test id="language/statements/try/cptn-finally-wo-catch"><reason>TODO</reason></test>
     <test id="language/statements/try/cptn-try"><reason>TODO</reason></test>
-    <test id="language/statements/try/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/try/dstr/obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/try/optional-catch-binding-finally"><reason>TODO</reason></test>
@@ -12928,7 +12852,6 @@
     <test id="language/statements/try/tco-catch-finally"><reason>TODO</reason></test>
     <test id="language/statements/try/tco-catch"><reason>TODO</reason></test>
     <test id="language/statements/try/tco-finally"><reason>TODO</reason></test>
-    <test id="language/statements/variable/dstr/ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/variable/dstr/obj-ptrn-id-init-fn-name-class"><reason>TODO</reason></test>
     <test id="language/statements/variable/fn-name-class"><reason>TODO</reason></test>


### PR DESCRIPTION
* Update iterator binding for array patterns
  * IteratorBind bytecode is newly added to handle the iteratior binding according to the standard (es10)
  * iterator binding operations for array element and rest element of array pattern are updated
  * IteratorStep related with for-of operation is left as future work
* Fix IteratorRecord as normal Object
  * handle IteratorRecord and its property by normal Object
  * for the ease of accessing and handling in the interpreter
