### PR TITLE
Allocate YarrPattern::m_captureGroupNames on GC heap

### DIFF
--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -288,7 +288,7 @@ RegExpObject::RegExpCacheEntry& RegExpObject::getCacheEntryAndCompileIfNeeded(Ex
         JSC::Yarr::YarrPattern* yarrPattern = nullptr;
         try {
             JSC::Yarr::ErrorCode errorCode = JSC::Yarr::ErrorCode::NoError;
-            yarrPattern = new (PointerFreeGC) JSC::Yarr::YarrPattern(source, (JSC::Yarr::RegExpFlags)option, errorCode);
+            yarrPattern = JSC::Yarr::YarrPattern::createYarrPattern(source, (JSC::Yarr::RegExpFlags)option, errorCode);
             yarrError = JSC::Yarr::errorMessage(errorCode);
         } catch (const std::bad_alloc& e) {
             ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "got too complicated RegExp pattern to process");

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -150,11 +150,6 @@ public:
     void* operator new[](size_t size) = delete;
 
 private:
-    void setBytecodePattern(JSC::Yarr::BytecodePattern* pattern)
-    {
-        m_bytecodePattern = pattern;
-    }
-
     void setOption(const Option& option);
     void internalInit(ExecutionState& state, String* source);
 

--- a/third_party/yarr/YarrPattern.cpp
+++ b/third_party/yarr/YarrPattern.cpp
@@ -580,12 +580,13 @@ public:
             m_pattern.m_numSubpatterns++;
             if (optGroupName) {
                 while (m_pattern.m_captureGroupNames.size() < subpatternId)
-                    m_pattern.m_captureGroupNames.append(String());
-                m_pattern.m_captureGroupNames.append(optGroupName.value());
+                    m_pattern.m_captureGroupNames.push_back(String());
+                m_pattern.m_captureGroupNames.push_back(optGroupName.value());
                 m_pattern.m_namedGroupToParenIndex.add(optGroupName.value(), subpatternId);
             }
-        } else
+        } else {
             ASSERT(!optGroupName);
+        }
 
         auto parenthesesDisjunction = std::make_unique<PatternDisjunction>(m_alternative);
         m_alternative->m_terms.append(PatternTerm(PatternTerm::TypeParenthesesSubpattern, subpatternId, parenthesesDisjunction.get(), capture, false));


### PR DESCRIPTION
* during the parsing of regexp, some string objects are dynamically generated
* fix m_captureGroupNames vector to be allocated on GC heap for capturing of these dynamic strings
* m_captureGroupNames would be cleared when YarrPattern deallocated

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>