### PR TITLE
Remove duplicated check code in Construct operation

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -115,6 +115,7 @@ private:
     static Value blockOperation(ExecutionState*& state, BlockOperation* code, size_t& programCounter, ByteCodeBlock* byteCodeBlock, Value* registerFile);
     static void replaceBlockLexicalEnvironmentOperation(ExecutionState& state, size_t programCounter, ByteCodeBlock* byteCodeBlock);
     static bool binaryInOperation(ExecutionState& state, const Value& left, const Value& right);
+    static Value constructOperation(ExecutionState& state, const Value& constructor, const size_t argc, NULLABLE Value* argv);
     static void callFunctionComplexCase(ExecutionState& state, CallFunctionComplexCase* code, Value* registerFile, ByteCodeBlock* byteCodeBlock);
     static void spreadFunctionArguments(ExecutionState& state, const Value* argv, const size_t argc, ValueVector& argVector);
 

--- a/src/runtime/BoundFunctionObject.cpp
+++ b/src/runtime/BoundFunctionObject.cpp
@@ -67,7 +67,7 @@ Value BoundFunctionObject::call(ExecutionState& state, const Value& thisValue, c
 // https://www.ecma-international.org/ecma-262/6.0/#sec-bound-function-exotic-objects-construct-argumentslist-newtarget
 Object* BoundFunctionObject::construct(ExecutionState& state, const size_t calledArgc, Value* calledArgv, Object* newTarget)
 {
-    ASSERT(isConstructor());
+    ASSERT(m_boundTargetFunction && m_boundTargetFunction->isConstructor());
 
     // Let target be the value of F’s [[BoundTargetFunction]] internal slot.
     // Let boundArgs be the value of F’s [[BoundArguments]] internal slot.

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -1054,19 +1054,17 @@ Value Object::call(ExecutionState& state, const Value& callee, const Value& this
     return callee.asPointerValue()->call(state, thisValue, argc, argv);
 }
 
-// https://www.ecma-international.org/ecma-262/6.0/#sec-construct
+// https://www.ecma-international.org/ecma-262/10.0/#sec-construct
 Object* Object::construct(ExecutionState& state, const Value& constructor, const size_t argc, NULLABLE Value* argv, Object* newTarget)
 {
-    if (!constructor.isConstructor()) {
-        if (constructor.isFunction()) {
-            ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, errorMessage_Not_Constructor_Function, constructor.asFunction()->codeBlock()->functionName());
-        }
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, errorMessage_Not_Constructor);
-    }
     // If newTarget was not passed, let newTarget be F.
     if (newTarget == nullptr) {
         newTarget = constructor.asObject();
     }
+
+    ASSERT(constructor.isConstructor());
+    ASSERT(newTarget->isConstructor());
+
     return constructor.asPointerValue()->construct(state, argc, argv, newTarget);
 }
 

--- a/src/runtime/ScriptFunctionObject.cpp
+++ b/src/runtime/ScriptFunctionObject.cpp
@@ -130,9 +130,6 @@ public:
 
 Object* ScriptFunctionObject::construct(ExecutionState& state, const size_t argc, NULLABLE Value* argv, Object* newTarget)
 {
-    if (UNLIKELY(!newTarget->isConstructor())) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, errorMessage_Not_Constructor_Function, codeBlock()->functionName());
-    }
     // Assert: Type(newTarget) is Object.
     ASSERT(newTarget->isObject());
     ASSERT(newTarget->isConstructor());


### PR DESCRIPTION
* Object::construct directly calls each internal construct method without any check code
* ByteCodeInterpreter::constructOperation is added to run IsConstructor check code

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>