### PR TITLE
Fix Iterator and WeakMap prototype objects to be an ordinary object

### DIFF
--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -173,7 +173,6 @@ public:
     };
 
     ArrayIteratorObject(ExecutionState& state, Object* array, Type type);
-    ArrayIteratorObject(ExecutionState& state, Object* proto, Object* array, Type type);
 
     virtual bool isArrayIteratorObject() const override
     {

--- a/src/runtime/GlobalObjectBuiltinArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinArray.cpp
@@ -1876,25 +1876,13 @@ static Value builtinArrayEntries(ExecutionState& state, Value thisValue, size_t 
 
 static Value builtinArrayIteratorNext(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
 {
-    if (!thisValue.isObject() || !thisValue.asObject()->isIteratorObject() || !thisValue.asObject()->asIteratorObject()->isArrayIteratorObject() || thisValue.asObject()->asIteratorObject()->isArrayIteratorPrototypeObject()) {
+    if (!thisValue.isObject() || !thisValue.asObject()->isArrayIteratorObject()) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().ArrayIterator.string(), true, state.context()->staticStrings().next.string(), errorMessage_GlobalObject_CalledOnIncompatibleReceiver);
     }
+
     ArrayIteratorObject* iter = thisValue.asObject()->asIteratorObject()->asArrayIteratorObject();
     return iter->next(state);
 }
-
-class ArrayIteratorPrototypeObject : public ArrayIteratorObject {
-public:
-    explicit ArrayIteratorPrototypeObject(ExecutionState& state, Object* proto, Object* array, ArrayIteratorObject::Type type)
-        : ArrayIteratorObject(state, proto, array, type)
-    {
-    }
-
-    virtual bool isArrayIteratorPrototypeObject() const override
-    {
-        return true;
-    }
-};
 
 void GlobalObject::installArray(ExecutionState& state)
 {
@@ -2014,7 +2002,7 @@ void GlobalObject::installArray(ExecutionState& state)
 
     m_array->setFunctionPrototype(state, m_arrayPrototype);
 
-    m_arrayIteratorPrototype = new ArrayIteratorPrototypeObject(state, m_iteratorPrototype, nullptr, ArrayIteratorObject::TypeKey);
+    m_arrayIteratorPrototype = new Object(state, m_iteratorPrototype);
     m_arrayIteratorPrototype->setGlobalIntrinsicObject(state, true);
 
     m_arrayIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().next),

--- a/src/runtime/GlobalObjectBuiltinMap.cpp
+++ b/src/runtime/GlobalObjectBuiltinMap.cpp
@@ -185,7 +185,7 @@ static Value builtinMapSizeGetter(ExecutionState& state, Value thisValue, size_t
 
 static Value builtinMapIteratorNext(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
 {
-    if (!thisValue.isObject() || !thisValue.asObject()->isIteratorObject() || !thisValue.asObject()->asIteratorObject()->isMapIteratorObject()) {
+    if (!thisValue.isObject() || !thisValue.asObject()->isMapIteratorObject()) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().MapIterator.string(), true, state.context()->staticStrings().next.string(), errorMessage_GlobalObject_CalledOnIncompatibleReceiver);
     }
     MapIteratorObject* iter = thisValue.asObject()->asIteratorObject()->asMapIteratorObject();
@@ -248,7 +248,7 @@ void GlobalObject::installMap(ExecutionState& state)
     ObjectPropertyDescriptor desc(gs, ObjectPropertyDescriptor::ConfigurablePresent);
     m_mapPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().size), desc);
 
-    m_mapIteratorPrototype = new MapIteratorObject(state, m_iteratorPrototype, nullptr, MapIteratorObject::TypeKey);
+    m_mapIteratorPrototype = new Object(state, m_iteratorPrototype);
     m_mapIteratorPrototype->setGlobalIntrinsicObject(state, true);
 
     m_mapIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().next),

--- a/src/runtime/GlobalObjectBuiltinSet.cpp
+++ b/src/runtime/GlobalObjectBuiltinSet.cpp
@@ -172,7 +172,7 @@ static Value builtinSetSizeGetter(ExecutionState& state, Value thisValue, size_t
 
 static Value builtinSetIteratorNext(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
 {
-    if (!thisValue.isObject() || !thisValue.asObject()->isIteratorObject() || !thisValue.asObject()->asIteratorObject()->isSetIteratorObject()) {
+    if (!thisValue.isObject() || !thisValue.asObject()->isSetIteratorObject()) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().SetIterator.string(), true, state.context()->staticStrings().next.string(), errorMessage_GlobalObject_CalledOnIncompatibleReceiver);
     }
     SetIteratorObject* iter = thisValue.asObject()->asIteratorObject()->asSetIteratorObject();
@@ -229,7 +229,7 @@ void GlobalObject::installSet(ExecutionState& state)
     ObjectPropertyDescriptor desc(gs, ObjectPropertyDescriptor::ConfigurablePresent);
     m_setPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().size), desc);
 
-    m_setIteratorPrototype = new SetIteratorObject(state, m_iteratorPrototype, nullptr, SetIteratorObject::TypeKey);
+    m_setIteratorPrototype = new Object(state, m_iteratorPrototype);
     m_setIteratorPrototype->setGlobalIntrinsicObject(state, true);
 
     m_setIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().next),

--- a/src/runtime/GlobalObjectBuiltinString.cpp
+++ b/src/runtime/GlobalObjectBuiltinString.cpp
@@ -1473,7 +1473,7 @@ static Value builtinStringIncludes(ExecutionState& state, Value thisValue, size_
 
 static Value builtinStringIteratorNext(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
 {
-    if (!thisValue.isObject() || !thisValue.asObject()->isIteratorObject() || !thisValue.asObject()->asIteratorObject()->isStringIteratorObject()) {
+    if (!thisValue.isObject() || !thisValue.asObject()->isStringIteratorObject()) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().StringIterator.string(), true, state.context()->staticStrings().next.string(), errorMessage_GlobalObject_CalledOnIncompatibleReceiver);
     }
     StringIteratorObject* iter = thisValue.asObject()->asIteratorObject()->asStringIteratorObject();
@@ -1662,7 +1662,7 @@ void GlobalObject::installString(ExecutionState& state)
 
     m_string->setFunctionPrototype(state, m_stringPrototype);
 
-    m_stringIteratorPrototype = new StringIteratorObject(state, m_iteratorPrototype, nullptr);
+    m_stringIteratorPrototype = new Object(state, m_iteratorPrototype);
     m_stringIteratorPrototype->setGlobalIntrinsicObject(state, true);
 
     m_stringIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().next),

--- a/src/runtime/GlobalObjectBuiltinWeakMap.cpp
+++ b/src/runtime/GlobalObjectBuiltinWeakMap.cpp
@@ -89,7 +89,7 @@ Value builtinWeakMapConstructor(ExecutionState& state, Value thisValue, size_t a
     return map;
 }
 
-#define RESOLVE_THIS_BINDING_TO_MAP(NAME, OBJ, BUILT_IN_METHOD)                                                                                                                                                                                \
+#define RESOLVE_THIS_BINDING_TO_WEAKMAP(NAME, OBJ, BUILT_IN_METHOD)                                                                                                                                                                            \
     if (!thisValue.isObject() || !thisValue.asObject()->isWeakMapObject()) {                                                                                                                                                                   \
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().OBJ.string(), true, state.context()->staticStrings().BUILT_IN_METHOD.string(), errorMessage_GlobalObject_CalledOnIncompatibleReceiver); \
     }                                                                                                                                                                                                                                          \
@@ -97,7 +97,7 @@ Value builtinWeakMapConstructor(ExecutionState& state, Value thisValue, size_t a
 
 static Value builtinWeakMapDelete(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
 {
-    RESOLVE_THIS_BINDING_TO_MAP(M, WeakMap, stringDelete);
+    RESOLVE_THIS_BINDING_TO_WEAKMAP(M, WeakMap, stringDelete);
     if (!argv[0].isObject()) {
         return Value(false);
     }
@@ -107,7 +107,7 @@ static Value builtinWeakMapDelete(ExecutionState& state, Value thisValue, size_t
 
 static Value builtinWeakMapGet(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
 {
-    RESOLVE_THIS_BINDING_TO_MAP(M, WeakMap, get);
+    RESOLVE_THIS_BINDING_TO_WEAKMAP(M, WeakMap, get);
     if (!argv[0].isObject()) {
         return Value();
     }
@@ -117,7 +117,7 @@ static Value builtinWeakMapGet(ExecutionState& state, Value thisValue, size_t ar
 
 static Value builtinWeakMapHas(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
 {
-    RESOLVE_THIS_BINDING_TO_MAP(M, WeakMap, has);
+    RESOLVE_THIS_BINDING_TO_WEAKMAP(M, WeakMap, has);
     if (!argv[0].isObject()) {
         return Value(false);
     }
@@ -127,7 +127,7 @@ static Value builtinWeakMapHas(ExecutionState& state, Value thisValue, size_t ar
 
 static Value builtinWeakMapSet(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Value newTarget)
 {
-    RESOLVE_THIS_BINDING_TO_MAP(M, WeakMap, set);
+    RESOLVE_THIS_BINDING_TO_WEAKMAP(M, WeakMap, set);
     if (!argv[0].isObject()) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "Invalid value used as weak map key");
     }
@@ -141,7 +141,7 @@ void GlobalObject::installWeakMap(ExecutionState& state)
     m_weakMap = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().WeakMap, builtinWeakMapConstructor, 0), NativeFunctionObject::__ForBuiltinConstructor__);
     m_weakMap->setGlobalIntrinsicObject(state);
 
-    m_weakMapPrototype = new WeakMapObject(state, m_objectPrototype);
+    m_weakMapPrototype = new Object(state, m_objectPrototype);
     m_weakMapPrototype->setGlobalIntrinsicObject(state, true);
     m_weakMapPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_weakMap, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 

--- a/src/runtime/MapObject.cpp
+++ b/src/runtime/MapObject.cpp
@@ -150,12 +150,7 @@ MapIteratorObject* MapObject::entries(ExecutionState& state)
 }
 
 MapIteratorObject::MapIteratorObject(ExecutionState& state, MapObject* map, Type type)
-    : MapIteratorObject(state, state.context()->globalObject()->mapIteratorPrototype(), map, type)
-{
-}
-
-MapIteratorObject::MapIteratorObject(ExecutionState& state, Object* proto, MapObject* map, Type type)
-    : IteratorObject(state, proto)
+    : IteratorObject(state, state.context()->globalObject()->mapIteratorPrototype())
     , m_map(map)
     , m_iteratorIndex(0)
     , m_type(type)

--- a/src/runtime/MapObject.h
+++ b/src/runtime/MapObject.h
@@ -79,12 +79,12 @@ public:
     };
 
     MapIteratorObject(ExecutionState& state, MapObject* map, Type type);
-    MapIteratorObject(ExecutionState& state, Object* proto, MapObject* map, Type type);
 
     virtual bool isMapIteratorObject() const override
     {
         return true;
     }
+
     virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Map Iterator";

--- a/src/runtime/SetObject.cpp
+++ b/src/runtime/SetObject.cpp
@@ -135,12 +135,7 @@ SetIteratorObject* SetObject::entries(ExecutionState& state)
 }
 
 SetIteratorObject::SetIteratorObject(ExecutionState& state, SetObject* set, Type type)
-    : SetIteratorObject(state, state.context()->globalObject()->setIteratorPrototype(), set, type)
-{
-}
-
-SetIteratorObject::SetIteratorObject(ExecutionState& state, Object* proto, SetObject* set, Type type)
-    : IteratorObject(state, proto)
+    : IteratorObject(state, state.context()->globalObject()->setIteratorPrototype())
     , m_set(set)
     , m_iteratorIndex(0)
     , m_type(type)

--- a/src/runtime/SetObject.h
+++ b/src/runtime/SetObject.h
@@ -78,12 +78,12 @@ public:
     };
 
     SetIteratorObject(ExecutionState& state, SetObject* set, Type type);
-    SetIteratorObject(ExecutionState& state, Object* proto, SetObject* set, Type type);
 
     virtual bool isSetIteratorObject() const override
     {
         return true;
     }
+
     virtual const char* internalClassProperty(ExecutionState& state) override
     {
         return "Set Iterator";

--- a/src/runtime/StringObject.cpp
+++ b/src/runtime/StringObject.cpp
@@ -129,12 +129,7 @@ ObjectHasPropertyResult StringObject::hasIndexedProperty(ExecutionState& state, 
 }
 
 StringIteratorObject::StringIteratorObject(ExecutionState& state, String* s)
-    : StringIteratorObject(state, state.context()->globalObject()->stringIteratorPrototype(), s)
-{
-}
-
-StringIteratorObject::StringIteratorObject(ExecutionState& state, Object* proto, String* s)
-    : IteratorObject(state, proto)
+    : IteratorObject(state, state.context()->globalObject()->stringIteratorPrototype())
     , m_string(s)
     , m_iteratorNextIndex(0)
 {

--- a/src/runtime/StringObject.h
+++ b/src/runtime/StringObject.h
@@ -74,7 +74,6 @@ private:
 class StringIteratorObject : public IteratorObject {
 public:
     StringIteratorObject(ExecutionState& state, String* string);
-    StringIteratorObject(ExecutionState& state, Object* proto, String* string);
 
     virtual bool isStringIteratorObject() const override
     {

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -62,7 +62,6 @@
     <test id="built-ins/ArrayBuffer/prototype/byteLength/this-is-sharedarraybuffer"><reason>TODO</reason></test>
     <test id="built-ins/ArrayBuffer/prototype/slice/this-is-sharedarraybuffer"><reason>TODO</reason></test>
     <test id="built-ins/ArrayBuffer/toindex-length"><reason>TODO</reason></test>
-    <test id="built-ins/ArrayIteratorPrototype/next/detach-typedarray-in-progress"><reason>TODO</reason></test>
     <test id="built-ins/AsyncFunction/proto-from-ctor-realm"><reason>TODO</reason></test>
     <test id="built-ins/AsyncGeneratorFunction/proto-from-ctor-realm"><reason>TODO</reason></test>
     <test id="built-ins/Atomics/Symbol.toStringTag"><reason>TODO</reason></test>
@@ -1788,9 +1787,6 @@
     <test id="built-ins/TypedArrayConstructors/prototype/toString/bigint-inherited"><reason>TODO</reason></test>
     <test id="built-ins/TypedArrayConstructors/prototype/values/bigint-inherited"><reason>TODO</reason></test>
     <test id="built-ins/WeakMap/proto-from-ctor-realm"><reason>TODO</reason></test>
-    <test id="built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-weakmap-prototype"><reason>TODO</reason></test>
-    <test id="built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-weakmap-prototype"><reason>TODO</reason></test>
-    <test id="built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-weakmap-prototype"><reason>TODO</reason></test>
     <test id="built-ins/WeakRef/constructor"><reason>TODO</reason></test>
     <test id="built-ins/WeakRef/instance-extensible"><reason>TODO</reason></test>
     <test id="built-ins/WeakRef/length"><reason>TODO</reason></test>


### PR DESCRIPTION
* remove ArrayIteratorPrototypeObject
* fix ArrayIteratorPrototype.next to throw a TypeError for detached buffer

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>