### PR TITLE
Add function and class name in object expression

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -173,7 +173,7 @@ void* Memory::gcMalloc(size_t siz)
 
 void* Memory::gcMallocAtomic(size_t siz)
 {
-    return GC_MALLOC(siz);
+    return GC_MALLOC_ATOMIC(siz);
 }
 
 void* Memory::gcMallocUncollectable(size_t siz)

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -726,13 +726,13 @@ public:
 
 class ObjectDefineOwnPropertyOperation : public ByteCode {
 public:
-    ObjectDefineOwnPropertyOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, const size_t propertyRegisterIndex, const size_t loadRegisterIndex, ObjectPropertyDescriptor::PresentAttribute presentAttribute, bool needsToRedefineFunctionNameOnValue)
+    ObjectDefineOwnPropertyOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, const size_t propertyRegisterIndex, const size_t loadRegisterIndex, ObjectPropertyDescriptor::PresentAttribute presentAttribute, bool redefineFunctionOrClassName)
         : ByteCode(Opcode::ObjectDefineOwnPropertyOperationOpcode, loc)
         , m_objectRegisterIndex(objectRegisterIndex)
         , m_propertyRegisterIndex(propertyRegisterIndex)
         , m_loadRegisterIndex(loadRegisterIndex)
         , m_presentAttribute(presentAttribute)
-        , m_needsToRedefineFunctionNameOnValue(needsToRedefineFunctionNameOnValue)
+        , m_redefineFunctionOrClassName(redefineFunctionOrClassName)
     {
     }
 
@@ -740,7 +740,7 @@ public:
     ByteCodeRegisterIndex m_propertyRegisterIndex;
     ByteCodeRegisterIndex m_loadRegisterIndex;
     ObjectPropertyDescriptor::PresentAttribute m_presentAttribute : 8;
-    bool m_needsToRedefineFunctionNameOnValue : 1;
+    bool m_redefineFunctionOrClassName : 1;
 #ifndef NDEBUG
 
     void dump(const char* byteCodeStart)

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -3038,9 +3038,12 @@ static Value createObjectPropertyFunctionName(ExecutionState& state, const Value
     StringBuilder builder;
     if (name.isSymbol()) {
         builder.appendString(prefix);
-        builder.appendString("[");
-        builder.appendString(name.asSymbol()->description());
-        builder.appendString("]");
+        if (name.asSymbol()->description()->length() > 0) {
+            // add symbol name if it is not an empty symbol
+            builder.appendString("[");
+            builder.appendString(name.asSymbol()->description());
+            builder.appendString("]");
+        }
     } else {
         builder.appendString(prefix);
         builder.appendString(name.toString(state));
@@ -3056,7 +3059,8 @@ NEVER_INLINE void ByteCodeInterpreter::objectDefineOwnPropertyOperation(Executio
 
     Value propertyStringOrSymbol = property.isSymbol() ? property : property.toString(state);
 
-    if (code->m_needsToRedefineFunctionNameOnValue) {
+    if (code->m_redefineFunctionOrClassName) {
+        ASSERT(value.isFunction());
         Value fnName = createObjectPropertyFunctionName(state, propertyStringOrSymbol, "");
         value.asFunction()->defineOwnProperty(state, state.context()->staticStrings().name, ObjectPropertyDescriptor(fnName));
     }

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -3065,12 +3065,11 @@ NEVER_INLINE void ByteCodeInterpreter::objectDefineOwnPropertyOperation(Executio
         value.asFunction()->defineOwnProperty(state, state.context()->staticStrings().name, ObjectPropertyDescriptor(fnName));
     }
 
-    ObjectPropertyName objPropName = ObjectPropertyName(state, propertyStringOrSymbol);
     // http://www.ecma-international.org/ecma-262/6.0/#sec-__proto__-property-names-in-object-initializers
     if (!willBeObject.asObject()->isScriptClassConstructorPrototypeObject() && (propertyStringOrSymbol.isString() && propertyStringOrSymbol.asString()->equals("__proto__"))) {
         willBeObject.asObject()->setPrototype(state, value);
     } else {
-        willBeObject.asObject()->defineOwnProperty(state, objPropName, ObjectPropertyDescriptor(value, code->m_presentAttribute));
+        willBeObject.asObject()->defineOwnProperty(state, ObjectPropertyName(state, propertyStringOrSymbol), ObjectPropertyDescriptor(value, code->m_presentAttribute));
     }
 }
 
@@ -3200,7 +3199,7 @@ NEVER_INLINE void ByteCodeInterpreter::createSpreadArrayObject(ExecutionState& s
 NEVER_INLINE void ByteCodeInterpreter::defineObjectGetterSetter(ExecutionState& state, ObjectDefineGetterSetter* code, Value* registerFile)
 {
     FunctionObject* fn = registerFile[code->m_objectPropertyValueRegisterIndex].asFunction();
-    Value pName = registerFile[code->m_objectPropertyNameRegisterIndex];
+    Value pName = code->m_objectPropertyNameRegisterIndex == REGISTER_LIMIT ? fn->codeBlock()->functionName().string() : registerFile[code->m_objectPropertyNameRegisterIndex];
     Value fnName;
     if (code->m_isGetter) {
         fnName = createObjectPropertyFunctionName(state, pName, "get ");

--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -321,13 +321,6 @@ public:
         return SyntaxNode();
     }
 
-    void tryToSetImplicitName(AtomicString s)
-    {
-        // dummy function for tryToSetImplicitName() of ClassExpressionNode
-        ASSERT(m_nodeType == ClassExpression);
-        return;
-    }
-
     SyntaxNodeList& expressions()
     {
         // dummy function for expressions() of SequenceExpressionNode

--- a/src/parser/ast/ClassDeclarationNode.h
+++ b/src/parser/ast/ClassDeclarationNode.h
@@ -77,14 +77,17 @@ public:
 
         m_class.classBody()->generateClassInitializer(codeBlock, context, classIndex);
 
-        size_t nameRegister = context->getRegister();
-        // we don't need to root class name string because it is AtomicString
-        codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), nameRegister, Value(context->m_classInfo.m_name.string())), context, this);
-        codeBlock->pushCode(ObjectDefineOwnPropertyWithNameOperation(ByteCodeLOC(m_loc.index), classIndex,
-                                                                     codeBlock->m_codeBlock->context()->staticStrings().name,
-                                                                     nameRegister, ObjectPropertyDescriptor::ConfigurablePresent),
-                            context, this);
-        context->giveUpRegister();
+        // add class name property if there is no 'name' static member
+        if (!m_class.classBody()->hasStaticMemberName(codeBlock->m_codeBlock->context()->staticStrings().name)) {
+            size_t nameRegister = context->getRegister();
+            // we don't need to root class name string because it is AtomicString
+            codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), nameRegister, Value(context->m_classInfo.m_name.string())), context, this);
+            codeBlock->pushCode(ObjectDefineOwnPropertyWithNameOperation(ByteCodeLOC(m_loc.index), classIndex,
+                                                                         codeBlock->m_codeBlock->context()->staticStrings().name,
+                                                                         nameRegister, ObjectPropertyDescriptor::ConfigurablePresent),
+                                context, this);
+            context->giveUpRegister();
+        }
 
         if (m_class.classBodyLexicalBlockIndex() != LEXICAL_BLOCK_INDEX_MAX) {
             ASSERT(classIdent);

--- a/src/parser/ast/ObjectExpressionNode.h
+++ b/src/parser/ast/ObjectExpressionNode.h
@@ -82,7 +82,8 @@ public:
                         codeBlock->pushCode(ObjectDefineOwnPropertyWithNameOperation(ByteCodeLOC(m_loc.index), objIndex, propertyAtomicName, valueIndex, ObjectPropertyDescriptor::AllPresent), context, this);
                     } else {
                         bool hasFunctionOnRightSide = p->value()->type() == ASTNodeType::FunctionExpression || p->value()->type() == ASTNodeType::ArrowFunctionExpression;
-                        codeBlock->pushCode(ObjectDefineOwnPropertyOperation(ByteCodeLOC(m_loc.index), objIndex, propertyIndex, valueIndex, ObjectPropertyDescriptor::AllPresent, hasFunctionOnRightSide), context, this);
+                        bool hasClassOnRightSide = p->value()->type() == ASTNodeType::ClassExpression && !p->value()->asClassExpression()->classNode().classBody()->hasStaticMemberName(codeBlock->m_codeBlock->context()->staticStrings().name);
+                        codeBlock->pushCode(ObjectDefineOwnPropertyOperation(ByteCodeLOC(m_loc.index), objIndex, propertyIndex, valueIndex, ObjectPropertyDescriptor::AllPresent, hasFunctionOnRightSide | hasClassOnRightSide), context, this);
                         // for drop property index
                         context->giveUpRegister();
                     }

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -3911,6 +3911,7 @@ public:
     template <class ASTBuilder>
     ASTNode parseLabelledStatement(ASTBuilder& builder, size_t multiLabelCount = 1)
     {
+        MetaNode node = this->createNode();
         ASTNode expr = nullptr;
         AtomicString name;
         bool isIdentifier = false;
@@ -3954,7 +3955,7 @@ public:
             statement = builder.createExpressionStatementNode(expr);
         }
 
-        return this->finalize(this->createNode(), statement);
+        return this->finalize(node, statement);
     }
 
     // ECMA-262 13.14 The throw statement

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -1760,12 +1760,14 @@ public:
             }
         }
 
+        if (!computed && keyNode->isIdentifier()) {
+            this->addImplicitName(valueNode, keyNode->asIdentifier()->name());
+        }
+
         if (!this->isParsingSingleFunction && (method || isGet || isSet)) {
-            if (!computed && keyNode->isIdentifier()) {
-                this->lastPoppedScopeContext->m_functionName = keyNode->asIdentifier()->name();
-            }
             this->lastPoppedScopeContext->m_isClassMethod = true;
         }
+
         return this->finalize(node, builder.createPropertyNode(keyNode, valueNode, kind, computed, shorthand));
     }
 
@@ -4946,10 +4948,11 @@ public:
             }
         }
 
+        if (!computed && keyNode->isIdentifier()) {
+            this->addImplicitName(value, keyNode->asIdentifier()->name());
+        }
+
         if (!this->isParsingSingleFunction) {
-            if (keyNode->type() == Identifier) {
-                this->lastPoppedScopeContext->m_functionName = keyNode->asIdentifier()->name();
-            }
             if (isStatic) {
                 this->lastPoppedScopeContext->m_isClassStaticMethod = true;
             } else {

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -7328,13 +7328,6 @@
     <test id="language/expressions/object/dstr/gen-meth-obj-ptrn-prop-id-init-unresolvable"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-obj-ptrn-prop-obj-value-null"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/gen-meth-obj-ptrn-prop-obj-value-undef"><reason>TODO</reason></test>
-    <test id="language/expressions/object/fn-name-accessor-get"><reason>TODO</reason></test>
-    <test id="language/expressions/object/fn-name-accessor-set"><reason>TODO</reason></test>
-    <test id="language/expressions/object/fn-name-arrow"><reason>TODO</reason></test>
-    <test id="language/expressions/object/fn-name-class"><reason>TODO</reason></test>
-    <test id="language/expressions/object/fn-name-cover"><reason>TODO</reason></test>
-    <test id="language/expressions/object/fn-name-fn"><reason>TODO</reason></test>
-    <test id="language/expressions/object/fn-name-gen"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/async-gen-meth-dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/async-gen-meth-dflt-params-arg-val-not-undefined"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/async-gen-meth-dflt-params-arg-val-undefined"><reason>TODO</reason></test>
@@ -7411,8 +7404,6 @@
     <test id="language/expressions/object/method-definition/async-gen-yield-star-sync-next"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/async-gen-yield-star-sync-return"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/async-gen-yield-star-sync-throw"><reason>TODO</reason></test>
-    <test id="language/expressions/object/method-definition/fn-name-fn"><reason>TODO</reason></test>
-    <test id="language/expressions/object/method-definition/fn-name-gen"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/gen-meth-dflt-params-abrupt"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/gen-meth-dflt-params-ref-later"><reason>TODO</reason></test>
     <test id="language/expressions/object/method-definition/gen-meth-dflt-params-ref-self"><reason>TODO</reason></test>
@@ -8313,10 +8304,6 @@
     <test id="language/statements/class/async-gen-method/yield-star-sync-return"><reason>TODO</reason></test>
     <test id="language/statements/class/async-gen-method/yield-star-sync-throw"><reason>TODO</reason></test>
     <test id="language/statements/class/classelementname-abrupt-completion"><reason>TODO</reason></test>
-    <test id="language/statements/class/definition/fn-name-accessor-get"><reason>TODO</reason></test>
-    <test id="language/statements/class/definition/fn-name-accessor-set"><reason>TODO</reason></test>
-    <test id="language/statements/class/definition/fn-name-gen-method"><reason>TODO</reason></test>
-    <test id="language/statements/class/definition/fn-name-method"><reason>TODO</reason></test>
     <test id="language/statements/class/definition/fn-name-static-precedence"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/async-gen-meth-ary-init-iter-close"><reason>TODO</reason></test>
     <test id="language/statements/class/dstr/async-gen-meth-ary-init-iter-get-err"><reason>TODO</reason></test>


### PR DESCRIPTION
* add symbol name for property method if it is not an empty symbol
* MetaNode in parseLabelledStatement is fixed correctly
* add implicit name to getter, setter function definition
* remove one LoadLiteral bytecode for each name of getter, setter function

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>