### PR TITLE
Fix [[Prototype]] initialization process for each object creation

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -2004,32 +2004,32 @@ ErrorObjectRef* ErrorObjectRef::create(ExecutionStateRef* state, ErrorObjectRef:
 
 ReferenceErrorObjectRef* ReferenceErrorObjectRef::create(ExecutionStateRef* state, StringRef* errorMessage)
 {
-    return toRef(new ReferenceErrorObject(*toImpl(state), toImpl(errorMessage)));
+    return toRef((ReferenceErrorObject*)ErrorObject::createError(*toImpl(state), ErrorObject::ReferenceError, toImpl(errorMessage)));
 }
 
 TypeErrorObjectRef* TypeErrorObjectRef::create(ExecutionStateRef* state, StringRef* errorMessage)
 {
-    return toRef(new TypeErrorObject(*toImpl(state), toImpl(errorMessage)));
+    return toRef((TypeErrorObject*)ErrorObject::createError(*toImpl(state), ErrorObject::TypeError, toImpl(errorMessage)));
 }
 
 SyntaxErrorObjectRef* SyntaxErrorObjectRef::create(ExecutionStateRef* state, StringRef* errorMessage)
 {
-    return toRef(new SyntaxErrorObject(*toImpl(state), toImpl(errorMessage)));
+    return toRef((SyntaxErrorObject*)ErrorObject::createError(*toImpl(state), ErrorObject::SyntaxError, toImpl(errorMessage)));
 }
 
 RangeErrorObjectRef* RangeErrorObjectRef::create(ExecutionStateRef* state, StringRef* errorMessage)
 {
-    return toRef(new RangeErrorObject(*toImpl(state), toImpl(errorMessage)));
+    return toRef((RangeErrorObject*)ErrorObject::createError(*toImpl(state), ErrorObject::RangeError, toImpl(errorMessage)));
 }
 
 URIErrorObjectRef* URIErrorObjectRef::create(ExecutionStateRef* state, StringRef* errorMessage)
 {
-    return toRef(new URIErrorObject(*toImpl(state), toImpl(errorMessage)));
+    return toRef((URIErrorObject*)ErrorObject::createError(*toImpl(state), ErrorObject::URIError, toImpl(errorMessage)));
 }
 
 EvalErrorObjectRef* EvalErrorObjectRef::create(ExecutionStateRef* state, StringRef* errorMessage)
 {
-    return toRef(new EvalErrorObject(*toImpl(state), toImpl(errorMessage)));
+    return toRef((EvalErrorObject*)ErrorObject::createError(*toImpl(state), ErrorObject::EvalError, toImpl(errorMessage)));
 }
 
 DateObjectRef* DateObjectRef::create(ExecutionStateRef* state)

--- a/src/heap/LeakCheckerBridge.cpp
+++ b/src/heap/LeakCheckerBridge.cpp
@@ -34,8 +34,9 @@ namespace Escargot {
 /* Usage in JS: registerLeakCheck( object: PointerValue, description: String ); */
 Value builtinRegisterLeakCheck(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
 {
-    if (!argv[0].isPointerValue())
-        state.throwException(new ErrorObject(state, new ASCIIString("builtinRegisterLeakCheck should get pointer-type argument")));
+    if (!argv[0].isPointerValue()) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::None, "builtinRegisterLeakCheck should get pointer-type argument");
+    }
 
     PointerValue* ptr = argv[0].asPointerValue();
     std::string description = argv[1].toString(state)->toUTF8StringData().data();

--- a/src/runtime/ArgumentsObject.cpp
+++ b/src/runtime/ArgumentsObject.cpp
@@ -67,8 +67,8 @@ void* ArgumentsObject::operator new(size_t size)
 }
 
 
-ArgumentsObject::ArgumentsObject(ExecutionState& state, ScriptFunctionObject* sourceFunctionObject, size_t argc, Value* argv, FunctionEnvironmentRecord* environmentRecordWillArgumentsObjectBeLocatedIn, bool isMapped)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3, true)
+ArgumentsObject::ArgumentsObject(ExecutionState& state, Object* proto, ScriptFunctionObject* sourceFunctionObject, size_t argc, Value* argv, FunctionEnvironmentRecord* environmentRecordWillArgumentsObjectBeLocatedIn, bool isMapped)
+    : Object(state, proto, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3)
     , m_targetRecord(environmentRecordWillArgumentsObjectBeLocatedIn->isFunctionEnvironmentRecordOnStack() ? nullptr : environmentRecordWillArgumentsObjectBeLocatedIn)
     , m_sourceFunctionObject(sourceFunctionObject)
     , m_argc((argc << 1) | 1)

--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -32,7 +32,7 @@ class ScriptFunctionObject;
 
 class ArgumentsObject : public Object {
 public:
-    ArgumentsObject(ExecutionState& state, ScriptFunctionObject* sourceFunctionObject, size_t argc, Value* argv, FunctionEnvironmentRecord* environmentRecordWillArgumentsObjectBeLocatedIn, bool isMapped);
+    ArgumentsObject(ExecutionState& state, Object* proto, ScriptFunctionObject* sourceFunctionObject, size_t argc, Value* argv, FunctionEnvironmentRecord* environmentRecordWillArgumentsObjectBeLocatedIn, bool isMapped);
     virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) override;

--- a/src/runtime/ArrayBufferObject.cpp
+++ b/src/runtime/ArrayBufferObject.cpp
@@ -34,31 +34,16 @@ ArrayBufferObject* ArrayBufferObject::allocateArrayBuffer(ExecutionState& state,
 }
 
 ArrayBufferObject::ArrayBufferObject(ExecutionState& state)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER, true)
-    , m_context(state.context())
-    , m_data(nullptr)
-    , m_bytelength(0)
+    : ArrayBufferObject(state, state.context()->globalObject()->arrayBufferPrototype())
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->arrayBufferPrototype());
-
-    GC_REGISTER_FINALIZER_NO_ORDER(this, [](void* obj,
-                                            void*) {
-        ArrayBufferObject* self = (ArrayBufferObject*)obj;
-        if (self->m_data) {
-            self->m_context->vmInstance()->platform()->onArrayBufferObjectDataBufferFree(self->m_context, self, self->m_data);
-        }
-    },
-                                   nullptr, nullptr, nullptr);
 }
 
 ArrayBufferObject::ArrayBufferObject(ExecutionState& state, Object* proto)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER, true)
+    : Object(state, proto, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER)
     , m_context(state.context())
     , m_data(nullptr)
     , m_bytelength(0)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, proto);
-
     GC_REGISTER_FINALIZER_NO_ORDER(this, [](void* obj,
                                             void*) {
         ArrayBufferObject* self = (ArrayBufferObject*)obj;

--- a/src/runtime/ArrayBufferObject.h
+++ b/src/runtime/ArrayBufferObject.h
@@ -44,6 +44,8 @@ class ArrayBufferObject : public Object {
 
 public:
     explicit ArrayBufferObject(ExecutionState& state);
+    explicit ArrayBufferObject(ExecutionState& state, Object* proto);
+
     static ArrayBufferObject* allocateArrayBuffer(ExecutionState& state, Value constructor);
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
@@ -152,8 +154,6 @@ public:
     void* operator new[](size_t size) = delete;
 
 private:
-    explicit ArrayBufferObject(ExecutionState& state, Object* proto);
-
     Context* m_context;
     uint8_t* m_data;
     unsigned m_bytelength;

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -29,19 +29,27 @@ namespace Escargot {
 size_t g_arrayObjectTag;
 
 ArrayObject::ArrayObject(ExecutionState& state)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER, false)
+    : ArrayObject(state, state.context()->globalObject()->arrayPrototype())
+{
+}
+
+ArrayObject::ArrayObject(ExecutionState& state, Object* proto)
+    : Object(state, proto, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER)
     , m_arrayLength(0)
     , m_fastModeData(nullptr)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->arrayPrototype());
-
     if (UNLIKELY(state.context()->vmInstance()->didSomePrototypeObjectDefineIndexedProperty())) {
         ensureObjectRareData()->m_isFastModeArrayObject = false;
     }
 }
 
 ArrayObject::ArrayObject(ExecutionState& state, double length)
-    : ArrayObject(state)
+    : ArrayObject(state, state.context()->globalObject()->arrayPrototype(), length)
+{
+}
+
+ArrayObject::ArrayObject(ExecutionState& state, Object* proto, double length)
+    : ArrayObject(state, proto)
 {
     // If length is -0, let length be +0.
     if (length == 0 && std::signbit(length)) {
@@ -56,7 +64,12 @@ ArrayObject::ArrayObject(ExecutionState& state, double length)
 }
 
 ArrayObject::ArrayObject(ExecutionState& state, const uint64_t& size)
-    : ArrayObject(state)
+    : ArrayObject(state, state.context()->globalObject()->arrayPrototype(), size)
+{
+}
+
+ArrayObject::ArrayObject(ExecutionState& state, Object* proto, const uint64_t& size)
+    : ArrayObject(state, proto)
 {
     if (UNLIKELY(size > ((1LL << 32LL) - 1LL))) {
         ErrorObject::throwBuiltinError(state, ErrorObject::RangeError, errorMessage_GlobalObject_InvalidArrayLength);
@@ -66,7 +79,12 @@ ArrayObject::ArrayObject(ExecutionState& state, const uint64_t& size)
 }
 
 ArrayObject::ArrayObject(ExecutionState& state, const Value* src, const uint64_t& size)
-    : ArrayObject(state, size)
+    : ArrayObject(state, state.context()->globalObject()->arrayPrototype(), src, size)
+{
+}
+
+ArrayObject::ArrayObject(ExecutionState& state, Object* proto, const Value* src, const uint64_t& size)
+    : ArrayObject(state, proto, size)
 {
     // Let array be ! ArrayCreate(0).
     // Let n be 0.
@@ -567,12 +585,16 @@ bool ArrayObject::preventExtensions(ExecutionState& state)
 }
 
 ArrayIteratorObject::ArrayIteratorObject(ExecutionState& state, Object* a, Type type)
-    : IteratorObject(state)
+    : ArrayIteratorObject(state, state.context()->globalObject()->arrayIteratorPrototype(), a, type)
+{
+}
+
+ArrayIteratorObject::ArrayIteratorObject(ExecutionState& state, Object* proto, Object* a, Type type)
+    : IteratorObject(state, proto)
     , m_array(a)
     , m_iteratorNextIndex(0)
     , m_type(type)
 {
-    Object::setPrototype(state, state.context()->globalObject()->arrayIteratorPrototype());
 }
 
 void* ArrayIteratorObject::operator new(size_t size)

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -44,9 +44,13 @@ class ArrayObject : public Object {
 
 public:
     explicit ArrayObject(ExecutionState& state);
+    explicit ArrayObject(ExecutionState& state, Object* proto);
     ArrayObject(ExecutionState& state, double size); // http://www.ecma-international.org/ecma-262/7.0/index.html#sec-arraycreate
+    ArrayObject(ExecutionState& state, Object* proto, double size); // http://www.ecma-international.org/ecma-262/7.0/index.html#sec-arraycreate
     ArrayObject(ExecutionState& state, const uint64_t& size);
+    ArrayObject(ExecutionState& state, Object* proto, const uint64_t& size);
     ArrayObject(ExecutionState& state, const Value* src, const uint64_t& size);
+    ArrayObject(ExecutionState& state, Object* proto, const Value* src, const uint64_t& size);
 
     static ArrayObject* createSpreadArray(ExecutionState& state);
 
@@ -139,8 +143,8 @@ private:
 
 class ArrayObjectPrototype : public ArrayObject {
 public:
-    ArrayObjectPrototype(ExecutionState& state)
-        : ArrayObject(state)
+    ArrayObjectPrototype(ExecutionState& state, Object* proto)
+        : ArrayObject(state, proto)
     {
     }
 
@@ -159,6 +163,7 @@ public:
     };
 
     ArrayIteratorObject(ExecutionState& state, Object* array, Type type);
+    ArrayIteratorObject(ExecutionState& state, Object* proto, Object* array, Type type);
 
     virtual bool isArrayIteratorObject() const override
     {

--- a/src/runtime/AsyncFromSyncIteratorObject.cpp
+++ b/src/runtime/AsyncFromSyncIteratorObject.cpp
@@ -25,10 +25,9 @@
 
 namespace Escargot {
 
-AsyncFromSyncIteratorObject::AsyncFromSyncIteratorObject(ExecutionState& state, IteratorRecord* syncIteratorRecord)
-    : Object(state)
+AsyncFromSyncIteratorObject::AsyncFromSyncIteratorObject(ExecutionState& state, Object* proto, IteratorRecord* syncIteratorRecord)
+    : Object(state, proto)
     , m_syncIteratorRecord(syncIteratorRecord)
 {
-    setPrototype(state, state.context()->globalObject()->asyncFromSyncIteratorPrototype());
 }
 }

--- a/src/runtime/AsyncFromSyncIteratorObject.h
+++ b/src/runtime/AsyncFromSyncIteratorObject.h
@@ -20,6 +20,7 @@
 #ifndef __EscargotAsyncFromSyncIteratorObject__
 #define __EscargotAsyncFromSyncIteratorObject__
 
+#include "runtime/Context.h"
 #include "runtime/Object.h"
 #include "runtime/IteratorObject.h"
 
@@ -30,12 +31,12 @@ class IteratorRecord;
 // https://www.ecma-international.org/ecma-262/10.0/#sec-async-from-sync-iterator-objects
 class AsyncFromSyncIteratorObject : public Object {
 public:
-    AsyncFromSyncIteratorObject(ExecutionState& state, IteratorRecord* syncIteratorRecord);
+    AsyncFromSyncIteratorObject(ExecutionState& state, Object* proto, IteratorRecord* syncIteratorRecord);
 
     // https://www.ecma-international.org/ecma-262/10.0/#sec-createasyncfromsynciterator
     static IteratorRecord* createAsyncFromSyncIterator(ExecutionState& state, IteratorRecord* syncIteratorRecord)
     {
-        return IteratorObject::getIterator(state, new AsyncFromSyncIteratorObject(state, syncIteratorRecord), false);
+        return IteratorObject::getIterator(state, new AsyncFromSyncIteratorObject(state, state.context()->globalObject()->asyncFromSyncIteratorPrototype(), syncIteratorRecord), false);
     }
 
     virtual bool isAsyncFromSyncIteratorObject() const override

--- a/src/runtime/AsyncGeneratorObject.cpp
+++ b/src/runtime/AsyncGeneratorObject.cpp
@@ -28,20 +28,11 @@
 
 namespace Escargot {
 
-AsyncGeneratorObject::AsyncGeneratorObject(ExecutionState& state)
-    : AsyncGeneratorObject(state, nullptr, nullptr, nullptr, Value(Value::Null))
-{
-    Object* prototype = new Object(state);
-    prototype->setPrototype(state, state.context()->globalObject()->asyncGeneratorPrototype());
-    setPrototype(state, prototype);
-}
-
-AsyncGeneratorObject::AsyncGeneratorObject(ExecutionState& state, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk, const Value& prototype)
-    : Object(state)
+AsyncGeneratorObject::AsyncGeneratorObject(ExecutionState& state, Object* proto, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk)
+    : Object(state, proto)
     , m_asyncGeneratorState(SuspendedStart)
     , m_executionPauser(state, this, executionState, registerFile, blk)
 {
-    setPrototype(state, prototype);
 }
 
 void* AsyncGeneratorObject::operator new(size_t size)
@@ -110,7 +101,7 @@ Value AsyncGeneratorObject::asyncGeneratorEnqueue(ExecutionState& state, const V
     // If Type(generator) is not Object, or if generator does not have an [[AsyncGeneratorState]] internal slot, then
     if (!generator.isObject() || !generator.asObject()->isAsyncGeneratorObject()) {
         // Let badGeneratorError be a newly created TypeError object.
-        TypeErrorObject* badGeneratorError = new TypeErrorObject(state, String::fromASCII("This value is not Async Generator Object."));
+        ErrorObject* badGeneratorError = ErrorObject::createError(state, ErrorObject::TypeError, String::fromASCII("This value is not Async Generator Object."));
         // Perform ! Call(promiseCapability.[[Reject]], undefined, « badGeneratorError »).
         Value argv(badGeneratorError);
         Object::call(state, promiseCapability.m_rejectFunction, Value(), 1, &argv);

--- a/src/runtime/AsyncGeneratorObject.h
+++ b/src/runtime/AsyncGeneratorObject.h
@@ -49,8 +49,7 @@ public:
         SuspendedYield
     };
 
-    AsyncGeneratorObject(ExecutionState& state);
-    AsyncGeneratorObject(ExecutionState& state, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk, const Value& prototype);
+    AsyncGeneratorObject(ExecutionState& state, Object* proto, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk);
 
     virtual const char* internalClassProperty(ExecutionState& state) override
     {

--- a/src/runtime/BooleanObject.cpp
+++ b/src/runtime/BooleanObject.cpp
@@ -24,17 +24,14 @@
 namespace Escargot {
 
 BooleanObject::BooleanObject(ExecutionState& state, bool value)
-    : Object(state)
-    , m_primitiveValue(value)
+    : BooleanObject(state, state.context()->globalObject()->booleanPrototype(), value)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->booleanPrototype());
 }
 
 BooleanObject::BooleanObject(ExecutionState& state, Object* proto, bool value)
-    : Object(state)
+    : Object(state, proto)
     , m_primitiveValue(value)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, proto);
 }
 
 void* BooleanObject::operator new(size_t size)

--- a/src/runtime/BooleanObject.h
+++ b/src/runtime/BooleanObject.h
@@ -26,8 +26,8 @@ namespace Escargot {
 
 class BooleanObject : public Object {
 public:
-    BooleanObject(ExecutionState& state, bool value = false);
-    BooleanObject(ExecutionState& state, Object* proto, bool value);
+    explicit BooleanObject(ExecutionState& state, bool value = false);
+    explicit BooleanObject(ExecutionState& state, Object* proto, bool value = false);
 
     bool primitiveValue()
     {

--- a/src/runtime/BoundFunctionObject.cpp
+++ b/src/runtime/BoundFunctionObject.cpp
@@ -27,7 +27,7 @@
 namespace Escargot {
 
 BoundFunctionObject::BoundFunctionObject(ExecutionState& state, Object* targetFunction, Value& boundThis, size_t boundArgc, Value* boundArgv, const Value& length, const Value& name)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2, false)
+    : Object(state, state.context()->globalObject()->objectPrototype(), ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2)
     , m_boundTargetFunction(targetFunction)
     , m_boundThis(boundThis)
 {

--- a/src/runtime/Context.cpp
+++ b/src/runtime/Context.cpp
@@ -86,8 +86,9 @@ Context::Context(VMInstance* instance)
     m_globalObject = new GlobalObject(stateForInit);
     m_globalObject->installBuiltins(stateForInit);
 
-    ArrayObject temp(stateForInit);
-    g_arrayObjectTag = *((size_t*)&temp);
+    // initialize object tag values after installation of builtins
+    g_arrayObjectTag = ArrayObject(stateForInit, m_globalObject->arrayPrototype()).getTag();
+    g_objectTag = Object(stateForInit).getTag();
 }
 
 void Context::throwException(ExecutionState& state, const Value& exception)

--- a/src/runtime/DataViewObject.h
+++ b/src/runtime/DataViewObject.h
@@ -29,16 +29,9 @@ namespace Escargot {
 
 class DataViewObject : public ArrayBufferView {
 public:
-    explicit DataViewObject(ExecutionState& state)
-        : ArrayBufferView(state)
-    {
-        Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->dataViewPrototype());
-    }
-
     explicit DataViewObject(ExecutionState& state, Object* proto)
-        : ArrayBufferView(state)
+        : ArrayBufferView(state, proto)
     {
-        Object::setPrototypeForIntrinsicObjectCreation(state, proto);
     }
 
     virtual TypedArrayType typedArrayType()

--- a/src/runtime/DateObject.cpp
+++ b/src/runtime/DateObject.cpp
@@ -154,21 +154,16 @@ static const char months[12][4] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
 static const char* invalidDate = "Invalid Date";
 
 DateObject::DateObject(ExecutionState& state)
-    : Object(state)
-    , m_primitiveValue(TIME64NAN)
-    , m_cachedLocal()
-    , m_isCacheDirty(false)
+    : DateObject(state, state.context()->globalObject()->datePrototype())
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->datePrototype());
 }
 
 DateObject::DateObject(ExecutionState& state, Object* proto)
-    : Object(state)
+    : Object(state, proto)
     , m_primitiveValue(TIME64NAN)
     , m_cachedLocal()
     , m_isCacheDirty(false)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, proto);
 }
 
 void DateObject::initCachedUTC(ExecutionState& state, DateObject* d)

--- a/src/runtime/DateObject.h
+++ b/src/runtime/DateObject.h
@@ -187,8 +187,8 @@ protected:
 
 class DatePrototypeObject : public DateObject {
 public:
-    DatePrototypeObject(ExecutionState& state)
-        : DateObject(state)
+    DatePrototypeObject(ExecutionState& state, Object* proto)
+        : DateObject(state, proto)
     {
     }
 

--- a/src/runtime/ErrorObject.cpp
+++ b/src/runtime/ErrorObject.cpp
@@ -133,66 +133,59 @@ void ErrorObject::throwBuiltinError(ExecutionState& state, Code code, String* ob
         str.replace(str.begin() + idx, str.begin() + idx + 2, replacer->toUTF16StringData().data());
     }
     errorMessage = new UTF16String(str.data(), str.length());
-    if (code == ReferenceError)
-        state.throwException(new ReferenceErrorObject(state, errorMessage));
-    else if (code == TypeError)
-        state.throwException(new TypeErrorObject(state, errorMessage));
-    else if (code == SyntaxError)
-        state.throwException(new SyntaxErrorObject(state, errorMessage));
-    else if (code == RangeError)
-        state.throwException(new RangeErrorObject(state, errorMessage));
-    else if (code == URIError)
-        state.throwException(new URIErrorObject(state, errorMessage));
-    else if (code == EvalError)
-        state.throwException(new EvalErrorObject(state, errorMessage));
-    else
-        state.throwException(new ErrorObject(state, errorMessage));
-}
-
-ErrorObject::ErrorObject(ExecutionState& state, String* errorMessage)
-    : Object(state)
-    , m_stackTraceData(nullptr)
-{
-    if (errorMessage->length()) {
-        defineOwnPropertyThrowsExceptionWhenStrictMode(state, state.context()->staticStrings().message,
-                                                       ObjectPropertyDescriptor(errorMessage, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
+    switch (code) {
+    case ReferenceError:
+        state.throwException(new ReferenceErrorObject(state, state.context()->globalObject()->referenceErrorPrototype(), errorMessage));
+        break;
+    case TypeError:
+        state.throwException(new TypeErrorObject(state, state.context()->globalObject()->typeErrorPrototype(), errorMessage));
+        break;
+    case SyntaxError:
+        state.throwException(new SyntaxErrorObject(state, state.context()->globalObject()->syntaxErrorPrototype(), errorMessage));
+        break;
+    case RangeError:
+        state.throwException(new RangeErrorObject(state, state.context()->globalObject()->rangeErrorPrototype(), errorMessage));
+        break;
+    case URIError:
+        state.throwException(new URIErrorObject(state, state.context()->globalObject()->uriErrorPrototype(), errorMessage));
+        break;
+    case EvalError:
+        state.throwException(new EvalErrorObject(state, state.context()->globalObject()->evalErrorPrototype(), errorMessage));
+        break;
+    default:
+        state.throwException(new ErrorObject(state, state.context()->globalObject()->errorPrototype(), errorMessage));
+        break;
     }
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->errorPrototype());
 }
 
 ErrorObject::ErrorObject(ExecutionState& state, Object* proto, String* errorMessage)
-    : Object(state)
+    : Object(state, proto)
     , m_stackTraceData(nullptr)
 {
     if (errorMessage->length()) {
         defineOwnPropertyThrowsExceptionWhenStrictMode(state, state.context()->staticStrings().message,
                                                        ObjectPropertyDescriptor(errorMessage, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
     }
-    Object::setPrototypeForIntrinsicObjectCreation(state, proto);
 }
 
 ErrorObject* ErrorObject::createError(ExecutionState& state, ErrorObject::Code code, String* errorMessage)
 {
-    if (code == ReferenceError)
-        return new ReferenceErrorObject(state, errorMessage);
-    else if (code == TypeError)
-        return new TypeErrorObject(state, errorMessage);
-    else if (code == SyntaxError)
-        return new SyntaxErrorObject(state, errorMessage);
-    else if (code == RangeError)
-        return new RangeErrorObject(state, errorMessage);
-    else if (code == URIError)
-        return new URIErrorObject(state, errorMessage);
-    else if (code == EvalError)
-        return new EvalErrorObject(state, errorMessage);
-    else
-        return new ErrorObject(state, errorMessage);
-}
-
-ReferenceErrorObject::ReferenceErrorObject(ExecutionState& state, String* errorMessage)
-    : ErrorObject(state, errorMessage)
-{
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->referenceErrorPrototype());
+    switch (code) {
+    case ReferenceError:
+        return new ReferenceErrorObject(state, state.context()->globalObject()->referenceErrorPrototype(), errorMessage);
+    case TypeError:
+        return new TypeErrorObject(state, state.context()->globalObject()->typeErrorPrototype(), errorMessage);
+    case SyntaxError:
+        return new SyntaxErrorObject(state, state.context()->globalObject()->syntaxErrorPrototype(), errorMessage);
+    case RangeError:
+        return new RangeErrorObject(state, state.context()->globalObject()->rangeErrorPrototype(), errorMessage);
+    case URIError:
+        return new URIErrorObject(state, state.context()->globalObject()->uriErrorPrototype(), errorMessage);
+    case EvalError:
+        return new EvalErrorObject(state, state.context()->globalObject()->evalErrorPrototype(), errorMessage);
+    default:
+        return new ErrorObject(state, state.context()->globalObject()->errorPrototype(), errorMessage);
+    }
 }
 
 ReferenceErrorObject::ReferenceErrorObject(ExecutionState& state, Object* proto, String* errorMessage)
@@ -200,21 +193,9 @@ ReferenceErrorObject::ReferenceErrorObject(ExecutionState& state, Object* proto,
 {
 }
 
-TypeErrorObject::TypeErrorObject(ExecutionState& state, String* errorMessage)
-    : ErrorObject(state, errorMessage)
-{
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->typeErrorPrototype());
-}
-
 TypeErrorObject::TypeErrorObject(ExecutionState& state, Object* proto, String* errorMessage)
     : ErrorObject(state, proto, errorMessage)
 {
-}
-
-RangeErrorObject::RangeErrorObject(ExecutionState& state, String* errorMessage)
-    : ErrorObject(state, errorMessage)
-{
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->rangeErrorPrototype());
 }
 
 RangeErrorObject::RangeErrorObject(ExecutionState& state, Object* proto, String* errorMessage)
@@ -222,32 +203,14 @@ RangeErrorObject::RangeErrorObject(ExecutionState& state, Object* proto, String*
 {
 }
 
-SyntaxErrorObject::SyntaxErrorObject(ExecutionState& state, String* errorMessage)
-    : ErrorObject(state, errorMessage)
-{
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->syntaxErrorPrototype());
-}
-
 SyntaxErrorObject::SyntaxErrorObject(ExecutionState& state, Object* proto, String* errorMessage)
     : ErrorObject(state, proto, errorMessage)
 {
 }
 
-URIErrorObject::URIErrorObject(ExecutionState& state, String* errorMessage)
-    : ErrorObject(state, errorMessage)
-{
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->uriErrorPrototype());
-}
-
 URIErrorObject::URIErrorObject(ExecutionState& state, Object* proto, String* errorMessage)
     : ErrorObject(state, proto, errorMessage)
 {
-}
-
-EvalErrorObject::EvalErrorObject(ExecutionState& state, String* errorMessage)
-    : ErrorObject(state, errorMessage)
-{
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->evalErrorPrototype());
 }
 
 EvalErrorObject::EvalErrorObject(ExecutionState& state, Object* proto, String* errorMessage)

--- a/src/runtime/ErrorObject.h
+++ b/src/runtime/ErrorObject.h
@@ -132,7 +132,6 @@ public:
     static void throwBuiltinError(ExecutionState& state, Code code, String* objectName, bool prototype, String* functionName, const char* templateString);
     static ErrorObject* createError(ExecutionState& state, ErrorObject::Code code, String* errorMessage);
 
-    ErrorObject(ExecutionState& state, String* errorMessage);
     ErrorObject(ExecutionState& state, Object* proto, String* errorMessage);
 
     virtual bool isErrorObject() const
@@ -183,37 +182,31 @@ private:
 
 class ReferenceErrorObject : public ErrorObject {
 public:
-    ReferenceErrorObject(ExecutionState& state, String* errorMessage);
     ReferenceErrorObject(ExecutionState& state, Object* proto, String* errorMessage);
 };
 
 class TypeErrorObject : public ErrorObject {
 public:
-    TypeErrorObject(ExecutionState& state, String* errorMessage);
     TypeErrorObject(ExecutionState& state, Object* proto, String* errorMessage);
 };
 
 class SyntaxErrorObject : public ErrorObject {
 public:
-    SyntaxErrorObject(ExecutionState& state, String* errorMessage);
     SyntaxErrorObject(ExecutionState& state, Object* proto, String* errorMessage);
 };
 
 class RangeErrorObject : public ErrorObject {
 public:
-    RangeErrorObject(ExecutionState& state, String* errorMessage);
     RangeErrorObject(ExecutionState& state, Object* proto, String* errorMessage);
 };
 
 class URIErrorObject : public ErrorObject {
 public:
-    URIErrorObject(ExecutionState& state, String* errorMessage);
     URIErrorObject(ExecutionState& state, Object* proto, String* errorMessage);
 };
 
 class EvalErrorObject : public ErrorObject {
 public:
-    EvalErrorObject(ExecutionState& state, String* errorMessage);
     EvalErrorObject(ExecutionState& state, Object* proto, String* errorMessage);
 };
 }

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -62,8 +62,8 @@ void FunctionObject::initStructureAndValues(ExecutionState& state, bool isConstr
 }
 
 // function for derived classes. derived class MUST initlize member variable of FunctionObject.
-FunctionObject::FunctionObject(ExecutionState& state, size_t defaultSpace)
-    : Object(state, defaultSpace, false)
+FunctionObject::FunctionObject(ExecutionState& state, Object* proto, size_t defaultSpace)
+    : Object(state, proto, defaultSpace)
 #ifndef NDEBUG
     , m_codeBlock((CodeBlock*)SIZE_MAX)
 #endif

--- a/src/runtime/FunctionObject.h
+++ b/src/runtime/FunctionObject.h
@@ -148,7 +148,7 @@ public:
     static FunctionSource createFunctionSourceFromScriptSource(ExecutionState& state, AtomicString functionName, size_t argumentValueArrayCount, Value* argumentValueArray, Value bodyString, bool useStrict, bool isGenerator, bool isAsync, bool allowSuperCall);
 
 protected:
-    FunctionObject(ExecutionState& state, size_t defaultSpace); // function for derived classes. derived class MUST initlize member variable of FunctionObject.
+    FunctionObject(ExecutionState& state, Object* proto, size_t defaultSpace); // function for derived classes. derived class MUST initlize member variable of FunctionObject.
 
     void initStructureAndValues(ExecutionState& state, bool isConstructor, bool isGenerator, bool isAsync);
     virtual size_t functionPrototypeIndex()

--- a/src/runtime/GeneratorObject.cpp
+++ b/src/runtime/GeneratorObject.cpp
@@ -27,20 +27,11 @@
 
 namespace Escargot {
 
-GeneratorObject::GeneratorObject(ExecutionState& state)
-    : GeneratorObject(state, nullptr, nullptr, nullptr, Value(Value::Null))
-{
-    Object* prototype = new Object(state);
-    prototype->setPrototype(state, state.context()->globalObject()->generatorPrototype());
-    setPrototype(state, prototype);
-}
-
-GeneratorObject::GeneratorObject(ExecutionState& state, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk, const Value& prototype)
-    : Object(state)
+GeneratorObject::GeneratorObject(ExecutionState& state, Object* proto, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk)
+    : Object(state, proto)
     , m_generatorState(GeneratorState::SuspendedStart)
     , m_executionPauser(state, this, executionState, registerFile, blk)
 {
-    setPrototype(state, prototype);
 }
 
 void* GeneratorObject::operator new(size_t size)

--- a/src/runtime/GeneratorObject.h
+++ b/src/runtime/GeneratorObject.h
@@ -45,8 +45,7 @@ public:
         Throw
     };
 
-    GeneratorObject(ExecutionState& state);
-    GeneratorObject(ExecutionState& state, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk, const Value& prototype);
+    GeneratorObject(ExecutionState& state, Object* proto, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk);
 
     virtual const char* internalClassProperty(ExecutionState& state) override
     {

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -49,7 +49,7 @@ public:
     friend class IdentifierNode;
 
     explicit GlobalObject(ExecutionState& state)
-        : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER, false)
+        : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER, Object::__ForGlobalBuiltin__)
         , m_context(state.context())
         , m_object(nullptr)
         , m_objectPrototypeToString(nullptr)
@@ -159,11 +159,9 @@ public:
         , m_asyncGeneratorFunction(nullptr)
     {
         m_objectPrototype = Object::createBuiltinObjectPrototype(state);
-        m_objectPrototype->markAsPrototypeObject(state);
-        m_objectPrototype->markThisObjectDontNeedStructureTransitionTable();
-        Object::setPrototype(state, m_objectPrototype);
 
-        m_structure = m_structure->convertToNonTransitionStructure();
+        Object::setPrototype(state, m_objectPrototype);
+        Object::setGlobalIntrinsicObject(state);
     }
 
     virtual bool isGlobalObject() const override

--- a/src/runtime/GlobalObjectBuiltinAsyncFromSyncIterator.cpp
+++ b/src/runtime/GlobalObjectBuiltinAsyncFromSyncIterator.cpp
@@ -109,7 +109,7 @@ static Value builtinAsyncFromSyncIteratorNext(ExecutionState& state, Value thisV
     // If Type(O) is not Object, or if O does not have a [[SyncIteratorRecord]] internal slot, then
     if (!O.isObject() || !O.asObject()->isAsyncFromSyncIteratorObject()) {
         // Let invalidIteratorError be a newly created TypeError object.
-        Value invalidIteratorError = new TypeErrorObject(state, String::fromASCII("given this value is not Async-from-Sync Iterator"));
+        Value invalidIteratorError = ErrorObject::createError(state, ErrorObject::TypeError, String::fromASCII("given this value is not Async-from-Sync Iterator"));
         // Perform ! Call(promiseCapability.[[Reject]], undefined, « invalidIteratorError »).
         Object::call(state, promiseCapability.m_rejectFunction, Value(), 1, &invalidIteratorError);
         // Return promiseCapability.[[Promise]].
@@ -142,7 +142,7 @@ static Value builtinAsyncFromSyncIteratorReturn(ExecutionState& state, Value thi
     // If Type(O) is not Object, or if O does not have a [[SyncIteratorRecord]] internal slot, then
     if (!O.isObject() || !O.asObject()->isAsyncFromSyncIteratorObject()) {
         // Let invalidIteratorError be a newly created TypeError object.
-        Value invalidIteratorError = new TypeErrorObject(state, String::fromASCII("given this value is not Async-from-Sync Iterator"));
+        Value invalidIteratorError = ErrorObject::createError(state, ErrorObject::TypeError, String::fromASCII("given this value is not Async-from-Sync Iterator"));
         // Perform ! Call(promiseCapability.[[Reject]], undefined, « invalidIteratorError »).
         Object::call(state, promiseCapability.m_rejectFunction, Value(), 1, &invalidIteratorError);
         // Return promiseCapability.[[Promise]].
@@ -185,7 +185,7 @@ static Value builtinAsyncFromSyncIteratorReturn(ExecutionState& state, Value thi
     // If Type(result) is not Object, then
     if (!result.isObject()) {
         // Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
-        Value typeError = new TypeErrorObject(state, String::fromASCII("result of iterator is not Object"));
+        Value typeError = ErrorObject::createError(state, ErrorObject::TypeError, String::fromASCII("result of iterator is not Object"));
         Object::call(state, promiseCapability.m_rejectFunction, Value(), 1, &typeError);
         // Return promiseCapability.[[Promise]].
         return promiseCapability.m_promise;
@@ -205,7 +205,7 @@ static Value builtinAsyncFromSyncIteratorThrow(ExecutionState& state, Value this
     // If Type(O) is not Object, or if O does not have a [[SyncIteratorRecord]] internal slot, then
     if (!O.isObject() || !O.asObject()->isAsyncFromSyncIteratorObject()) {
         // Let invalidIteratorError be a newly created TypeError object.
-        Value invalidIteratorError = new TypeErrorObject(state, String::fromASCII("given this value is not Async-from-Sync Iterator"));
+        Value invalidIteratorError = ErrorObject::createError(state, ErrorObject::TypeError, String::fromASCII("given this value is not Async-from-Sync Iterator"));
         // Perform ! Call(promiseCapability.[[Reject]], undefined, « invalidIteratorError »).
         Object::call(state, promiseCapability.m_rejectFunction, Value(), 1, &invalidIteratorError);
         // Return promiseCapability.[[Promise]].
@@ -247,7 +247,7 @@ static Value builtinAsyncFromSyncIteratorThrow(ExecutionState& state, Value this
     // If Type(result) is not Object, then
     if (!result.isObject()) {
         // Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
-        Value typeError = new TypeErrorObject(state, String::fromASCII("result of iterator is not Object"));
+        Value typeError = ErrorObject::createError(state, ErrorObject::TypeError, String::fromASCII("result of iterator is not Object"));
         Object::call(state, promiseCapability.m_rejectFunction, Value(), 1, &typeError);
         // Return promiseCapability.[[Promise]].
         return promiseCapability.m_promise;
@@ -259,10 +259,8 @@ static Value builtinAsyncFromSyncIteratorThrow(ExecutionState& state, Value this
 void GlobalObject::installAsyncFromSyncIterator(ExecutionState& state)
 {
     // https://www.ecma-international.org/ecma-262/10.0/#sec-%asyncfromsynciteratorprototype%-object
-    m_asyncFromSyncIteratorPrototype = new Object(state);
-    m_asyncFromSyncIteratorPrototype->markThisObjectDontNeedStructureTransitionTable();
-
-    m_asyncFromSyncIteratorPrototype->setPrototype(state, m_asyncIteratorPrototype);
+    m_asyncFromSyncIteratorPrototype = new Object(state, m_asyncIteratorPrototype);
+    m_asyncFromSyncIteratorPrototype->setGlobalIntrinsicObject(state, true);
 
     m_asyncFromSyncIteratorPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                                         ObjectPropertyDescriptor(String::fromASCII("Async-from-Sync Iterator"), ObjectPropertyDescriptor::ConfigurablePresent));

--- a/src/runtime/GlobalObjectBuiltinAsyncFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinAsyncFunction.cpp
@@ -39,20 +39,17 @@ static Value builtinAsyncFunction(ExecutionState& state, Value thisValue, size_t
     }
     Object* proto = Object::getPrototypeFromConstructor(state, newTarget.asObject(), state.context()->globalObject()->asyncFunctionPrototype());
 
-    ScriptAsyncFunctionObject* result = new ScriptAsyncFunctionObject(state, functionSource.codeBlock, functionSource.outerEnvironment);
-    result->setPrototype(state, proto);
-    return result;
+    return new ScriptAsyncFunctionObject(state, proto, functionSource.codeBlock, functionSource.outerEnvironment);
 }
 
 void GlobalObject::installAsyncFunction(ExecutionState& state)
 {
     m_asyncFunction = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().AsyncFunction, builtinAsyncFunction, 1), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_asyncFunction->markThisObjectDontNeedStructureTransitionTable();
+    m_asyncFunction->setGlobalIntrinsicObject(state);
     m_asyncFunction->setPrototype(state, m_function);
 
-    m_asyncFunctionPrototype = new Object(state);
-    m_asyncFunctionPrototype->setPrototype(state, m_functionPrototype);
-
+    m_asyncFunctionPrototype = new Object(state, m_functionPrototype);
+    m_asyncFunctionPrototype->setGlobalIntrinsicObject(state, true);
     m_asyncFunction->setFunctionPrototype(state, m_asyncFunctionPrototype);
 
     m_asyncFunctionPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor),

--- a/src/runtime/GlobalObjectBuiltinAsyncGeneratorFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinAsyncGeneratorFunction.cpp
@@ -38,9 +38,7 @@ static Value builtinAsyncGeneratorFunction(ExecutionState& state, Value thisValu
     }
     Object* proto = Object::getPrototypeFromConstructor(state, newTarget.asObject(), state.context()->globalObject()->asyncGenerator());
 
-    ScriptAsyncGeneratorFunctionObject* result = new ScriptAsyncGeneratorFunctionObject(state, functionSource.codeBlock, functionSource.outerEnvironment);
-    result->setPrototype(state, proto);
-    return result;
+    return new ScriptAsyncGeneratorFunctionObject(state, proto, functionSource.codeBlock, functionSource.outerEnvironment);
 }
 
 static Value builtinAsyncGeneratorNext(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
@@ -62,12 +60,12 @@ void GlobalObject::installAsyncGeneratorFunction(ExecutionState& state)
 {
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-asyncgeneratorfunction
     m_asyncGeneratorFunction = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().AsyncGeneratorFunction, builtinAsyncGeneratorFunction, 1), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_asyncGeneratorFunction->markThisObjectDontNeedStructureTransitionTable();
+    m_asyncGeneratorFunction->setGlobalIntrinsicObject(state);
     m_asyncGeneratorFunction->setPrototype(state, m_function);
 
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-properties-of-asyncgeneratorfunction-prototype
-    m_asyncGenerator = new Object(state);
-    m_asyncGenerator->setPrototype(state, m_functionPrototype);
+    m_asyncGenerator = new Object(state, m_functionPrototype);
+    m_asyncGenerator->setGlobalIntrinsicObject(state, true);
 
     m_asyncGeneratorFunction->setFunctionPrototype(state, m_asyncGenerator);
 
@@ -78,9 +76,8 @@ void GlobalObject::installAsyncGeneratorFunction(ExecutionState& state)
                                         ObjectPropertyDescriptor(state.context()->staticStrings().AsyncGeneratorFunction.string(), ObjectPropertyDescriptor::ConfigurablePresent));
 
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-properties-of-asyncgenerator-prototype
-    m_asyncGeneratorPrototype = new Object(state);
-    m_asyncGeneratorPrototype->markThisObjectDontNeedStructureTransitionTable();
-    m_asyncGeneratorPrototype->setPrototype(state, m_asyncIteratorPrototype);
+    m_asyncGeneratorPrototype = new Object(state, m_asyncIteratorPrototype);
+    m_asyncGeneratorPrototype->setGlobalIntrinsicObject(state, true);
 
     m_asyncGenerator->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().prototype), ObjectPropertyDescriptor(m_asyncGeneratorPrototype, ObjectPropertyDescriptor::ConfigurablePresent));
     m_asyncGeneratorPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_asyncGenerator, ObjectPropertyDescriptor::ConfigurablePresent));

--- a/src/runtime/GlobalObjectBuiltinAsyncIterator.cpp
+++ b/src/runtime/GlobalObjectBuiltinAsyncIterator.cpp
@@ -33,7 +33,7 @@ void GlobalObject::installAsyncIterator(ExecutionState& state)
 {
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-%iteratorprototype%-object
     m_asyncIteratorPrototype = new Object(state);
-    m_asyncIteratorPrototype->markThisObjectDontNeedStructureTransitionTable();
+    m_asyncIteratorPrototype->setGlobalIntrinsicObject(state, true);
 
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-asynciteratorprototype-asynciterator
     m_asyncIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().asyncIterator),

--- a/src/runtime/GlobalObjectBuiltinBoolean.cpp
+++ b/src/runtime/GlobalObjectBuiltinBoolean.cpp
@@ -63,12 +63,10 @@ void GlobalObject::installBoolean(ExecutionState& state)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
     m_boolean = new NativeFunctionObject(state, NativeFunctionInfo(strings->Boolean, builtinBooleanConstructor, 1), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_boolean->markThisObjectDontNeedStructureTransitionTable();
-    m_boolean->setPrototype(state, m_functionPrototype);
-    m_booleanPrototype = m_objectPrototype;
-    m_booleanPrototype = new BooleanObject(state, false);
-    m_booleanPrototype->markThisObjectDontNeedStructureTransitionTable();
-    m_booleanPrototype->setPrototype(state, m_objectPrototype);
+    m_boolean->setGlobalIntrinsicObject(state);
+
+    m_booleanPrototype = new BooleanObject(state, m_objectPrototype, false);
+    m_booleanPrototype->setGlobalIntrinsicObject(state, true);
     m_booleanPrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(m_boolean, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     // $19.3.3.2 Boolean.prototype.toString

--- a/src/runtime/GlobalObjectBuiltinDataView.cpp
+++ b/src/runtime/GlobalObjectBuiltinDataView.cpp
@@ -154,14 +154,12 @@ static Value builtinDataViewByteOffsetGetter(ExecutionState& state, Value thisVa
 void GlobalObject::installDataView(ExecutionState& state)
 {
     m_dataView = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().DataView, builtinDataViewConstructor, 3), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_dataView->markThisObjectDontNeedStructureTransitionTable();
-    m_dataView->setPrototype(state, m_functionPrototype);
+    m_dataView->setGlobalIntrinsicObject(state);
 
-    m_dataViewPrototype = m_objectPrototype;
-    m_dataViewPrototype = new DataViewObject(state);
-    m_dataViewPrototype->markThisObjectDontNeedStructureTransitionTable();
-    m_dataViewPrototype->setPrototype(state, m_objectPrototype);
+    m_dataViewPrototype = new DataViewObject(state, m_objectPrototype);
+    m_dataViewPrototype->setGlobalIntrinsicObject(state, true);
     m_dataView->setFunctionPrototype(state, m_dataViewPrototype);
+
     m_dataViewPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_dataView, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
     m_dataViewPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, Value(state.context()->vmInstance()->globalSymbols().toStringTag)),
                                                           ObjectPropertyDescriptor(Value(state.context()->staticStrings().DataView.string()), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinDate.cpp
+++ b/src/runtime/GlobalObjectBuiltinDate.cpp
@@ -554,12 +554,10 @@ static Value builtinDateToPrimitive(ExecutionState& state, Value thisValue, size
 void GlobalObject::installDate(ExecutionState& state)
 {
     m_date = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Date, builtinDateConstructor, 7), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_date->markThisObjectDontNeedStructureTransitionTable();
-    m_date->setPrototype(state, m_functionPrototype);
-    m_datePrototype = m_objectPrototype;
-    m_datePrototype = new DatePrototypeObject(state);
-    m_datePrototype->markThisObjectDontNeedStructureTransitionTable();
-    m_datePrototype->setPrototype(state, m_objectPrototype);
+    m_date->setGlobalIntrinsicObject(state);
+
+    m_datePrototype = new DatePrototypeObject(state, m_objectPrototype);
+    m_datePrototype->setGlobalIntrinsicObject(state, true);
 
     m_datePrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_date, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 

--- a/src/runtime/GlobalObjectBuiltinIntl.cpp
+++ b/src/runtime/GlobalObjectBuiltinIntl.cpp
@@ -443,13 +443,14 @@ static Value builtinIntlGetCanonicalLocales(ExecutionState& state, Value thisVal
 void GlobalObject::installIntl(ExecutionState& state)
 {
     m_intl = new Object(state);
-    m_intl->markThisObjectDontNeedStructureTransitionTable();
+    m_intl->setGlobalIntrinsicObject(state);
 
     const StaticStrings* strings = &state.context()->staticStrings();
     defineOwnProperty(state, ObjectPropertyName(strings->Intl),
                       ObjectPropertyDescriptor(m_intl, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_intlCollator = new NativeFunctionObject(state, NativeFunctionInfo(strings->Collator, builtinIntlCollatorConstructor, 0), NativeFunctionObject::__ForBuiltinConstructor__);
+    m_intlCollator->setGlobalIntrinsicObject(state);
 
     FunctionObject* compareFunction = new NativeFunctionObject(state, NativeFunctionInfo(strings->compare, builtinIntlCollatorCompareGetter, 0, NativeFunctionInfo::Strict));
     m_intlCollator->getFunctionPrototype(state).asObject()->defineOwnProperty(state, state.context()->staticStrings().compare,
@@ -465,6 +466,7 @@ void GlobalObject::installIntl(ExecutionState& state)
                                       ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->supportedLocalesOf, builtinIntlCollatorSupportedLocalesOf, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent | ObjectPropertyDescriptor::WritablePresent)));
 
     m_intlDateTimeFormat = new NativeFunctionObject(state, NativeFunctionInfo(strings->DateTimeFormat, builtinIntlDateTimeFormatConstructor, 0), NativeFunctionObject::__ForBuiltinConstructor__);
+    m_intlDateTimeFormat->setGlobalIntrinsicObject(state);
 
     FunctionObject* formatFunction = new NativeFunctionObject(state, NativeFunctionInfo(strings->format, builtinIntlDateTimeFormatFormatGetter, 0, NativeFunctionInfo::Strict));
     m_intlDateTimeFormat->getFunctionPrototype(state).asObject()->defineOwnProperty(state, state.context()->staticStrings().format,
@@ -477,6 +479,7 @@ void GlobalObject::installIntl(ExecutionState& state)
                                             ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->supportedLocalesOf, builtinIntlDateTimeFormatSupportedLocalesOf, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent | ObjectPropertyDescriptor::WritablePresent)));
 
     m_intlNumberFormat = new NativeFunctionObject(state, NativeFunctionInfo(strings->NumberFormat, builtinIntlNumberFormatConstructor, 0), NativeFunctionObject::__ForBuiltinConstructor__);
+    m_intlNumberFormat->setGlobalIntrinsicObject(state);
 
     formatFunction = new NativeFunctionObject(state, NativeFunctionInfo(strings->format, builtinIntlNumberFormatFormatGetter, 0, NativeFunctionInfo::Strict));
     m_intlNumberFormat->getFunctionPrototype(state).asObject()->defineOwnProperty(state, state.context()->staticStrings().format,

--- a/src/runtime/GlobalObjectBuiltinIterator.cpp
+++ b/src/runtime/GlobalObjectBuiltinIterator.cpp
@@ -34,7 +34,7 @@ static Value builtinIteratorIterator(ExecutionState& state, Value thisValue, siz
 void GlobalObject::installIterator(ExecutionState& state)
 {
     m_iteratorPrototype = new Object(state);
-    m_iteratorPrototype->markThisObjectDontNeedStructureTransitionTable();
+    m_iteratorPrototype->setGlobalIntrinsicObject(state, true);
 
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-%iteratorprototype%-@@iterator
     FunctionObject* fn = new NativeFunctionObject(state, NativeFunctionInfo(AtomicString(state, String::fromASCII("[Symbol.iterator]")), builtinIteratorIterator, 0, NativeFunctionInfo::Strict));

--- a/src/runtime/GlobalObjectBuiltinJSON.cpp
+++ b/src/runtime/GlobalObjectBuiltinJSON.cpp
@@ -668,7 +668,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
 void GlobalObject::installJSON(ExecutionState& state)
 {
     m_json = new Object(state);
-    m_json->markThisObjectDontNeedStructureTransitionTable();
+    m_json->setGlobalIntrinsicObject(state);
     m_json->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, Value(state.context()->vmInstance()->globalSymbols().toStringTag)),
                                              ObjectPropertyDescriptor(Value(state.context()->staticStrings().JSON.string()), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent)));
 

--- a/src/runtime/GlobalObjectBuiltinMath.cpp
+++ b/src/runtime/GlobalObjectBuiltinMath.cpp
@@ -415,7 +415,7 @@ static Value builtinMathExpm1(ExecutionState& state, Value thisValue, size_t arg
 void GlobalObject::installMath(ExecutionState& state)
 {
     m_math = new Object(state);
-    m_math->markThisObjectDontNeedStructureTransitionTable();
+    m_math->setGlobalIntrinsicObject(state);
 
     m_math->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, Value(state.context()->vmInstance()->globalSymbols().toStringTag)),
                                              ObjectPropertyDescriptor(Value(state.context()->staticStrings().Math.string()), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinNumber.cpp
+++ b/src/runtime/GlobalObjectBuiltinNumber.cpp
@@ -387,13 +387,12 @@ void GlobalObject::installNumber(ExecutionState& state)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
     m_number = new NativeFunctionObject(state, NativeFunctionInfo(strings->Number, builtinNumberConstructor, 1), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_number->markThisObjectDontNeedStructureTransitionTable();
-    m_number->setPrototype(state, m_functionPrototype);
-    m_numberPrototype = m_objectPrototype;
-    m_numberPrototype = new NumberObject(state, 0);
-    m_numberPrototype->markThisObjectDontNeedStructureTransitionTable();
-    m_numberPrototype->setPrototype(state, m_objectPrototype);
+    m_number->setGlobalIntrinsicObject(state);
+
+    m_numberPrototype = new NumberObject(state, m_objectPrototype, 0);
+    m_numberPrototype->setGlobalIntrinsicObject(state, true);
     m_number->setFunctionPrototype(state, m_numberPrototype);
+
     m_numberPrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(m_number, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_numberPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(strings->toString),

--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -357,7 +357,7 @@ static Value builtinObjectFromEntries(ExecutionState& state, Value thisValue, si
 
         Value nextItem = IteratorObject::iteratorValue(state, next.value());
         if (!nextItem.isObject()) {
-            TypeErrorObject* errorobj = new TypeErrorObject(state, new ASCIIString("TypeError"));
+            ErrorObject* errorobj = ErrorObject::createError(state, ErrorObject::TypeError, new ASCIIString("TypeError"));
             return IteratorObject::iteratorClose(state, iteratorRecord, errorobj, true);
         }
 
@@ -666,11 +666,10 @@ void GlobalObject::installObject(ExecutionState& state)
 {
     const StaticStrings& strings = state.context()->staticStrings();
 
-    FunctionObject* emptyFunction = m_functionPrototype;
     m_object = new NativeFunctionObject(state, NativeFunctionInfo(strings.Object, builtinObjectConstructor, 1), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_object->markThisObjectDontNeedStructureTransitionTable();
-    m_object->setPrototype(state, emptyFunction);
+    m_object->setGlobalIntrinsicObject(state);
     m_object->setFunctionPrototype(state, m_objectPrototype);
+
     // $19.1.2.2 Object.create (O [,Properties])
     m_objectCreate = new NativeFunctionObject(state, NativeFunctionInfo(strings.create, builtinObjectCreate, 2, NativeFunctionInfo::Strict));
     m_object->defineOwnProperty(state, ObjectPropertyName(strings.create),

--- a/src/runtime/GlobalObjectBuiltinPromise.cpp
+++ b/src/runtime/GlobalObjectBuiltinPromise.cpp
@@ -376,8 +376,7 @@ void GlobalObject::installPromise(ExecutionState& state)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
     m_promise = new NativeFunctionObject(state, NativeFunctionInfo(strings->Promise, builtinPromiseConstructor, 1), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_promise->markThisObjectDontNeedStructureTransitionTable();
-    m_promise->setPrototype(state, m_functionPrototype);
+    m_promise->setGlobalIntrinsicObject(state);
 
     {
         JSGetterSetter gs(
@@ -387,7 +386,8 @@ void GlobalObject::installPromise(ExecutionState& state)
     }
 
     m_promisePrototype = new Object(state);
-    m_promisePrototype->markThisObjectDontNeedStructureTransitionTable();
+    m_promisePrototype->setGlobalIntrinsicObject(state, true);
+
     m_promisePrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(m_promise, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
     m_promisePrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                                          ObjectPropertyDescriptor(Value(state.context()->staticStrings().Promise.string()), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinProxy.cpp
+++ b/src/runtime/GlobalObjectBuiltinProxy.cpp
@@ -105,7 +105,7 @@ void GlobalObject::installProxy(ExecutionState& state)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
     m_proxy = new NativeFunctionObject(state, NativeFunctionInfo(strings->Proxy, builtinProxyConstructor, 2), NativeFunctionObject::__ForBuiltinProxyConstructor__);
-    m_proxy->markThisObjectDontNeedStructureTransitionTable();
+    m_proxy->setGlobalIntrinsicObject(state);
 
     m_proxy->defineOwnPropertyThrowsException(state, ObjectPropertyName(strings->revocable), ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->revocable, builtinProxyRevocable, 2, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 

--- a/src/runtime/GlobalObjectBuiltinReflect.cpp
+++ b/src/runtime/GlobalObjectBuiltinReflect.cpp
@@ -312,7 +312,7 @@ void GlobalObject::installReflect(ExecutionState& state)
 {
     const StaticStrings* strings = &state.context()->staticStrings();
     m_reflect = new Object(state);
-    m_reflect->markThisObjectDontNeedStructureTransitionTable();
+    m_reflect->setGlobalIntrinsicObject(state);
 
     m_reflect->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().apply),
                                                 ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().apply, builtinReflectApply, 3, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinSet.cpp
+++ b/src/runtime/GlobalObjectBuiltinSet.cpp
@@ -182,8 +182,7 @@ static Value builtinSetIteratorNext(ExecutionState& state, Value thisValue, size
 void GlobalObject::installSet(ExecutionState& state)
 {
     m_set = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Set, builtinSetConstructor, 0), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_set->markThisObjectDontNeedStructureTransitionTable();
-    m_set->setPrototype(state, m_functionPrototype);
+    m_set->setGlobalIntrinsicObject(state);
 
     {
         JSGetterSetter gs(
@@ -192,9 +191,8 @@ void GlobalObject::installSet(ExecutionState& state)
         m_set->defineOwnProperty(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().species), desc);
     }
 
-    m_setPrototype = m_objectPrototype;
-    m_setPrototype = new SetPrototypeObject(state);
-    m_setPrototype->markThisObjectDontNeedStructureTransitionTable();
+    m_setPrototype = new SetPrototypeObject(state, m_objectPrototype);
+    m_setPrototype->setGlobalIntrinsicObject(state, true);
     m_setPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_set, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_setPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().clear),
@@ -231,8 +229,8 @@ void GlobalObject::installSet(ExecutionState& state)
     ObjectPropertyDescriptor desc(gs, ObjectPropertyDescriptor::ConfigurablePresent);
     m_setPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().size), desc);
 
-    m_setIteratorPrototype = m_iteratorPrototype;
-    m_setIteratorPrototype = new SetIteratorObject(state, nullptr, SetIteratorObject::TypeKey);
+    m_setIteratorPrototype = new SetIteratorObject(state, m_iteratorPrototype, nullptr, SetIteratorObject::TypeKey);
+    m_setIteratorPrototype->setGlobalIntrinsicObject(state, true);
 
     m_setIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().next),
                                                              ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().next, builtinSetIteratorNext, 0, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinSymbol.cpp
+++ b/src/runtime/GlobalObjectBuiltinSymbol.cpp
@@ -104,8 +104,7 @@ Value builtinSymbolKeyFor(ExecutionState& state, Value thisValue, size_t argc, V
 void GlobalObject::installSymbol(ExecutionState& state)
 {
     m_symbol = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Symbol, builtinSymbolConstructor, 0), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_symbol->markThisObjectDontNeedStructureTransitionTable();
-    m_symbol->setPrototype(state, m_functionPrototype);
+    m_symbol->setGlobalIntrinsicObject(state);
 
     m_symbol->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().stringFor),
                                 ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().stringFor, builtinSymbolFor, 1, NativeFunctionInfo::Strict)),
@@ -115,9 +114,9 @@ void GlobalObject::installSymbol(ExecutionState& state)
                                 ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().keyFor, builtinSymbolKeyFor, 1, NativeFunctionInfo::Strict)),
                                                          (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
-    m_symbolPrototype = m_objectPrototype;
     m_symbolPrototype = new Object(state);
-    m_symbolPrototype->markThisObjectDontNeedStructureTransitionTable();
+    m_symbolPrototype->setGlobalIntrinsicObject(state, true);
+
     m_symbolPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_symbol, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_symbolPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().toString),

--- a/src/runtime/GlobalObjectBuiltinTypedArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinTypedArray.cpp
@@ -1588,11 +1588,11 @@ FunctionObject* GlobalObject::installTypedArray(ExecutionState& state, AtomicStr
 {
     const StaticStrings* strings = &state.context()->staticStrings();
     NativeFunctionObject* taConstructor = new NativeFunctionObject(state, NativeFunctionInfo(taName, builtinTypedArrayConstructor<TA, elementSize, TypeAdaptor>, 3), NativeFunctionObject::__ForBuiltinConstructor__);
-    taConstructor->markThisObjectDontNeedStructureTransitionTable();
+    taConstructor->setGlobalIntrinsicObject(state);
 
     *proto = m_objectPrototype;
     Object* taPrototype = new TypedArrayObjectPrototype(state);
-    taPrototype->markThisObjectDontNeedStructureTransitionTable();
+    taPrototype->setGlobalIntrinsicObject(state, true);
     taPrototype->setPrototype(state, typedArrayFunction->getFunctionPrototype(state));
 
     taConstructor->setPrototype(state, typedArrayFunction); // %TypedArray%
@@ -1649,15 +1649,15 @@ static Value builtinTypedArrayToStringTagGetter(ExecutionState& state, Value thi
 void GlobalObject::installTypedArray(ExecutionState& state)
 {
     m_arrayBuffer = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().ArrayBuffer, builtinArrayBufferConstructor, 1), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_arrayBuffer->markThisObjectDontNeedStructureTransitionTable();
-    m_arrayBuffer->setPrototype(state, m_functionPrototype);
+    m_arrayBuffer->setGlobalIntrinsicObject(state);
+
     m_arrayBuffer->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().isView),
                                      ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().isView, builtinArrayBufferIsView, 1, NativeFunctionInfo::Strict)),
                                                               (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
-    m_arrayBufferPrototype = m_objectPrototype;
-    m_arrayBufferPrototype = new ArrayBufferObject(state);
-    m_arrayBufferPrototype->setPrototype(state, m_objectPrototype);
+    m_arrayBufferPrototype = new ArrayBufferObject(state, m_objectPrototype);
+    m_arrayBufferPrototype->setGlobalIntrinsicObject(state, true);
+
     m_arrayBufferPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_arrayBuffer, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
     m_arrayBufferPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                                              ObjectPropertyDescriptor(Value(state.context()->staticStrings().ArrayBuffer.string()), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent)));
@@ -1686,6 +1686,7 @@ void GlobalObject::installTypedArray(ExecutionState& state)
 
     // %TypedArray%
     FunctionObject* typedArrayFunction = new NativeFunctionObject(state, NativeFunctionInfo(strings->TypedArray, builtinTypedArrayConstructor, 0), NativeFunctionObject::__ForBuiltinConstructor__);
+    typedArrayFunction->setGlobalIntrinsicObject(state);
 
     typedArrayFunction->defineOwnPropertyThrowsException(state, ObjectPropertyName(strings->from),
                                                          ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->from, builtinTypedArrayFrom, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
@@ -1701,6 +1702,7 @@ void GlobalObject::installTypedArray(ExecutionState& state)
 
     // %TypedArray%.prototype
     Object* typedArrayPrototype = typedArrayFunction->getFunctionPrototype(state).asObject();
+    typedArrayPrototype->setGlobalIntrinsicObject(state, true);
     typedArrayPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(strings->subarray),
                                                           ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->subarray, builtinTypedArraySubArray, 2, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
     typedArrayPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(strings->set),

--- a/src/runtime/GlobalObjectBuiltinWeakMap.cpp
+++ b/src/runtime/GlobalObjectBuiltinWeakMap.cpp
@@ -63,7 +63,7 @@ Value builtinWeakMapConstructor(ExecutionState& state, Value thisValue, size_t a
 
         Value nextItem = IteratorObject::iteratorValue(state, next.value());
         if (!nextItem.isObject()) {
-            TypeErrorObject* errorobj = new TypeErrorObject(state, new ASCIIString("TypeError"));
+            ErrorObject* errorobj = ErrorObject::createError(state, ErrorObject::TypeError, new ASCIIString("TypeError"));
             return IteratorObject::iteratorClose(state, iteratorRecord, errorobj, true);
         }
 
@@ -139,11 +139,10 @@ static Value builtinWeakMapSet(ExecutionState& state, Value thisValue, size_t ar
 void GlobalObject::installWeakMap(ExecutionState& state)
 {
     m_weakMap = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().WeakMap, builtinWeakMapConstructor, 0), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_weakMap->markThisObjectDontNeedStructureTransitionTable();
-    m_weakMap->setPrototype(state, m_functionPrototype);
-    m_weakMapPrototype = m_objectPrototype;
-    m_weakMapPrototype = new WeakMapObject(state);
-    m_weakMapPrototype->markThisObjectDontNeedStructureTransitionTable();
+    m_weakMap->setGlobalIntrinsicObject(state);
+
+    m_weakMapPrototype = new WeakMapObject(state, m_objectPrototype);
+    m_weakMapPrototype->setGlobalIntrinsicObject(state, true);
     m_weakMapPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_weakMap, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_weakMapPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().stringDelete),

--- a/src/runtime/GlobalObjectBuiltinWeakSet.cpp
+++ b/src/runtime/GlobalObjectBuiltinWeakSet.cpp
@@ -127,11 +127,10 @@ static Value builtinWeakSetHas(ExecutionState& state, Value thisValue, size_t ar
 void GlobalObject::installWeakSet(ExecutionState& state)
 {
     m_weakSet = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().WeakSet, builtinWeakSetConstructor, 0), NativeFunctionObject::__ForBuiltinConstructor__);
-    m_weakSet->markThisObjectDontNeedStructureTransitionTable();
-    m_weakSet->setPrototype(state, m_functionPrototype);
-    m_weakSetPrototype = m_objectPrototype;
-    m_weakSetPrototype = new WeakSetPrototypeObject(state);
-    m_weakSetPrototype->markThisObjectDontNeedStructureTransitionTable();
+    m_weakSet->setGlobalIntrinsicObject(state);
+
+    m_weakSetPrototype = new WeakSetPrototypeObject(state, m_objectPrototype);
+    m_weakSetPrototype->setGlobalIntrinsicObject(state, true);
     m_weakSetPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_weakSet, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_weakSetPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().stringDelete),

--- a/src/runtime/IteratorObject.cpp
+++ b/src/runtime/IteratorObject.cpp
@@ -29,7 +29,12 @@
 namespace Escargot {
 
 IteratorObject::IteratorObject(ExecutionState& state)
-    : Object(state)
+    : IteratorObject(state, state.context()->globalObject()->objectPrototype())
+{
+}
+
+IteratorObject::IteratorObject(ExecutionState& state, Object* proto)
+    : Object(state, proto)
 {
 }
 

--- a/src/runtime/IteratorObject.h
+++ b/src/runtime/IteratorObject.h
@@ -52,6 +52,7 @@ public:
 class IteratorObject : public Object {
 public:
     explicit IteratorObject(ExecutionState& state);
+    explicit IteratorObject(ExecutionState& state, Object* proto);
 
     virtual bool isIteratorObject() const
     {

--- a/src/runtime/MapObject.cpp
+++ b/src/runtime/MapObject.cpp
@@ -25,15 +25,13 @@
 namespace Escargot {
 
 MapObject::MapObject(ExecutionState& state)
-    : Object(state)
+    : MapObject(state, state.context()->globalObject()->mapPrototype())
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->mapPrototype());
 }
 
 MapObject::MapObject(ExecutionState& state, Object* proto)
-    : Object(state)
+    : Object(state, proto)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, proto);
 }
 
 void* MapObject::operator new(size_t size)
@@ -152,12 +150,16 @@ MapIteratorObject* MapObject::entries(ExecutionState& state)
 }
 
 MapIteratorObject::MapIteratorObject(ExecutionState& state, MapObject* map, Type type)
-    : IteratorObject(state)
+    : MapIteratorObject(state, state.context()->globalObject()->mapIteratorPrototype(), map, type)
+{
+}
+
+MapIteratorObject::MapIteratorObject(ExecutionState& state, Object* proto, MapObject* map, Type type)
+    : IteratorObject(state, proto)
     , m_map(map)
     , m_iteratorIndex(0)
     , m_type(type)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->mapIteratorPrototype());
 }
 
 void* MapIteratorObject::operator new(size_t size)

--- a/src/runtime/MapObject.h
+++ b/src/runtime/MapObject.h
@@ -32,6 +32,7 @@ class MapObject : public Object {
 
 public:
     typedef TightVector<std::pair<SmallValue, SmallValue>, GCUtil::gc_malloc_allocator<std::pair<SmallValue, SmallValue>>> MapObjectData;
+
     explicit MapObject(ExecutionState& state);
     explicit MapObject(ExecutionState& state, Object* proto);
 
@@ -76,7 +77,9 @@ public:
         TypeValue,
         TypeKeyValue
     };
+
     MapIteratorObject(ExecutionState& state, MapObject* map, Type type);
+    MapIteratorObject(ExecutionState& state, Object* proto, MapObject* map, Type type);
 
     virtual bool isMapIteratorObject() const override
     {

--- a/src/runtime/NativeFunctionObject.cpp
+++ b/src/runtime/NativeFunctionObject.cpp
@@ -24,18 +24,11 @@
 
 namespace Escargot {
 
-// function for derived classes. derived class MUST initlize member variable of FunctionObject.
-NativeFunctionObject::NativeFunctionObject(ExecutionState& state, size_t defaultSpace)
-    : FunctionObject(state, defaultSpace)
-{
-}
-
 NativeFunctionObject::NativeFunctionObject(ExecutionState& state, CodeBlock* codeBlock)
-    : FunctionObject(state, codeBlock->isNativeFunctionConstructor() ? (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3) : (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2))
+    : FunctionObject(state, state.context()->globalObject()->functionPrototype(), codeBlock->isNativeFunctionConstructor() ? (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3) : (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2))
 {
     m_codeBlock = codeBlock;
     initStructureAndValues(state, m_codeBlock->isNativeFunctionConstructor(), false, false);
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->functionPrototype());
     if (NativeFunctionObject::isConstructor())
         m_structure = state.context()->defaultStructureForBuiltinFunctionObject();
 
@@ -43,15 +36,14 @@ NativeFunctionObject::NativeFunctionObject(ExecutionState& state, CodeBlock* cod
 }
 
 NativeFunctionObject::NativeFunctionObject(ExecutionState& state, NativeFunctionInfo info)
-    : FunctionObject(state, info.m_isConstructor ? (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3) : (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2))
+    : FunctionObject(state, state.context()->globalObject()->functionPrototype(), info.m_isConstructor ? (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3) : (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2))
 {
     m_codeBlock = new CodeBlock(state.context(), info);
     initStructureAndValues(state, m_codeBlock->isNativeFunctionConstructor(), false, false);
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->functionPrototype());
 }
 
 NativeFunctionObject::NativeFunctionObject(ExecutionState& state, CodeBlock* codeBlock, ForGlobalBuiltin)
-    : FunctionObject(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2)
+    : FunctionObject(state, state.context()->globalObject()->objectPrototype(), ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2)
 {
     m_codeBlock = codeBlock;
     ASSERT(!NativeFunctionObject::isConstructor());
@@ -59,12 +51,11 @@ NativeFunctionObject::NativeFunctionObject(ExecutionState& state, CodeBlock* cod
 }
 
 NativeFunctionObject::NativeFunctionObject(ExecutionState& state, CodeBlock* codeBlock, ForBuiltinConstructor)
-    : FunctionObject(state, codeBlock->isNativeFunctionConstructor() ? (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3) : (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2))
+    : FunctionObject(state, state.context()->globalObject()->functionPrototype(), codeBlock->isNativeFunctionConstructor() ? (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3) : (ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2))
 {
     m_codeBlock = codeBlock;
 
     initStructureAndValues(state, codeBlock->isNativeFunctionConstructor(), false, false);
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->functionPrototype());
     if (NativeFunctionObject::isConstructor())
         m_structure = state.context()->defaultStructureForBuiltinFunctionObject();
 
@@ -72,12 +63,11 @@ NativeFunctionObject::NativeFunctionObject(ExecutionState& state, CodeBlock* cod
 }
 
 NativeFunctionObject::NativeFunctionObject(ExecutionState& state, NativeFunctionInfo info, ForBuiltinConstructor)
-    : FunctionObject(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3)
+    : FunctionObject(state, state.context()->globalObject()->functionPrototype(), ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 3)
 {
     m_codeBlock = new CodeBlock(state.context(), info);
 
     initStructureAndValues(state, m_codeBlock->isNativeFunctionConstructor(), false, false);
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->functionPrototype());
     m_structure = state.context()->defaultStructureForBuiltinFunctionObject();
 
     ASSERT(NativeFunctionObject::isConstructor());
@@ -85,7 +75,7 @@ NativeFunctionObject::NativeFunctionObject(ExecutionState& state, NativeFunction
 }
 
 NativeFunctionObject::NativeFunctionObject(ExecutionState& state, NativeFunctionInfo info, ForBuiltinProxyConstructor)
-    : FunctionObject(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2)
+    : FunctionObject(state, state.context()->globalObject()->functionPrototype(), ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 2)
 {
     m_codeBlock = new CodeBlock(state.context(), info);
 
@@ -93,7 +83,6 @@ NativeFunctionObject::NativeFunctionObject(ExecutionState& state, NativeFunction
     m_structure = state.context()->defaultStructureForNotConstructorFunctionObject();
     m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 0] = (Value(m_codeBlock->functionName().string()));
     m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1] = (Value(m_codeBlock->functionLength()));
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->functionPrototype());
 
     ASSERT(NativeFunctionObject::isConstructor());
     ASSERT(codeBlock()->hasCallNativeFunctionCode());

--- a/src/runtime/NativeFunctionObject.h
+++ b/src/runtime/NativeFunctionObject.h
@@ -53,7 +53,6 @@ public:
 protected:
     template <bool isConstruct>
     ALWAYS_INLINE Value processNativeFunctionCall(ExecutionState& state, const Value& receiver, const size_t argc, Value* argv, Object* newTarget);
-    NativeFunctionObject(ExecutionState& state, size_t defaultSpace); // function for derived classes. derived class MUST initlize member variable of FunctionObject.
 };
 }
 

--- a/src/runtime/NumberObject.cpp
+++ b/src/runtime/NumberObject.cpp
@@ -27,17 +27,14 @@
 namespace Escargot {
 
 NumberObject::NumberObject(ExecutionState& state, double value)
-    : Object(state)
-    , m_primitiveValue(value)
+    : NumberObject(state, state.context()->globalObject()->numberPrototype(), value)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->numberPrototype());
 }
 
 NumberObject::NumberObject(ExecutionState& state, Object* proto, double value)
-    : Object(state)
+    : Object(state, proto)
     , m_primitiveValue(value)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, proto);
 }
 
 void* NumberObject::operator new(size_t size)

--- a/src/runtime/NumberObject.h
+++ b/src/runtime/NumberObject.h
@@ -29,8 +29,8 @@ namespace Escargot {
 
 class NumberObject : public Object {
 public:
-    NumberObject(ExecutionState& state, double value = 0);
-    NumberObject(ExecutionState& state, Object* proto, double value);
+    explicit NumberObject(ExecutionState& state, double value = 0);
+    explicit NumberObject(ExecutionState& state, Object* proto, double value = 0);
 
     double primitiveValue()
     {

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -717,6 +717,8 @@ class Object : public PointerValue {
     friend struct ObjectRareData;
 
 public:
+    enum ForGlobalBuiltin { __ForGlobalBuiltin__ };
+
     explicit Object(ExecutionState& state);
     explicit Object(ExecutionState& state, Object* proto);
 
@@ -1058,6 +1060,7 @@ public:
     IteratorObject* entries(ExecutionState& state);
 
     Value speciesConstructor(ExecutionState& state, const Value& defaultConstructor);
+    void markAsPrototypeObject(ExecutionState& state);
 
 protected:
     static inline void fillGCDescriptor(GC_word* desc)
@@ -1067,8 +1070,9 @@ protected:
         GC_set_bit(desc, GC_WORD_OFFSET(Object, m_values));
     }
 
-    Object(ExecutionState& state, size_t defaultSpace, bool initPlainArea);
-    void initPlainObject(ExecutionState& state);
+    explicit Object(ExecutionState& state, Object* proto, size_t defaultSpace);
+    explicit Object(ExecutionState& state, size_t defaultSpace, ForGlobalBuiltin);
+
     ObjectRareData* rareData() const
     {
         if ((size_t)m_prototype > 2 && g_objectRareDataTag == *((size_t*)(m_prototype))) {
@@ -1169,9 +1173,8 @@ protected:
         }
     }
 
-    void setPrototypeForIntrinsicObjectCreation(ExecutionState& state, Object* obj);
+    void setGlobalIntrinsicObject(ExecutionState& state, bool isPrototype = false);
 
-    void markAsPrototypeObject(ExecutionState& state);
     void deleteOwnProperty(ExecutionState& state, size_t idx);
 };
 }

--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -31,35 +31,29 @@
 namespace Escargot {
 
 RegExpObject::RegExpObject(ExecutionState& state, String* source, String* option)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 5, true)
-    , m_source(NULL)
-    , m_optionString(NULL)
-    , m_option(None)
-    , m_yarrPattern(NULL)
-    , m_bytecodePattern(NULL)
-    , m_lastIndex(Value(0))
-    , m_lastExecutedString(NULL)
+    : RegExpObject(state, state.context()->globalObject()->regexpPrototype(), source, option)
 {
-    initRegExpObject(state, true);
+}
+
+RegExpObject::RegExpObject(ExecutionState& state, Object* proto, String* source, String* option)
+    : RegExpObject(state, proto, true)
+{
     init(state, source, option);
 }
 
 RegExpObject::RegExpObject(ExecutionState& state, String* source, unsigned int option)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 5, true)
-    , m_source(NULL)
-    , m_optionString(NULL)
-    , m_option(None)
-    , m_yarrPattern(NULL)
-    , m_bytecodePattern(NULL)
-    , m_lastIndex(Value(0))
-    , m_lastExecutedString(NULL)
+    : RegExpObject(state, state.context()->globalObject()->regexpPrototype(), source, option)
 {
-    initRegExpObject(state, true);
+}
+
+RegExpObject::RegExpObject(ExecutionState& state, Object* proto, String* source, unsigned int option)
+    : RegExpObject(state, proto, true)
+{
     initWithOption(state, source, (Option)option);
 }
 
-RegExpObject::RegExpObject(ExecutionState& state, bool hasLastIndex)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + (hasLastIndex ? 5 : 4), true)
+RegExpObject::RegExpObject(ExecutionState& state, Object* proto, bool hasLastIndex)
+    : Object(state, proto, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + (hasLastIndex ? 5 : 4))
     , m_source(NULL)
     , m_optionString(NULL)
     , m_option(None)
@@ -69,7 +63,6 @@ RegExpObject::RegExpObject(ExecutionState& state, bool hasLastIndex)
     , m_lastExecutedString(NULL)
 {
     initRegExpObject(state, hasLastIndex);
-    init(state, String::emptyString, String::emptyString);
 }
 
 void RegExpObject::initRegExpObject(ExecutionState& state, bool hasLastIndex)
@@ -78,12 +71,10 @@ void RegExpObject::initRegExpObject(ExecutionState& state, bool hasLastIndex)
         for (size_t i = 0; i < ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 5; i++)
             m_values[i] = Value();
         m_structure = state.context()->defaultStructureForRegExpObject();
-        setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->regexpPrototype());
     } else {
         for (size_t i = 0; i < ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 4; i++)
             m_values[i] = Value();
         m_structure = state.context()->defaultStructureForObject();
-        setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->regexpPrototype());
     }
 }
 

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -85,9 +85,11 @@ public:
         JSC::Yarr::BytecodePattern* m_bytecodePattern;
     };
 
-    explicit RegExpObject(ExecutionState& state, bool hasLastIndex = true);
     RegExpObject(ExecutionState& state, String* source, String* option);
+    RegExpObject(ExecutionState& state, Object* proto, String* source, String* option);
+
     RegExpObject(ExecutionState& state, String* source, unsigned int option);
+    RegExpObject(ExecutionState& state, Object* proto, String* source, unsigned int option);
 
     void init(ExecutionState& state, String* source, String* option = String::emptyString);
     void initWithOption(ExecutionState& state, String* source, Option option);
@@ -153,6 +155,9 @@ public:
 
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
+
+protected:
+    explicit RegExpObject(ExecutionState& state, Object* proto, bool hasLastIndex = true);
 
 private:
     void setOption(const Option& option);

--- a/src/runtime/ScriptArrowFunctionObject.h
+++ b/src/runtime/ScriptArrowFunctionObject.h
@@ -26,8 +26,8 @@ namespace Escargot {
 
 class ScriptArrowFunctionObject : public ScriptFunctionObject {
 public:
-    ScriptArrowFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue)
-        : ScriptFunctionObject(state, codeBlock, outerEnvironment, false, codeBlock->isGenerator(), codeBlock->isAsync())
+    ScriptArrowFunctionObject(ExecutionState& state, Object* proto, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue)
+        : ScriptFunctionObject(state, proto, codeBlock, outerEnvironment, false, codeBlock->isGenerator(), codeBlock->isAsync())
         , m_thisValue(thisValue)
     {
     }

--- a/src/runtime/ScriptAsyncFunctionObject.cpp
+++ b/src/runtime/ScriptAsyncFunctionObject.cpp
@@ -25,8 +25,8 @@
 
 namespace Escargot {
 
-ScriptAsyncFunctionObject::ScriptAsyncFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue, Object* homeObject)
-    : ScriptFunctionObject(state, codeBlock, outerEnvironment, false, false, true)
+ScriptAsyncFunctionObject::ScriptAsyncFunctionObject(ExecutionState& state, Object* proto, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue, Object* homeObject)
+    : ScriptFunctionObject(state, proto, codeBlock, outerEnvironment, false, false, true)
     , m_thisValue(thisValue)
     , m_homeObject(homeObject)
 {

--- a/src/runtime/ScriptAsyncFunctionObject.h
+++ b/src/runtime/ScriptAsyncFunctionObject.h
@@ -30,7 +30,7 @@ namespace Escargot {
 class ScriptAsyncFunctionObject : public ScriptFunctionObject {
 public:
     // both thisValue, homeObject are optional
-    ScriptAsyncFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue = SmallValue(SmallValue::EmptyValue), Object* homeObject = nullptr);
+    ScriptAsyncFunctionObject(ExecutionState& state, Object* proto, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue = SmallValue(SmallValue::EmptyValue), Object* homeObject = nullptr);
 
     virtual bool isScriptAsyncFunctionObject() const override
     {

--- a/src/runtime/ScriptAsyncGeneratorFunctionObject.cpp
+++ b/src/runtime/ScriptAsyncGeneratorFunctionObject.cpp
@@ -26,8 +26,7 @@ namespace Escargot {
 
 Object* ScriptAsyncGeneratorFunctionObject::createFunctionPrototypeObject(ExecutionState& state)
 {
-    Object* prototype = new Object(state);
-    prototype->setPrototype(state, state.context()->globalObject()->asyncGeneratorPrototype());
+    Object* prototype = new Object(state, state.context()->globalObject()->asyncGeneratorPrototype());
     return prototype;
 }
 

--- a/src/runtime/ScriptAsyncGeneratorFunctionObject.h
+++ b/src/runtime/ScriptAsyncGeneratorFunctionObject.h
@@ -26,8 +26,8 @@ namespace Escargot {
 
 class ScriptAsyncGeneratorFunctionObject : public ScriptFunctionObject {
 public:
-    ScriptAsyncGeneratorFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue = SmallValue(SmallValue::EmptyValue), Object* homeObject = nullptr)
-        : ScriptFunctionObject(state, codeBlock, outerEnvironment, false, true, true)
+    ScriptAsyncGeneratorFunctionObject(ExecutionState& state, Object* proto, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue = SmallValue(SmallValue::EmptyValue), Object* homeObject = nullptr)
+        : ScriptFunctionObject(state, proto, codeBlock, outerEnvironment, false, true, true)
         , m_thisValue(thisValue)
         , m_homeObject(homeObject)
     {

--- a/src/runtime/ScriptClassConstructorFunctionObject.h
+++ b/src/runtime/ScriptClassConstructorFunctionObject.h
@@ -39,7 +39,7 @@ public:
 
 class ScriptClassConstructorFunctionObject : public ScriptFunctionObject {
 public:
-    ScriptClassConstructorFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, Object* homeObject, String* classSourceCode);
+    ScriptClassConstructorFunctionObject(ExecutionState& state, Object* proto, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, Object* homeObject, String* classSourceCode);
 
     friend class FunctionObjectProcessCallGenerator;
     virtual Value call(ExecutionState& state, const Value& thisValue, const size_t argc, NULLABLE Value* argv) override;

--- a/src/runtime/ScriptClassMethodFunctionObject.h
+++ b/src/runtime/ScriptClassMethodFunctionObject.h
@@ -27,8 +27,8 @@ namespace Escargot {
 // {method, get, set} of object literal also uses this class
 class ScriptClassMethodFunctionObject : public ScriptFunctionObject {
 public:
-    ScriptClassMethodFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, Object* homeObject)
-        : ScriptFunctionObject(state, codeBlock, outerEnvironment, false, codeBlock->isGenerator(), codeBlock->isAsync())
+    ScriptClassMethodFunctionObject(ExecutionState& state, Object* proto, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, Object* homeObject)
+        : ScriptFunctionObject(state, proto, codeBlock, outerEnvironment, false, codeBlock->isGenerator(), codeBlock->isAsync())
         , m_homeObject(homeObject)
     {
     }

--- a/src/runtime/ScriptFunctionObject.h
+++ b/src/runtime/ScriptFunctionObject.h
@@ -29,10 +29,10 @@ class ScriptFunctionObject : public FunctionObject {
     friend class ByteCodeInterpreter;
 
 public:
-    ScriptFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, bool isConstructor, bool isGenerator, bool isAsync);
+    ScriptFunctionObject(ExecutionState& state, Object* proto, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, bool isConstructor, bool isGenerator, bool isAsync);
 
 protected:
-    ScriptFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, size_t defaultPropertyCount);
+    ScriptFunctionObject(ExecutionState& state, Object* proto, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, size_t defaultPropertyCount);
 
     friend class FunctionObjectProcessCallGenerator;
     // https://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist

--- a/src/runtime/ScriptGeneratorFunctionObject.cpp
+++ b/src/runtime/ScriptGeneratorFunctionObject.cpp
@@ -26,8 +26,7 @@ namespace Escargot {
 
 Object* ScriptGeneratorFunctionObject::createFunctionPrototypeObject(ExecutionState& state)
 {
-    Object* prototype = new Object(state);
-    prototype->setPrototype(state, state.context()->globalObject()->generatorPrototype());
+    Object* prototype = new Object(state, state.context()->globalObject()->generatorPrototype());
     return prototype;
 }
 

--- a/src/runtime/ScriptGeneratorFunctionObject.h
+++ b/src/runtime/ScriptGeneratorFunctionObject.h
@@ -28,8 +28,8 @@ namespace Escargot {
 class ScriptGeneratorFunctionObject : public ScriptFunctionObject {
 public:
     // both thisValue, homeObject are optional
-    ScriptGeneratorFunctionObject(ExecutionState& state, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue = SmallValue(SmallValue::EmptyValue), Object* homeObject = nullptr)
-        : ScriptFunctionObject(state, codeBlock, outerEnvironment, false, true, false)
+    ScriptGeneratorFunctionObject(ExecutionState& state, Object* proto, CodeBlock* codeBlock, LexicalEnvironment* outerEnvironment, SmallValue thisValue = SmallValue(SmallValue::EmptyValue), Object* homeObject = nullptr)
+        : ScriptFunctionObject(state, proto, codeBlock, outerEnvironment, false, true, false)
         , m_thisValue(thisValue)
         , m_homeObject(homeObject)
     {

--- a/src/runtime/SetObject.cpp
+++ b/src/runtime/SetObject.cpp
@@ -25,15 +25,13 @@
 namespace Escargot {
 
 SetObject::SetObject(ExecutionState& state)
-    : Object(state)
+    : SetObject(state, state.context()->globalObject()->setPrototype())
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->setPrototype());
 }
 
 SetObject::SetObject(ExecutionState& state, Object* proto)
-    : Object(state)
+    : Object(state, proto)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, proto);
 }
 
 void* SetObject::operator new(size_t size)
@@ -137,12 +135,16 @@ SetIteratorObject* SetObject::entries(ExecutionState& state)
 }
 
 SetIteratorObject::SetIteratorObject(ExecutionState& state, SetObject* set, Type type)
-    : IteratorObject(state)
+    : SetIteratorObject(state, state.context()->globalObject()->setIteratorPrototype(), set, type)
+{
+}
+
+SetIteratorObject::SetIteratorObject(ExecutionState& state, Object* proto, SetObject* set, Type type)
+    : IteratorObject(state, proto)
     , m_set(set)
     , m_iteratorIndex(0)
     , m_type(type)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->setIteratorPrototype());
 }
 
 void* SetIteratorObject::operator new(size_t size)

--- a/src/runtime/SetObject.h
+++ b/src/runtime/SetObject.h
@@ -32,6 +32,7 @@ class SetObject : public Object {
 
 public:
     typedef TightVector<SmallValue, GCUtil::gc_malloc_allocator<SmallValue>> SetObjectData;
+
     explicit SetObject(ExecutionState& state);
     explicit SetObject(ExecutionState& state, Object* proto);
 
@@ -70,8 +71,8 @@ private:
 
 class SetPrototypeObject : public SetObject {
 public:
-    explicit SetPrototypeObject(ExecutionState& state)
-        : SetObject(state)
+    explicit SetPrototypeObject(ExecutionState& state, Object* proto)
+        : SetObject(state, proto)
     {
     }
 
@@ -88,7 +89,9 @@ public:
         TypeValue,
         TypeKeyValue
     };
-    SetIteratorObject(ExecutionState& state, SetObject* map, Type type);
+
+    SetIteratorObject(ExecutionState& state, SetObject* set, Type type);
+    SetIteratorObject(ExecutionState& state, Object* proto, SetObject* set, Type type);
 
     virtual bool isSetIteratorObject() const override
     {

--- a/src/runtime/StringObject.cpp
+++ b/src/runtime/StringObject.cpp
@@ -24,12 +24,16 @@
 namespace Escargot {
 
 StringObject::StringObject(ExecutionState& state, String* value)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1, true)
+    : StringObject(state, state.context()->globalObject()->stringPrototype(), value)
+{
+}
+
+StringObject::StringObject(ExecutionState& state, Object* proto, String* value)
+    : Object(state, proto, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1)
     , m_primitiveValue(value)
 {
     m_structure = state.context()->defaultStructureForStringObject();
     m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER] = Value();
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->stringPrototype());
 }
 
 void* StringObject::operator new(size_t size)
@@ -125,11 +129,15 @@ ObjectHasPropertyResult StringObject::hasIndexedProperty(ExecutionState& state, 
 }
 
 StringIteratorObject::StringIteratorObject(ExecutionState& state, String* s)
-    : IteratorObject(state)
+    : StringIteratorObject(state, state.context()->globalObject()->stringIteratorPrototype(), s)
+{
+}
+
+StringIteratorObject::StringIteratorObject(ExecutionState& state, Object* proto, String* s)
+    : IteratorObject(state, proto)
     , m_string(s)
     , m_iteratorNextIndex(0)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->stringIteratorPrototype());
 }
 
 void* StringIteratorObject::operator new(size_t size)

--- a/src/runtime/StringObject.h
+++ b/src/runtime/StringObject.h
@@ -28,6 +28,7 @@ namespace Escargot {
 class StringObject : public Object {
 public:
     StringObject(ExecutionState& state, String* value = String::emptyString);
+    StringObject(ExecutionState& state, Object* proto, String* value = String::emptyString);
 
     String* primitiveValue()
     {
@@ -73,6 +74,7 @@ private:
 class StringIteratorObject : public IteratorObject {
 public:
     StringIteratorObject(ExecutionState& state, String* string);
+    StringIteratorObject(ExecutionState& state, Object* proto, String* string);
 
     virtual bool isStringIteratorObject() const override
     {

--- a/src/runtime/SymbolObject.cpp
+++ b/src/runtime/SymbolObject.cpp
@@ -24,11 +24,15 @@
 namespace Escargot {
 
 SymbolObject::SymbolObject(ExecutionState& state, Symbol* value)
-    : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1, true)
+    : SymbolObject(state, state.context()->globalObject()->symbolPrototype(), value)
+{
+}
+
+SymbolObject::SymbolObject(ExecutionState& state, Object* proto, Symbol* value)
+    : Object(state, proto, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER + 1)
     , m_primitiveValue(value)
 {
     m_structure = state.context()->defaultStructureForSymbolObject();
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->symbolPrototype());
 }
 
 void* SymbolObject::operator new(size_t size)

--- a/src/runtime/SymbolObject.h
+++ b/src/runtime/SymbolObject.h
@@ -27,7 +27,8 @@ namespace Escargot {
 
 class SymbolObject : public Object {
 public:
-    SymbolObject(ExecutionState& state, Symbol* s);
+    explicit SymbolObject(ExecutionState& state, Symbol* s);
+    explicit SymbolObject(ExecutionState& state, Object* proto, Symbol* s);
 
     Symbol* primitiveValue()
     {

--- a/src/runtime/TypedArrayObject.cpp
+++ b/src/runtime/TypedArrayObject.cpp
@@ -19,22 +19,21 @@
 
 #include "Escargot.h"
 #include "TypedArrayObject.h"
-#include "Context.h"
 #include "GlobalObject.h"
 
 namespace Escargot {
 
 #define DEFINE_FN(Type, type, siz)                                                                                                      \
     template <>                                                                                                                         \
-    void TypedArrayObject<Type##Adaptor, siz>::typedArrayObjectPrototypeFiller(ExecutionState& state)                                   \
+    Object* TypedArrayObject<Type##Adaptor, siz>::typedArrayObjectDefaultPrototype(ExecutionState& state)                               \
     {                                                                                                                                   \
-        Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->type##ArrayPrototype());                 \
+        return state.context()->globalObject()->type##ArrayPrototype();                                                                 \
     }                                                                                                                                   \
     template <>                                                                                                                         \
     void TypedArrayObject<Type##Adaptor, siz>::setPrototypeFromConstructor(ExecutionState& state, Object* newTarget)                    \
     {                                                                                                                                   \
         Object* proto = Object::getPrototypeFromConstructor(state, newTarget, state.context()->globalObject()->type##ArrayPrototype()); \
-        Object::setPrototypeForIntrinsicObjectCreation(state, proto);                                                                   \
+        Object::setPrototype(state, proto);                                                                                             \
     }                                                                                                                                   \
     template <>                                                                                                                         \
     const char* TypedArrayObject<Type##Adaptor, siz>::internalClassProperty(ExecutionState& state)                                      \

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -20,6 +20,7 @@
 #ifndef __EscargotTypedArrayObject__
 #define __EscargotTypedArrayObject__
 
+#include "runtime/Context.h"
 #include "runtime/Object.h"
 #include "runtime/ErrorObject.h"
 #include "runtime/ArrayBufferObject.h"
@@ -30,12 +31,14 @@ namespace Escargot {
 
 class ArrayBufferView : public Object {
 public:
-    explicit ArrayBufferView(ExecutionState& state)
-        : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER, true)
+    explicit ArrayBufferView(ExecutionState& state, Object* proto)
+        : Object(state, proto, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER)
+        , m_buffer(nullptr)
+        , m_rawBuffer(nullptr)
+        , m_byteLength(0)
+        , m_byteOffset(0)
+        , m_arrayLength(0)
     {
-        m_rawBuffer = nullptr;
-        m_buffer = nullptr;
-        m_arrayLength = m_byteOffset = m_byteLength = 0;
     }
 
     virtual TypedArrayType typedArrayType() = 0;
@@ -270,13 +273,12 @@ struct Float64Adaptor : TypedArrayAdaptor<FloatTypedArrayAdaptor<double>> {
 
 template <typename TypeAdaptor, int typedArrayElementSize>
 class TypedArrayObject : public ArrayBufferView {
-    void typedArrayObjectPrototypeFiller(ExecutionState& state);
+    Object* typedArrayObjectDefaultPrototype(ExecutionState& state);
 
 public:
     explicit TypedArrayObject(ExecutionState& state)
-        : ArrayBufferView(state)
+        : ArrayBufferView(state, typedArrayObjectDefaultPrototype(state))
     {
-        typedArrayObjectPrototypeFiller(state);
     }
 
     void setPrototypeFromConstructor(ExecutionState& state, Object* newTarget);

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -335,10 +335,9 @@ VMInstance::VMInstance(Platform* platform, const char* locale, const char* timez
 
     GC_add_event_callback(gcEventCallback, this);
 
+    // initialize tag values
     g_doubleInSmallValueTag = DoubleInSmallValue(0).getTag();
-
     g_objectRareDataTag = ObjectRareData(nullptr).getTag();
-
     g_symbolTag = Symbol(nullptr).getTag();
 
 #define DECLARE_GLOBAL_SYMBOLS(name) m_globalSymbols.name = new Symbol(String::fromASCII("Symbol." #name));

--- a/src/runtime/WeakMapObject.cpp
+++ b/src/runtime/WeakMapObject.cpp
@@ -25,15 +25,13 @@
 namespace Escargot {
 
 WeakMapObject::WeakMapObject(ExecutionState& state)
-    : Object(state)
+    : WeakMapObject(state, state.context()->globalObject()->weakMapPrototype())
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->weakMapPrototype());
 }
 
 WeakMapObject::WeakMapObject(ExecutionState& state, Object* proto)
-    : Object(state)
+    : Object(state, proto)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, proto);
 }
 
 void* WeakMapObject::WeakMapObjectDataItem::operator new(size_t size)

--- a/src/runtime/WeakSetObject.cpp
+++ b/src/runtime/WeakSetObject.cpp
@@ -25,15 +25,13 @@
 namespace Escargot {
 
 WeakSetObject::WeakSetObject(ExecutionState& state)
-    : Object(state)
+    : WeakSetObject(state, state.context()->globalObject()->weakSetPrototype())
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, state.context()->globalObject()->weakSetPrototype());
 }
 
 WeakSetObject::WeakSetObject(ExecutionState& state, Object* proto)
-    : Object(state)
+    : Object(state, proto)
 {
-    Object::setPrototypeForIntrinsicObjectCreation(state, proto);
 }
 
 void* WeakSetObject::operator new(size_t size)

--- a/src/runtime/WeakSetObject.h
+++ b/src/runtime/WeakSetObject.h
@@ -64,8 +64,8 @@ private:
 
 class WeakSetPrototypeObject : public WeakSetObject {
 public:
-    explicit WeakSetPrototypeObject(ExecutionState& state)
-        : WeakSetObject(state)
+    explicit WeakSetPrototypeObject(ExecutionState& state, Object* proto)
+        : WeakSetObject(state, proto)
     {
     }
 


### PR DESCRIPTION
[[Prototype]] initialization process is updated.
For each initialization of global intrinsic objects, it directly sets [[prototype]] internal slot.
This approach reduces `setPrototype` calls as much as possible.
For [[Prototype]] setting during runtime, it first marked as prototype and then directly initialized together when each object is created. Runtime [[Prototype]] change could be occurred by `setPrototype` and through `getPrototypeFromConstructor` call only. This patch invokes `markAsPrototypeObject` for each case.

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>