### PR TITLE
Fix bugs in function parameter

### DIFF
--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -99,7 +99,7 @@ int getValidValueInInterpretedCodeBlock(void* ptr, GC_mark_custom_result* arr)
     arr[2].from = (GC_word*)&current->m_identifierInfos;
     arr[2].to = (GC_word*)current->m_identifierInfos.data();
     arr[3].from = (GC_word*)&current->m_parameterNames;
-    arr[3].to = (GC_word*)current->m_parameterNames;
+    arr[3].to = (GC_word*)current->m_parameterNames.data();
     arr[4].from = (GC_word*)&current->m_identifierInfoMap;
     arr[4].to = (GC_word*)current->m_identifierInfoMap;
     arr[5].from = (GC_word*)&current->m_parentCodeBlock;

--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -84,6 +84,7 @@ struct ByteCodeGenerateContext {
         , m_canSkipCopyToRegister(true)
         , m_keepNumberalLiteralsInRegisterFile(numeralLiteralData)
         , m_inObjectDestruction(false)
+        , m_inParameterInitialization(false)
         , m_shouldGenerateLOCData(false)
         , m_forInOfVarBinding(false)
         , m_isLeftBindingAffectedByRightExpression(false)
@@ -118,6 +119,7 @@ struct ByteCodeGenerateContext {
         , m_keepNumberalLiteralsInRegisterFile(contextBefore.m_keepNumberalLiteralsInRegisterFile)
         , m_inCallingExpressionScope(contextBefore.m_inCallingExpressionScope)
         , m_inObjectDestruction(contextBefore.m_inObjectDestruction)
+        , m_inParameterInitialization(contextBefore.m_inParameterInitialization)
         , m_shouldGenerateLOCData(contextBefore.m_shouldGenerateLOCData)
         , m_forInOfVarBinding(contextBefore.m_forInOfVarBinding)
         , m_isLeftBindingAffectedByRightExpression(contextBefore.m_isLeftBindingAffectedByRightExpression)
@@ -274,18 +276,33 @@ struct ByteCodeGenerateContext {
 
     void addLexicallyDeclaredNames(AtomicString name)
     {
-        bool finded = false;
+        bool find = false;
         auto iter = m_lexicallyDeclaredNames->begin();
         while (iter != m_lexicallyDeclaredNames->end()) {
             if (iter->first == m_lexicalBlockIndex && iter->second == name) {
-                finded = true;
+                find = true;
                 break;
             }
             iter++;
         }
 
-        if (!finded) {
+        if (!find) {
             m_lexicallyDeclaredNames->push_back(std::make_pair(m_lexicalBlockIndex, name));
+        }
+    }
+
+    void addInitializedParameterNames(AtomicString name)
+    {
+        bool find = false;
+        for (size_t i = 0; i < m_initializedParameterNames.size(); i++) {
+            if (m_initializedParameterNames[i] == name) {
+                find = true;
+                break;
+            }
+        }
+
+        if (!find) {
+            m_initializedParameterNames.push_back(name);
         }
     }
 
@@ -320,6 +337,7 @@ struct ByteCodeGenerateContext {
     bool m_keepNumberalLiteralsInRegisterFile : 1;
     bool m_inCallingExpressionScope : 1;
     bool m_inObjectDestruction : 1;
+    bool m_inParameterInitialization : 1;
     bool m_isHeadOfMemberExpression : 1;
     bool m_shouldGenerateLOCData : 1;
     bool m_forInOfVarBinding : 1;
@@ -327,6 +345,7 @@ struct ByteCodeGenerateContext {
 
     std::shared_ptr<std::vector<ByteCodeRegisterIndex>> m_registerStack;
     std::shared_ptr<std::vector<std::pair<size_t, AtomicString>>> m_lexicallyDeclaredNames;
+    std::vector<AtomicString> m_initializedParameterNames;
     std::vector<size_t> m_breakStatementPositions;
     std::vector<size_t> m_continueStatementPositions;
     std::vector<std::pair<String*, size_t>> m_labeledBreakStatmentPositions;

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -2161,7 +2161,7 @@ NEVER_INLINE ArrayObject* ByteCodeInterpreter::createRestElementOperation(Execut
     ASSERT(state.resolveCallee());
 
     ArrayObject* newArray;
-    size_t parameterLen = (size_t)byteCodeBlock->m_codeBlock->parameterCount();
+    size_t parameterLen = (size_t)byteCodeBlock->m_codeBlock->parameterCount() - 1; // parameter length except the rest element
     size_t argc = state.argc();
     Value* argv = state.argv();
 
@@ -3451,7 +3451,7 @@ NEVER_INLINE void ByteCodeInterpreter::ensureArgumentsObjectOperation(ExecutionS
 {
     auto functionRecord = state.mostNearestFunctionLexicalEnvironment()->record()->asDeclarativeEnvironmentRecord()->asFunctionEnvironmentRecord();
     auto functionObject = functionRecord->functionObject()->asScriptFunctionObject();
-    bool isMapped = !functionObject->codeBlock()->hasParameterOtherThanIdentifier() && !functionObject->codeBlock()->isStrict();
+    bool isMapped = functionObject->codeBlock()->shouldHaveMappedArguments();
     functionObject->generateArgumentsObject(state, state.argc(), state.argv(), functionRecord, registerFile + byteCodeBlock->m_requiredRegisterFileSizeInValueSize, isMapped);
 }
 }

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -359,7 +359,7 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
 void InterpretedCodeBlock::captureArguments()
 {
     AtomicString arguments = m_context->staticStrings().arguments;
-    ASSERT(!isOnParameterName(arguments));
+    ASSERT(!hasParameterName(arguments));
     ASSERT(!isGlobalScopeCodeBlock() && !isArrowFunctionExpression());
 
     if (m_usesArgumentsObject) {

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -208,6 +208,11 @@ public:
         return m_hasParameterOtherThanIdentifier;
     }
 
+    bool shouldHaveMappedArguments() const
+    {
+        return !hasParameterOtherThanIdentifier() && !isStrict();
+    }
+
     bool allowSuperCall() const
     {
         return m_allowSuperCall;
@@ -277,9 +282,9 @@ public:
         return m_needsVirtualIDOperation;
     }
 
-    uint16_t parameterCount()
+    uint16_t functionLength()
     {
-        return m_parameterCount;
+        return m_functionLength;
     }
 
     bool isInterpretedCodeBlock()
@@ -334,7 +339,7 @@ protected:
     bool m_hasParameterOtherThanIdentifier : 1;
     bool m_allowSuperCall : 1;
     bool m_allowSuperProperty : 1;
-    uint16_t m_parameterCount;
+    uint16_t m_functionLength;
 
     AtomicString m_functionName;
 
@@ -364,14 +369,22 @@ public:
     /* capture ok, block vector index(if not block variable, returns SIZE_MAX) */
     std::pair<bool, size_t> tryCaptureIdentifiersFromChildCodeBlock(LexicalBlockIndex blockIndex, AtomicString name);
 
-    AtomicString* parameterNames() const
+    const AtomicStringTightVector& parameterNames() const
     {
+        // return all parameter names vector including targets of patterns and rest element
         return m_parameterNames;
     }
 
     size_t parameterNamesCount() const
     {
-        return m_parameterNamesCount;
+        // return the number of all parameter names including targets of patterns and rest element
+        return m_parameterNames.size();
+    }
+
+    size_t parameterCount() const
+    {
+        // return the number of parameter elements
+        return m_parameterCount;
     }
 
     struct IndexedIdentifierInfo {
@@ -667,7 +680,7 @@ public:
 
     bool isOnParameterName(const AtomicString& name)
     {
-        for (size_t i = 0; i < m_parameterNamesCount; i++) {
+        for (size_t i = 0; i < parameterNamesCount(); i++) {
             if (m_parameterNames[i] == name) {
                 return true;
             }
@@ -771,8 +784,8 @@ protected:
     Script* m_script;
     StringView m_src; // function source including parameters
 
-    AtomicString* m_parameterNames;
-    uint16_t m_parameterNamesCount : 16;
+    AtomicStringTightVector m_parameterNames;
+    uint16_t m_parameterCount : 16;
     LexicalBlockIndex m_functionBodyBlockIndex : 16;
 
     uint16_t m_identifierOnStackCount; // this member variable only count `var`

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -678,7 +678,7 @@ public:
         return findVarName(name) != SIZE_MAX;
     }
 
-    bool isOnParameterName(const AtomicString& name)
+    bool hasParameterName(const AtomicString& name)
     {
         for (size_t i = 0; i < parameterNamesCount(); i++) {
             if (m_parameterNames[i] == name) {

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -82,7 +82,7 @@ InterpretedCodeBlock* ScriptParser::generateCodeBlockTreeFromASTWalker(Context* 
                 AtomicString uname = scopeCtx->m_childBlockScopes[i]->m_usingNames[j];
                 auto blockIndex = scopeCtx->m_childBlockScopes[i]->m_blockIndex;
                 if (uname == arguments) {
-                    if (UNLIKELY(codeBlock->isOnParameterName(arguments))) {
+                    if (UNLIKELY(codeBlock->hasParameterName(arguments))) {
                         continue;
                     } else {
                         bool hasKindOfArgumentsHolderOnAncestors = false;
@@ -96,11 +96,11 @@ InterpretedCodeBlock* ScriptParser::generateCodeBlockTreeFromASTWalker(Context* 
                             argumentsObjectHolder = argumentsObjectHolder->parentCodeBlock();
                         }
 
-                        if (hasKindOfArgumentsHolderOnAncestors && !argumentsObjectHolder->isOnParameterName(arguments)) {
+                        if (hasKindOfArgumentsHolderOnAncestors && !argumentsObjectHolder->hasParameterName(arguments)) {
                             InterpretedCodeBlock* argumentsVariableHolder = nullptr;
                             InterpretedCodeBlock* c = codeBlock->parentCodeBlock();
                             while (c && !c->isGlobalScopeCodeBlock()) {
-                                if (c->isOnParameterName(arguments)) {
+                                if (c->hasParameterName(arguments)) {
                                     argumentsVariableHolder = c;
                                     break;
                                 } else if (!c->isArrowFunctionExpression()) {

--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -190,7 +190,8 @@ struct ASTFunctionScopeContext {
     bool m_allowSuperCall : 1;
     bool m_allowSuperProperty : 1;
     unsigned int m_nodeType : 2; // it is actually NodeType but used on FunctionExpression, ArrowFunctionExpression and FunctionDeclaration only
-    unsigned int m_parameterCount : 16;
+    unsigned int m_functionLength : 16; // represent the number of consecutive identifier parameters from the start of parameter list (function length)
+    unsigned int m_parameterCount : 16; // represent the number of parameter element nodes
     LexicalBlockIndex m_functionBodyBlockIndex : 16;
     LexicalBlockIndex m_lexicalBlockIndexFunctionLocatedIn : 16;
     ASTFunctionScopeContextNameInfoVector m_varNames;
@@ -507,6 +508,7 @@ struct ASTFunctionScopeContext {
         , m_allowSuperCall(false)
         , m_allowSuperProperty(false)
         , m_nodeType(ASTNodeType::Program)
+        , m_functionLength(0)
         , m_parameterCount(0)
         , m_functionBodyBlockIndex(0)
         , m_lexicalBlockIndexFunctionLocatedIn(LEXICAL_BLOCK_INDEX_MAX)

--- a/src/parser/ast/AssignmentPatternNode.h
+++ b/src/parser/ast/AssignmentPatternNode.h
@@ -74,8 +74,17 @@ public:
         context->giveUpRegister(); // for drop cmpIndex
 
         // not undefined case, set srcRegister
+
+        // for the case of function (x = x) {...}
+        // set m_inParameterInitialization to false at first m_left->generateStoreByteCode, so addInitializedParameterNames is called by second m_left->generateStoreByteCode.
+        bool oldInParameterInitialization = context->m_inParameterInitialization;
+        context->m_inParameterInitialization = false;
+
         m_left->generateResolveAddressByteCode(codeBlock, context);
         m_left->generateStoreByteCode(codeBlock, context, srcRegister, false);
+
+        context->m_inParameterInitialization = oldInParameterInitialization;
+
         codeBlock->pushCode<Jump>(Jump(ByteCodeLOC(m_loc.index)), context, this);
         size_t pos2 = codeBlock->lastCodePosition<Jump>();
 

--- a/src/parser/ast/InitializeParameterExpressionNode.h
+++ b/src/parser/ast/InitializeParameterExpressionNode.h
@@ -37,9 +37,11 @@ public:
     virtual ASTNodeType type() override { return ASTNodeType::InitializeParameterExpression; }
     virtual void generateResultNotRequiredExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
+        context->m_inParameterInitialization = true;
         if (m_left->isIdentifier()) {
             auto r = m_left->asIdentifier()->isAllocatedOnStack(context);
             if (std::get<0>(r)) {
+                context->addInitializedParameterNames(m_left->asIdentifier()->name());
                 codeBlock->pushCode(GetParameter(ByteCodeLOC(m_loc.index), std::get<1>(r), m_paramIndex), context, this);
             } else {
                 size_t rightRegister = context->getRegister();
@@ -56,6 +58,7 @@ public:
             m_left->generateStoreByteCode(codeBlock, context, rightRegister, false);
             context->giveUpRegister();
         }
+        context->m_inParameterInitialization = false;
     }
 
     virtual void iterateChildren(const std::function<void(Node* node)>& fn) override

--- a/src/runtime/ArgumentsObject.cpp
+++ b/src/runtime/ArgumentsObject.cpp
@@ -82,7 +82,9 @@ ArgumentsObject::ArgumentsObject(ExecutionState& state, ScriptFunctionObject* so
 
         // https://www.ecma-international.org/ecma-262/6.0/#sec-createmappedargumentsobject
         // Let numberOfParameters be the number of elements in parameterNames
-        int numberOfParameters = m_sourceFunctionObject->codeBlock()->asInterpretedCodeBlock()->parameterNamesCount();
+        int numberOfParameters = m_sourceFunctionObject->codeBlock()->asInterpretedCodeBlock()->parameterNames().size();
+        // all parameters are pure identifier nodes, so function length is same as the number of parameters
+        ASSERT(numberOfParameters == m_sourceFunctionObject->codeBlock()->functionLength());
         // Let index be 0.
         int index = 0;
         // Repeat while index < len ,

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -41,7 +41,7 @@ void FunctionObject::initStructureAndValues(ExecutionState& state, bool isConstr
         ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2 < m_structure->propertyCount());
         m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = SmallValue::EmptyValue; // lazy init on VMInstance::functionPrototypeNativeGetter
         m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(m_codeBlock->functionName().string()));
-        m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2] = (Value(m_codeBlock->parameterCount()));
+        m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2] = (Value(m_codeBlock->functionLength()));
     } else {
         if (isConstructor) {
             m_structure = state.context()->defaultStructureForFunctionObject();
@@ -50,13 +50,13 @@ void FunctionObject::initStructureAndValues(ExecutionState& state, bool isConstr
             ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2 < m_structure->propertyCount());
             m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = SmallValue::EmptyValue; // lazy init on VMInstance::functionPrototypeNativeGetter
             m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(m_codeBlock->functionName().string()));
-            m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2] = (Value(m_codeBlock->parameterCount()));
+            m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2] = (Value(m_codeBlock->functionLength()));
         } else {
             m_structure = state.context()->defaultStructureForNotConstructorFunctionObject();
             ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0 < m_structure->propertyCount());
             ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1 < m_structure->propertyCount());
             m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = (Value(m_codeBlock->functionName().string()));
-            m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(m_codeBlock->parameterCount()));
+            m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(m_codeBlock->functionLength()));
         }
     }
 }

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -57,6 +57,7 @@ public:
         , m_objectFreeze(nullptr)
         , m_function(nullptr)
         , m_functionPrototype(nullptr)
+        , m_functionApply(nullptr)
         , m_iteratorPrototype(nullptr)
         , m_error(nullptr)
         , m_errorPrototype(nullptr)

--- a/src/runtime/NativeFunctionObject.cpp
+++ b/src/runtime/NativeFunctionObject.cpp
@@ -92,7 +92,7 @@ NativeFunctionObject::NativeFunctionObject(ExecutionState& state, NativeFunction
     // The Proxy constructor does not have a prototype property
     m_structure = state.context()->defaultStructureForNotConstructorFunctionObject();
     m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = (Value(m_codeBlock->functionName().string()));
-    m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(m_codeBlock->parameterCount()));
+    m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(m_codeBlock->functionLength()));
     Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->functionPrototype());
 
     ASSERT(NativeFunctionObject::isConstructor());
@@ -122,7 +122,7 @@ Value NativeFunctionObject::processNativeFunctionCall(ExecutionState& state, con
 
     CallNativeFunctionData* code = m_codeBlock->nativeFunctionData();
 
-    size_t len = m_codeBlock->parameterCount();
+    size_t len = m_codeBlock->functionLength();
     if (argc < len) {
         Value* newArgv = (Value*)alloca(sizeof(Value) * len);
         for (size_t i = 0; i < argc; i++) {

--- a/src/runtime/ScriptClassConstructorFunctionObject.cpp
+++ b/src/runtime/ScriptClassConstructorFunctionObject.cpp
@@ -35,7 +35,7 @@ ScriptClassConstructorFunctionObject::ScriptClassConstructorFunctionObject(Execu
 
     ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0 < m_structure->propertyCount());
     ASSERT(ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1 < m_structure->propertyCount());
-    m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = (Value(m_codeBlock->parameterCount()));
+    m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = (Value(m_codeBlock->functionLength()));
     m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = SmallValue::EmptyValue; // lazy init on VMInstance::functionPrototypeNativeGetter
 }
 

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -3845,7 +3845,6 @@
     <test id="language/expressions/addition/coerce-bigint-to-string"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/length-dflt"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/scope-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -6761,14 +6760,12 @@
     <test id="language/expressions/class/elements/wrapped-in-sc-static-private-methods"><reason>TODO</reason></test>
     <test id="language/expressions/class/elements/wrapped-in-sc-static-private-methods-with-fields"><reason>TODO</reason></test>
     <test id="language/expressions/class/elements/wrapped-in-sc-string-literal-names"><reason>TODO</reason></test>
-    <test id="language/expressions/class/gen-method-length-dflt"><reason>TODO</reason></test>
     <test id="language/expressions/class/gen-method-static/dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/expressions/class/gen-method-static/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/class/gen-method-static/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/expressions/class/gen-method/dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/expressions/class/gen-method/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/class/gen-method/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/class/method-length-dflt"><reason>TODO</reason></test>
     <test id="language/expressions/class/method-static/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/class/method-static/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/expressions/class/method/dflt-params-ref-later"><reason>TODO</reason></test>
@@ -6812,7 +6809,6 @@
     <test id="language/expressions/class/private-static-setter-multiple-evaluations-of-class-function-ctor"><reason>TODO</reason></test>
     <test id="language/expressions/class/private-static-setter-multiple-evaluations-of-class-realm"><reason>TODO</reason></test>
     <test id="language/expressions/class/scope-name-lex-open-heritage"><reason>TODO</reason></test>
-    <test id="language/expressions/class/static-method-length-dflt"><reason>TODO</reason></test>
     <test id="language/expressions/coalesce/abrupt-is-a-short-circuit"><reason>TODO</reason></test>
     <test id="language/expressions/coalesce/chainable"><reason>TODO</reason></test>
     <test id="language/expressions/coalesce/chainable-if-parenthesis-covered-logical-and"><reason>TODO</reason></test>
@@ -7348,7 +7344,6 @@
     <test id="language/expressions/exponentiation/bigint-zero-base-zero-exponent"><reason>TODO</reason></test>
     <test id="language/expressions/function/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/function/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/function/length-dflt"><reason>TODO</reason></test>
     <test id="language/expressions/function/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/expressions/function/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/expressions/function/scope-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -7409,7 +7404,6 @@
     <test id="language/expressions/generators/dstr/obj-ptrn-prop-obj-value-undef"><reason>TODO</reason></test>
     <test id="language/expressions/generators/eval-body-proto-realm"><reason>TODO</reason></test>
     <test id="language/expressions/generators/generator-created-after-decl-inst"><reason>TODO</reason></test>
-    <test id="language/expressions/generators/length-dflt"><reason>TODO</reason></test>
     <test id="language/expressions/generators/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/expressions/generators/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/expressions/generators/scope-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -7791,10 +7785,8 @@
     <test id="language/expressions/object/method-definition/gen-meth-dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/gen-meth-dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/gen-meth-dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/object/method-definition/generator-length-dflt"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/meth-dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/meth-dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/object/method-definition/name-length-dflt"><reason>TODO</reason></test>
     <test id="language/expressions/object/scope-gen-meth-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/expressions/object/scope-gen-meth-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/expressions/object/scope-gen-meth-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -11099,21 +11091,18 @@
     <test id="language/statements/class/elements/wrapped-in-sc-static-private-methods"><reason>TODO</reason></test>
     <test id="language/statements/class/elements/wrapped-in-sc-static-private-methods-with-fields"><reason>TODO</reason></test>
     <test id="language/statements/class/elements/wrapped-in-sc-string-literal-names"><reason>TODO</reason></test>
-    <test id="language/statements/class/gen-method-length-dflt"><reason>TODO</reason></test>
     <test id="language/statements/class/gen-method-static/dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/statements/class/gen-method-static/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/statements/class/gen-method-static/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/statements/class/gen-method/dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/statements/class/gen-method/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/statements/class/gen-method/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/statements/class/method-length-dflt"><reason>TODO</reason></test>
     <test id="language/statements/class/method-static/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/statements/class/method-static/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/statements/class/method/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/statements/class/method/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/statements/class/scope-name-lex-open-heritage"><reason>TODO</reason></test>
     <test id="language/statements/class/static-classelementname-abrupt-completion"><reason>TODO</reason></test>
-    <test id="language/statements/class/static-method-length-dflt"><reason>TODO</reason></test>
     <test id="language/statements/class/subclass/class-definition-null-proto-this"><reason>TODO</reason></test>
     <test id="language/statements/class/super/in-constructor-superproperty-evaluation"><reason>TODO</reason></test>
     <test id="language/statements/do-while/cptn-abrupt-empty"><reason>TODO</reason></test>
@@ -12384,7 +12373,6 @@
     <test id="language/statements/for/tco-var-body"><reason>TODO</reason></test>
     <test id="language/statements/function/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/statements/function/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/statements/function/length-dflt"><reason>TODO</reason></test>
     <test id="language/statements/function/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/statements/function/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/statements/function/scope-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -12444,7 +12432,6 @@
     <test id="language/statements/generators/dstr/obj-ptrn-prop-obj-value-null"><reason>TODO</reason></test>
     <test id="language/statements/generators/dstr/obj-ptrn-prop-obj-value-undef"><reason>TODO</reason></test>
     <test id="language/statements/generators/generator-created-after-decl-inst"><reason>TODO</reason></test>
-    <test id="language/statements/generators/length-dflt"><reason>TODO</reason></test>
     <test id="language/statements/generators/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/statements/generators/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/statements/generators/scope-param-rest-elem-var-close"><reason>TODO</reason></test>

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -3843,8 +3843,6 @@
     <test id="language/expressions/addition/bigint-toprimitive"><reason>TODO</reason></test>
     <test id="language/expressions/addition/bigint-wrapped-values"><reason>TODO</reason></test>
     <test id="language/expressions/addition/coerce-bigint-to-string"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dflt-params-ref-later"><reason>TODO</reason></test>
-    <test id="language/expressions/arrow-function/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/expressions/arrow-function/scope-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -6766,10 +6764,6 @@
     <test id="language/expressions/class/gen-method/dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/expressions/class/gen-method/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/class/gen-method/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/class/method-static/dflt-params-ref-later"><reason>TODO</reason></test>
-    <test id="language/expressions/class/method-static/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/class/method/dflt-params-ref-later"><reason>TODO</reason></test>
-    <test id="language/expressions/class/method/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/expressions/class/private-getter-brand-check-multiple-evaluations-of-class-eval"><reason>TODO</reason></test>
     <test id="language/expressions/class/private-getter-brand-check-multiple-evaluations-of-class-eval-indirect"><reason>TODO</reason></test>
     <test id="language/expressions/class/private-getter-brand-check-multiple-evaluations-of-class-factory"><reason>TODO</reason></test>
@@ -7342,8 +7336,6 @@
     <test id="language/expressions/exponentiation/bigint-toprimitive"><reason>TODO</reason></test>
     <test id="language/expressions/exponentiation/bigint-wrapped-values"><reason>TODO</reason></test>
     <test id="language/expressions/exponentiation/bigint-zero-base-zero-exponent"><reason>TODO</reason></test>
-    <test id="language/expressions/function/dflt-params-ref-later"><reason>TODO</reason></test>
-    <test id="language/expressions/function/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/expressions/function/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/expressions/function/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/expressions/function/scope-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -7785,8 +7777,6 @@
     <test id="language/expressions/object/method-definition/gen-meth-dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/gen-meth-dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/gen-meth-dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/expressions/object/method-definition/meth-dflt-params-ref-later"><reason>TODO</reason></test>
-    <test id="language/expressions/object/method-definition/meth-dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/expressions/object/scope-gen-meth-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/expressions/object/scope-gen-meth-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/expressions/object/scope-gen-meth-param-rest-elem-var-close"><reason>TODO</reason></test>
@@ -11097,10 +11087,6 @@
     <test id="language/statements/class/gen-method/dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/statements/class/gen-method/dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/statements/class/gen-method/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/statements/class/method-static/dflt-params-ref-later"><reason>TODO</reason></test>
-    <test id="language/statements/class/method-static/dflt-params-ref-self"><reason>TODO</reason></test>
-    <test id="language/statements/class/method/dflt-params-ref-later"><reason>TODO</reason></test>
-    <test id="language/statements/class/method/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/statements/class/scope-name-lex-open-heritage"><reason>TODO</reason></test>
     <test id="language/statements/class/static-classelementname-abrupt-completion"><reason>TODO</reason></test>
     <test id="language/statements/class/subclass/class-definition-null-proto-this"><reason>TODO</reason></test>
@@ -12371,8 +12357,6 @@
     <test id="language/statements/for/tco-let-body"><reason>TODO</reason></test>
     <test id="language/statements/for/tco-lhs-body"><reason>TODO</reason></test>
     <test id="language/statements/for/tco-var-body"><reason>TODO</reason></test>
-    <test id="language/statements/function/dflt-params-ref-later"><reason>TODO</reason></test>
-    <test id="language/statements/function/dflt-params-ref-self"><reason>TODO</reason></test>
     <test id="language/statements/function/scope-param-elem-var-close"><reason>TODO</reason></test>
     <test id="language/statements/function/scope-param-elem-var-open"><reason>TODO</reason></test>
     <test id="language/statements/function/scope-param-rest-elem-var-close"><reason>TODO</reason></test>


### PR DESCRIPTION
* fix a case in which parameter value is referenced before initialization to throw a reference error
* fix function length to represent the number of consecutive identifiers from the start of parameter list
* collect parameter names including the target names of patterns and rest element
* separate function length and parameter count
* simplify the process of parameter collecting and rename parameter related functions more intuitively

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>