### PR TITLE
Add kangax runner

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,6 @@
     path = test/octane
     url = https://github.com/chromium/octane.git
     ignore = untracked
+[submodule "test/kangax"]
+	path = test/kangax
+	url = https://github.com/kangax/compat-table.git

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,6 +129,9 @@ def isPr() {
                     'Escargot-debugger-test-64bit' : {
                         sh 'tools/run-tests.py --arch=x86_64 --engine="${WORKSPACE}/build/debugger_out_linux64/escargot" escargot-debugger'
                     },
+                    'kangax test-suites' : {
+                        sh 'python tools/kangax/run-kangax.py --engine="${WORKSPACE}/build/out_linux64/escargot"' 
+                    },
                 )
             }
         }

--- a/tools/kangax/escargot.js
+++ b/tools/kangax/escargot.js
@@ -1,0 +1,205 @@
+/*
+ *  Node.js test runner for running data-*.js tests with escargot 'escargot' command.
+ *
+ *  Reports discrepancies to console; fix them manually in data-*.js files.
+ *  Expects 'escargot' to be already built.  Example:
+ *
+ *    $ node escargot.js /path/to/escargot [suitename]
+ */
+
+var fs = require('fs');
+var child_process = require('child_process');
+var console = require('console');
+
+var testCount = 0;
+var testSuccess = 0;
+var testOutOfDate = 0;
+
+var escargotCommand = process.argv[2];
+var suites = process.argv.slice(3);
+
+var environments = JSON.parse(fs.readFileSync('environments.json').toString());
+
+// Key for .res (e.g. test.res.escargotscript1_0), automatic based on `escargot --version`.
+var escargotKey = (function () {
+        return '1';
+})();
+console.log('escargot result key is: test.res.' + escargotKey);
+// escargotKey = "escargot2_3_0" // uncomment this line to test pre 2.3.0
+
+// List of keys for inheriting results from previous versions.
+var escargotKeyList = (function () {
+    var res = [];
+    for (var k in environments) {
+        var env = environments[k];
+        if (env.family !== 'Escargot') {
+            continue;
+        }
+        res.push(k);
+        if (k === escargotKey) {
+            // Include versions up to 'escargotKey' but not newer.
+            break;
+        }
+    }
+    return res;
+})();
+console.log('escargot key list for inheriting results is:', escargotKeyList);
+
+var createIterableHelper =
+'var global = this;\n' +
+'global.__createIterableObject = function (arr, methods) {\n' +
+'    methods = methods || {};\n' +
+'    if (typeof Symbol !== "function" || !Symbol.iterator)\n' +
+'      return {};\n' +
+'    arr.length++;\n' +
+'    var iterator = {\n' +
+'      next: function() {\n' +
+'        return { value: arr.shift(), done: arr.length <= 0 };\n' +
+'      },\n' +
+'      "return": methods["return"],\n' +
+'      "throw": methods["throw"]\n' +
+'    };\n' +
+'    var iterable = {};\n' +
+'    iterable[Symbol.iterator] = function(){ return iterator; };\n' +
+'    return iterable;\n' +
+'  };\n';
+
+var asyncTestHelperHead =
+'var asyncPassed = false;\n' +
+'\n' +
+'function asyncTestPassed() {\n' +
+'  asyncPassed = true;\n' +
+'}\n' +
+'\n' +
+'function setTimeout(cb, time, ...cbarg) {\n' +
+'  if (!jobqueue[time]) {\n' +
+'    jobqueue[time] = [];\n' +
+'  }\n' +
+'  jobqueue[time].push({cb, cbarg});\n' +
+'}\n' +
+'\n' +
+'var jobqueue = [];\n';
+
+var asyncTestHelperTail =
+'jobqueue.forEach(function(jobs) {\n' +
+'  for (var job of jobs) {\n' +
+'    job.cb(...job.cbarg);\n' +
+'  }\n' +
+'});\n' +
+'\n' +
+'function onCloseAsyncCheck() {\n' +
+'  if (!asyncPassed) {\n' +
+'    print("Async[FAILURE]");\n' +
+'    throw "Async check failed";\n' +
+'  }\n' +
+'  print("[SUCCESS]");\n' +
+'}\n';
+
+// Run test / subtests, recursively.  Report results, indicate data files
+// which are out of date.
+function runTest(parents, test, sublevel) {
+    var testPath = parents.join(' -> ') + ' -> ' + test.name;
+
+    if (typeof test.exec === 'function') {
+        var src = test.exec.toString();
+        var m = /^function\s*\w*\s*\(.*?\)\s*\{\s*\/\*([\s\S]*?)\*\/\s*\}$/m.exec(src);
+        var evalcode;
+        var processArgs = ['escargottest.js'];
+        var script = '';
+
+        if (src.includes('__createIterableObject')) {
+            script += createIterableHelper;
+        } else if (src.includes('global')) {
+            script += 'var global = this;\n';
+        }
+
+        if (src.includes('asyncTestPassed')) {
+            script += asyncTestHelperHead + m[1] + asyncTestHelperTail;
+            processArgs.unshift('--call-on-exit','onCloseAsyncCheck');
+        } else {
+            if (m) {
+                evalcode = '(function test() {' + m[1] + '})();';
+            } else {
+                evalcode = '(' + src + ')()';
+            }
+
+            script += 'var evalcode = ' + JSON.stringify(evalcode) + ';\n' +
+                     'try {\n' +
+                     '    var res = eval(evalcode);\n' +
+                     '    if (res !== true && res !== 1) { throw new Error("failed: " + res); }\n' +
+                     '    print("[SUCCESS]");\n' +
+                     '} catch (e) {\n' +
+                     '    print("[FAILURE]", e);\n' +
+                     '    /*throw e;*/\n' +
+                     '}\n';
+        }
+
+        fs.writeFileSync(processArgs[processArgs.length - 1], script);
+        var success = false;
+        try {
+            var stdout = child_process.execFileSync(escargotCommand, processArgs, {
+                encoding: 'utf-8'
+            });
+            //console.log(stdout);
+
+            if (/^\[SUCCESS\]$/gm.test(stdout)) {
+                success = true;
+                testSuccess++;
+            } else {
+                //console.log(stdout);
+            }
+        } catch (e) {
+            //console.log(e);
+        }
+        testCount++;
+
+        if (test.res) {
+            // Take expected result from newest escargot version not newer
+            // than current version.
+            var expect = void 0;
+            escargotKeyList.forEach(function (k) {
+                if (test.res[k] !== void 0) {
+                    expect = test.res[k];
+                }
+            });
+
+            if (expect === success) {
+                // Matches.
+            } else if (expect === void 0 && !success) {
+                testOutOfDate++;
+                console.log(testPath + ': test result missing, res: ' + expect + ', actual: ' + success);
+            } else {
+                testOutOfDate++;
+                console.log(testPath + ': test result out of date, res: ' + expect + ', actual: ' + success);
+            }
+        } else {
+            testOutOfDate++;
+            console.log(testPath + ': test.res missing');
+        }
+    }
+    if (test.subtests) {
+        var newParents = parents.slice(0);
+        newParents.push(test.name);
+        test.subtests.forEach(function (v) { runTest(newParents, v, sublevel + 1); });
+    }
+}
+
+fs.readdirSync('.').forEach(function (filename) {
+    var m = /^data-(.*)\.js$/.exec(filename);
+    if (!m) {
+        return;
+    }
+    var suitename = m[1];
+    if (suites.length != 0 && !suites.includes(suitename)) {
+        return;
+    }
+
+    console.log('');
+    console.log('**** ' + suitename + ' ****');
+    console.log('');
+    var testsuite = require('./data-' + suitename + '.js');
+    testsuite.tests.forEach(function (v) { runTest([ suitename ], v, 0); });
+});
+
+console.log(testCount + ' tests executed: ' + testSuccess + ' success, ' + (testCount - testSuccess) + ' fail');
+console.log(testOutOfDate + ' tests are out of date (data-*.js file .res)');

--- a/tools/kangax/escargot.patch
+++ b/tools/kangax/escargot.patch
@@ -1,0 +1,23 @@
+diff --git a/environments.json b/environments.json
+index f7b14fd7..eca521de 100644
+--- a/environments.json
++++ b/environments.json
+@@ -3204,6 +3204,18 @@
+       "es6"
+     ]
+   },
++  "escargot": {
++    "full": "Escargot Master",
++    "family": "Escargot",
++    "short": "Esc",
++    "platformtype": "engine",
++    "release": "2019-11-15",
++    "obsolete": false,
++    "test_suites": [
++      "es6",
++      "es2016plus"
++    ]
++  },
+   "nashorn1_8": {
+     "full": "Oracle Nashorn 1.8",
+     "family": "Nashorn",

--- a/tools/kangax/run-kangax.py
+++ b/tools/kangax/run-kangax.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+# Copyright 2020-present Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+import os
+
+from argparse import ArgumentParser
+
+PATH = os.path.dirname(os.path.abspath(__file__))
+
+TERM_RED = '\033[1;31m'
+TERM_GREEN = '\033[1;32m'
+TERM_YELLOW = '\033[1;33m'
+TERM_EMPTY = '\033[0m'
+
+
+def separator_line():
+    print("{0}=====================================\n {1}".format(TERM_YELLOW, TERM_EMPTY))
+
+
+def get_results(filename, no_of_lines=1):
+    res = []
+    file = open(filename,'r')
+    lines = file.readlines()
+    last_lines = lines[-no_of_lines:]
+    for line in last_lines:
+        res.append(line)
+    file.close()
+    return res
+
+
+def run_testsuite(suite,engine):
+    separator_line()
+    print("{0}Running kangax suite(s):\n {1}{2}".format(TERM_YELLOW, 'es6\n es2016plus\n' if suite=='""' else suite, TERM_EMPTY))
+    separator_line()
+
+    if engine != 'local':
+        engine = engine
+    else:
+        engine = '../../escargot'
+
+    os.chdir(PATH + '/../../test/kangax/')
+    if suite == '""':
+        es6res = open("./kangaxES6Res.txt", "w")
+        es6plusres = open("./kangaxES6PLUSRes.txt", "w")
+        nodeFails = open("./kangaxRunErrors.txt", "w")
+        subprocess.call(['node', './escargot.js', engine, 'es6'], stdout = es6res, stderr = nodeFails)
+        print("{0}ES6 RESULTS:\n{1}".format(TERM_YELLOW, TERM_EMPTY))
+        grepProc = subprocess.Popen(['grep -hr "actual: false" ./kangaxES6Res.txt'], stdout=subprocess.PIPE, shell=True)
+        (fails, err) = grepProc.communicate()
+        print(''.join(get_results("./kangaxES6Res.txt", 2)))
+        print("{0}ES6 Fails:\n{1}".format(TERM_RED, TERM_EMPTY))
+        print(''.join(fails))
+        print("{0}Errors:\n{1}".format(TERM_RED, TERM_EMPTY))
+        es6res.close()
+        nodeFails.close()
+        with open("./kangaxRunErrors.txt", "r") as lines:
+            print(lines.read())
+        print('\n')
+
+        nodeFails = open("./kangaxRunErrors.txt", "w")
+        subprocess.call(['node', './escargot.js', engine, 'es2016plus'], stdout = es6plusres, stderr = nodeFails)
+        print("{0}ES6PLUS RESULTS:\n{1}".format(TERM_YELLOW, TERM_EMPTY))
+        grepProc = subprocess.Popen(['grep -hr "actual: false" ./kangaxES6PLUSRes.txt'], stdout=subprocess.PIPE, shell=True)
+        (fails, err) = grepProc.communicate()
+        print(''.join(get_results("./kangaxES6PLUSRes.txt", 2)))
+        print("{0}ES6PLUS FAILS:\n{1}".format(TERM_RED, TERM_EMPTY))
+        print(''.join(fails))
+        print("{0}Errors:\n{1}".format(TERM_RED, TERM_EMPTY))
+        es6plusres.close()
+        nodeFails.close()
+        with open("./kangaxRunErrors.txt", "r") as lines:
+            print(lines.read())
+        print('\n')
+    else:
+        res = open("./kangaxRes.txt", "w")
+        nodeFails = open("./kangaxRunErrors.txt", "w")
+        subprocess.call(['node', './escargot.js', engine, suite], stdout = res, stderr = nodeFails)
+        grepProc = subprocess.Popen(['grep -hr "actual: false" ./kangaxRes.txt'], stdout=subprocess.PIPE, shell=True)
+        (fails, err) = grepProc.communicate()
+        print("{0}{1} RESULTS:\n\n{2}".format(TERM_YELLOW, suite, TERM_EMPTY))
+        print( ''.join(get_results("./kangaxRes.txt", 2)))
+        print("{0}FAILS:\n{1}".format(TERM_RED, TERM_EMPTY))
+        print(''.join(fails))
+        print("{0}Errors:\n{1}".format(TERM_RED, TERM_EMPTY))
+        res.close()
+        nodeFails.close()
+        with open("./kangaxRunErrors.txt", "r") as lines:
+            print(lines.read())
+        print('\n')
+
+
+def kangax_setup():
+    os.chdir(PATH + '/../../test/')
+    if os.path.isdir("./kangax/"):
+        print("{0}/test/kangax directory is present\nAssuming correct repository there{1}\n".format(TERM_YELLOW, TERM_EMPTY))
+    else:
+        print("{0}Update kangax repository\n{1}{2}\n".format(TERM_YELLOW, PATH + '/../../test/' + 'kangax', TERM_EMPTY))
+        os.system("git submodule update {0}".format(PATH + '/../../test/kangax'))
+
+
+    separator_line()
+    print("{0}Patching kangax enviroment\n applying patch{1}".format(TERM_YELLOW, TERM_EMPTY))
+    os.chdir(PATH + '/../../test/kangax')
+    os.system('git apply {0}'.format(PATH + '/escargot.patch'))
+    os.chdir(PATH)
+    print("{0} adding Escargot runner{1}\n".format(TERM_YELLOW, TERM_EMPTY))
+    os.system('cp {0} {1}'.format(PATH + '/escargot.js',PATH + '/../../test/kangax/'))
+
+
+
+def main():
+    parser = ArgumentParser(description='Kangax runner for the Escargot engine')
+    parser.add_argument('--suite', nargs='?', default='""',  choices=['es6', 'es6plus'], help='Run kangax suite (choices: %(choices)s)')
+    parser.add_argument('--engine', nargs='?', default='local', help='Define escargot path. Leave empty for project root ./escargot file')
+    args = parser.parse_args()
+
+    separator_line()
+    print("{0}KANGAX RUNNER FOR \nESCARGOT REPOSITORY\n{1}".format(TERM_YELLOW, TERM_EMPTY))
+    separator_line()
+    kangax_setup()
+    run_testsuite(args.suite,args.engine)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The runner clones down the files into test/kangax,
patches it with escargot, copies the runner into it,
and finally it runs and prints the results.

kangaxES6PLUSRes,kangaxES6Res and kangaxRes files are created to store the corresponding suite's full log. The summary only contains the original kangax summary, and all the failing test.

`--suite {es6,es6plus}` addded as parameters, default run without any parameters will run both suites.

Signed-off-by: Bela Toth tbela@inf.u-szeged.hu