### PR TITLE
Update Object.prototype.toString

### DIFF
--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -42,11 +42,6 @@ public:
     virtual ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override;
     virtual bool set(ExecutionState& state, const ObjectPropertyName& propertyName, const Value& v, const Value& receiver) override;
     virtual bool setIndexedProperty(ExecutionState& state, const Value& property, const Value& value) override;
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Arguments";
-    }
 
     virtual bool isInlineCacheable() override
     {

--- a/src/runtime/ArrayBufferObject.h
+++ b/src/runtime/ArrayBufferObject.h
@@ -48,12 +48,6 @@ public:
 
     static ArrayBufferObject* allocateArrayBuffer(ExecutionState& state, Value constructor);
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "ArrayBuffer";
-    }
-
     static const uint32_t maxArrayBufferSize = 210000000;
 
     // Clone srcBuffer's srcByteOffset ~ end.

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -59,11 +59,6 @@ public:
         return true;
     }
 
-    virtual bool isArray(ExecutionState& state) const override
-    {
-        return true;
-    }
-
     virtual bool isInlineCacheable() override
     {
         return false;

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -93,12 +93,6 @@ public:
     static Value arrayLengthNativeGetter(ExecutionState& state, Object* self);
     static bool arrayLengthNativeSetter(ExecutionState& state, Object* self, const Value& newData);
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Array";
-    }
-
     void defineOwnIndexedPropertyWithExpandedLength(ExecutionState& state, const size_t& index, const Value& value)
     {
         ASSERT(index < getArrayLength(state));
@@ -174,10 +168,6 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Array Iterator";
-    }
     virtual std::pair<Value, bool> advance(ExecutionState& state) override;
 
     void* operator new(size_t size);

--- a/src/runtime/AsyncGeneratorObject.h
+++ b/src/runtime/AsyncGeneratorObject.h
@@ -51,11 +51,6 @@ public:
 
     AsyncGeneratorObject(ExecutionState& state, Object* proto, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk);
 
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "AsyncGenerator";
-    }
-
     virtual bool isAsyncGeneratorObject() const override
     {
         return true;

--- a/src/runtime/BooleanObject.h
+++ b/src/runtime/BooleanObject.h
@@ -44,12 +44,6 @@ public:
         return true;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "Boolean";
-    }
-
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 

--- a/src/runtime/BoundFunctionObject.h
+++ b/src/runtime/BoundFunctionObject.h
@@ -48,12 +48,6 @@ public:
         return m_boundTargetFunction;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Function";
-    }
-
     virtual Context* getFunctionRealm(ExecutionState& state) override
     {
         return m_boundTargetFunction->getFunctionRealm(state);

--- a/src/runtime/DataViewObject.h
+++ b/src/runtime/DataViewObject.h
@@ -44,11 +44,6 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "DataView";
-    }
-
     // 24.2.1.1
     Value getViewValue(ExecutionState& state, Value index, Value _isLittleEndian, TypedArrayType type)
     {

--- a/src/runtime/DateObject.h
+++ b/src/runtime/DateObject.h
@@ -121,13 +121,6 @@ public:
     int getUTCMonth(ExecutionState& state);
     int getUTCSeconds(ExecutionState& state);
 
-
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "Date";
-    }
-
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 

--- a/src/runtime/ErrorObject.h
+++ b/src/runtime/ErrorObject.h
@@ -139,12 +139,6 @@ public:
         return true;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "Error";
-    }
-
     struct StackTraceGCData {
         union {
             ByteCodeBlock* byteCodeBlock;

--- a/src/runtime/FunctionObject.h
+++ b/src/runtime/FunctionObject.h
@@ -122,12 +122,6 @@ public:
         return codeBlock()->isDerivedClassConstructor() ? ConstructorKind::Derived : ConstructorKind::Base;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Function";
-    }
-
     // https://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects
     // internal [[homeObject]] slot
     virtual Object* homeObject()

--- a/src/runtime/GeneratorObject.h
+++ b/src/runtime/GeneratorObject.h
@@ -47,11 +47,6 @@ public:
 
     GeneratorObject(ExecutionState& state, Object* proto, ExecutionState* executionState, Value* registerFile, ByteCodeBlock* blk);
 
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Generator";
-    }
-
     virtual bool isGeneratorObject() const override
     {
         return true;

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -242,11 +242,6 @@ public:
     Value eval(ExecutionState& state, const Value& arg);
     Value evalLocal(ExecutionState& state, const Value& arg, Value thisValue, InterpretedCodeBlock* parentCodeBlock, bool inWithOperation); // we get isInWithOperation as parameter because this affects bytecode
 
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "global";
-    }
-
     FunctionObject* object()
     {
         return m_object;

--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -97,18 +97,34 @@ static Value builtinObjectToString(ExecutionState& state, Value thisValue, size_
     StringBuilder builder;
     builder.appendString("[object ");
 
-    if (thisObject->isArray(state)) {
-        builder.appendString("Array");
+    Value toStringTag = thisObject->get(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag)).value(state, thisObject);
+    if (toStringTag.isString()) {
+        builder.appendString(toStringTag.asString());
     } else {
-        Value toStringTag = thisObject->get(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag)).value(state, thisObject);
-        if (toStringTag.isString()) {
-            builder.appendString(toStringTag.asString());
+        if (thisObject->isArray(state)) {
+            builder.appendString("Array");
+        } else if (thisObject->isStringObject()) {
+            builder.appendString("String");
+        } else if (thisObject->isArgumentsObject()) {
+            builder.appendString("Arguments");
+        } else if (thisObject->isCallable()) {
+            builder.appendString("Function");
+        } else if (thisObject->isErrorObject()) {
+            builder.appendString("Error");
+        } else if (thisObject->isBooleanObject()) {
+            builder.appendString("Boolean");
+        } else if (thisObject->isNumberObject()) {
+            builder.appendString("Number");
+        } else if (thisObject->isDateObject()) {
+            builder.appendString("Date");
+        } else if (thisObject->isRegExpObject()) {
+            builder.appendString("RegExp");
         } else {
-            builder.appendString(thisObject->internalClassProperty(state));
+            builder.appendString("Object");
         }
     }
-
     builder.appendString("]");
+
     return AtomicString(state, builder.finalize()).string();
 }
 

--- a/src/runtime/GlobalObjectBuiltinTypedArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinTypedArray.cpp
@@ -1640,8 +1640,9 @@ static Value builtinTypedArrayToStringTagGetter(ExecutionState& state, Value thi
     if (!O.isObject()) {
         return Value();
     }
-    if (O.asObject() && O.asObject()->isTypedArrayObject()) {
-        return Value(String::fromASCII(O.asObject()->internalClassProperty(state)));
+
+    if (O.asObject()->isTypedArrayObject()) {
+        return Value(O.asObject()->asArrayBufferView()->typedArrayName(state));
     }
     return Value();
 }

--- a/src/runtime/IteratorObject.h
+++ b/src/runtime/IteratorObject.h
@@ -85,11 +85,6 @@ public:
 
     Value next(ExecutionState& state);
 
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "Iterator";
-    }
-
     virtual std::pair<Value, bool> advance(ExecutionState& state)
     {
         RELEASE_ASSERT_NOT_REACHED();

--- a/src/runtime/MapObject.h
+++ b/src/runtime/MapObject.h
@@ -41,12 +41,6 @@ public:
         return true;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Map";
-    }
-
     void clear(ExecutionState& state);
     bool deleteOperation(ExecutionState& state, const Value& key);
     Value get(ExecutionState& state, const Value& key);
@@ -85,10 +79,6 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Map Iterator";
-    }
     virtual std::pair<Value, bool> advance(ExecutionState& state) override;
 
     void* operator new(size_t size);

--- a/src/runtime/NumberObject.h
+++ b/src/runtime/NumberObject.h
@@ -60,12 +60,6 @@ public:
     typedef char RadixBuffer[2180];
     static char* toStringWithRadix(ExecutionState& state, RadixBuffer& buffer, double number, unsigned radix);
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "Number";
-    }
-
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -30,6 +30,7 @@
 #include "NumberObject.h"
 #include "BooleanObject.h"
 #include "SymbolObject.h"
+#include "ProxyObject.h"
 #include "util/Util.h"
 #include "interpreter/ByteCodeInterpreter.h"
 
@@ -1333,6 +1334,24 @@ uint64_t Object::lengthES6(ExecutionState& state)
     return get(state, state.context()->staticStrings().length).value(state, this).toLength(state);
 }
 
+bool Object::isArray(ExecutionState& state)
+{
+    if (isArrayObject()) {
+        return true;
+    }
+    if (isProxyObject()) {
+        ProxyObject* proxy = asProxyObject();
+        if (proxy->handler() == nullptr) {
+            ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Proxy.string(), false, String::emptyString, "%s: Proxy handler should not null.");
+            return false;
+        }
+        if (proxy->target() == nullptr) {
+            return false;
+        }
+        return proxy->target()->isArray(state);
+    }
+    return false;
+}
 
 bool Object::nextIndexForward(ExecutionState& state, Object* obj, const int64_t cur, const int64_t end, int64_t& nextIndex)
 {

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -965,12 +965,6 @@ public:
         return isArrayObject() && rareData()->m_isSpreadArrayObject;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "Object";
-    }
-
     void* extraData()
     {
         if (rareData()) {

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -789,12 +789,6 @@ public:
         return rareData() == nullptr ? true : rareData()->m_isExtensible;
     }
 
-    // http://www.ecma-international.org/ecma-262/6.0/index.html#is-array
-    virtual bool isArray(ExecutionState& state) const
-    {
-        return false;
-    }
-
     // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
     virtual bool preventExtensions(ExecutionState&)
     {
@@ -868,6 +862,9 @@ public:
     virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
     virtual uint64_t length(ExecutionState& state);
     uint64_t lengthES6(ExecutionState& state);
+
+    // https://www.ecma-international.org/ecma-262/10.0/#sec-isarray
+    bool isArray(ExecutionState& state);
 
     bool hasOwnProperty(ExecutionState& state, const ObjectPropertyName& propertyName)
     {

--- a/src/runtime/PromiseObject.h
+++ b/src/runtime/PromiseObject.h
@@ -104,12 +104,6 @@ public:
         return true;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "Promise";
-    }
-
     void fulfill(ExecutionState& state, Value value);
     void reject(ExecutionState& state, Value reason);
 

--- a/src/runtime/ProxyObject.cpp
+++ b/src/runtime/ProxyObject.cpp
@@ -616,19 +616,6 @@ Object::OwnPropertyKeyVector ProxyObject::ownPropertyKeys(ExecutionState& state)
     return OwnPropertyKeyVector(trapResult.data(), trapResult.size());
 }
 
-bool ProxyObject::isArray(ExecutionState& state) const
-{
-    // 3.a. If handler is null, throw a TypeError exception.
-    if (m_handler == nullptr) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Proxy.string(), false, String::emptyString, "%s: Proxy handler should not be null.");
-        return false;
-    }
-
-    // 3.b Let target be the value of the [[ProxyTarget]] internal slot of argument.
-    // 3.c Return IsArray(target).
-    return m_target->isArray(state);
-}
-
 bool ProxyObject::isExtensible(ExecutionState& state)
 {
     auto strings = &state.context()->staticStrings();

--- a/src/runtime/ProxyObject.h
+++ b/src/runtime/ProxyObject.h
@@ -118,7 +118,6 @@ public:
     virtual Value getPrototype(ExecutionState&) override;
     virtual Object* getPrototypeObject(ExecutionState&) override;
 
-    virtual bool isArray(ExecutionState&) const override;
     virtual bool isExtensible(ExecutionState&) override;
 
     virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) override;

--- a/src/runtime/ProxyObject.h
+++ b/src/runtime/ProxyObject.h
@@ -76,15 +76,6 @@ public:
         return m_isConstructible;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        if (!m_target) {
-            ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Proxy.string(), false, String::emptyString, "%s: \'target\' argument of Proxy cannot be null");
-        }
-        return m_target->internalClassProperty(state);
-    }
-
     virtual Context* getFunctionRealm(ExecutionState& state) override;
 
     static ProxyObject* createProxy(ExecutionState& state, const Value& target, const Value& handler);

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -150,12 +150,6 @@ public:
     ArrayObject* createRegExpMatchedArray(ExecutionState& state, const RegexMatchResult& result, String* input);
     void pushBackToRegExpMatchedArray(ExecutionState& state, ArrayObject* array, size_t& index, const size_t limit, const RegexMatchResult& result, String* str);
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "RegExp";
-    }
-
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 

--- a/src/runtime/SetObject.h
+++ b/src/runtime/SetObject.h
@@ -41,12 +41,6 @@ public:
         return true;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Set";
-    }
-
     void add(ExecutionState& state, const Value& key);
     void clear(ExecutionState& state);
     bool deleteOperation(ExecutionState& state, const Value& key);
@@ -84,10 +78,6 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "Set Iterator";
-    }
     virtual std::pair<Value, bool> advance(ExecutionState& state) override;
 
     void* operator new(size_t size);

--- a/src/runtime/StringObject.h
+++ b/src/runtime/StringObject.h
@@ -57,12 +57,6 @@ public:
         return m_primitiveValue->length();
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "String";
-    }
-
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 
@@ -80,10 +74,6 @@ public:
         return true;
     }
 
-    virtual const char* internalClassProperty(ExecutionState& state) override
-    {
-        return "String Iterator";
-    }
     virtual std::pair<Value, bool> advance(ExecutionState& state) override;
 
     void* operator new(size_t size);

--- a/src/runtime/TypedArrayObject.cpp
+++ b/src/runtime/TypedArrayObject.cpp
@@ -36,11 +36,6 @@ namespace Escargot {
         Object::setPrototype(state, proto);                                                                                             \
     }                                                                                                                                   \
     template <>                                                                                                                         \
-    const char* TypedArrayObject<Type##Adaptor, siz>::internalClassProperty(ExecutionState& state)                                      \
-    {                                                                                                                                   \
-        return #Type "Array";                                                                                                           \
-    }                                                                                                                                   \
-    template <>                                                                                                                         \
     String* TypedArrayObject<Type##Adaptor, siz>::typedArrayName(ExecutionState& state)                                                 \
     {                                                                                                                                   \
         return state.context()->staticStrings().Type##Array.string();                                                                   \

--- a/src/runtime/TypedArrayObject.cpp
+++ b/src/runtime/TypedArrayObject.cpp
@@ -39,6 +39,11 @@ namespace Escargot {
     const char* TypedArrayObject<Type##Adaptor, siz>::internalClassProperty(ExecutionState& state)                                      \
     {                                                                                                                                   \
         return #Type "Array";                                                                                                           \
+    }                                                                                                                                   \
+    template <>                                                                                                                         \
+    String* TypedArrayObject<Type##Adaptor, siz>::typedArrayName(ExecutionState& state)                                                 \
+    {                                                                                                                                   \
+        return state.context()->staticStrings().Type##Array.string();                                                                   \
     }
 
 DEFINE_FN(Int8, int8, 1);

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -42,6 +42,11 @@ public:
     }
 
     virtual TypedArrayType typedArrayType() = 0;
+    virtual String* typedArrayName(ExecutionState& state)
+    {
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
     ALWAYS_INLINE ArrayBufferObject* buffer() { return m_buffer; }
     ALWAYS_INLINE uint8_t* rawBuffer() { return m_rawBuffer; }
     ALWAYS_INLINE unsigned byteLength() { return m_byteLength; }
@@ -285,6 +290,7 @@ public:
 
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
     virtual const char* internalClassProperty(ExecutionState& state) override;
+    virtual String* typedArrayName(ExecutionState& state) override;
 
     virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override
     {

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -288,8 +288,6 @@ public:
 
     void setPrototypeFromConstructor(ExecutionState& state, Object* newTarget);
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state) override;
     virtual String* typedArrayName(ExecutionState& state) override;
 
     virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override

--- a/src/runtime/WeakMapObject.h
+++ b/src/runtime/WeakMapObject.h
@@ -44,12 +44,6 @@ public:
         return true;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "WeakMap";
-    }
-
     bool deleteOperation(ExecutionState& state, Object* key);
     Value get(ExecutionState& state, Object* key);
     bool has(ExecutionState& state, Object* key);

--- a/src/runtime/WeakSetObject.h
+++ b/src/runtime/WeakSetObject.h
@@ -45,12 +45,6 @@ public:
         return true;
     }
 
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
-    virtual const char* internalClassProperty(ExecutionState& state)
-    {
-        return "WeakSet";
-    }
-
     void add(ExecutionState& state, Object* key);
     bool deleteOperation(ExecutionState& state, Object* key);
     bool has(ExecutionState& state, Object* key);

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -356,6 +356,10 @@ PersistentRefHolder<ContextRef> createEscargotContext(VMInstanceRef* instance)
         }
 
 #if defined(ESCARGOT_ENABLE_TEST)
+        // There is no specific standard for the [@@toStringTag] property of global object.
+        // But "global" string is added here to pass legacy TCs
+        context->globalObject()->defineDataProperty(state, context->vmInstance()->toStringTagSymbol(), ObjectRef::DataPropertyDescriptor(AtomicStringRef::create(context, "global")->string(), (ObjectRef::PresentAttribute)(ObjectRef::NonWritablePresent | ObjectRef::NonEnumerablePresent | ObjectRef::ConfigurablePresent)));
+
         {
             FunctionObjectRef::NativeFunctionInfo nativeFunctionInfo(AtomicStringRef::create(context, "uneval"), builtinUneval, 1, true, false);
             FunctionObjectRef* buildFunctionObjectRef = FunctionObjectRef::create(state, nativeFunctionInfo);

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -641,9 +641,7 @@
     <test id="built-ins/Object/prototype/toLocaleString/primitive_this_value_getter"><reason>TODO</reason></test>
     <test id="built-ins/Object/prototype/toString/Object.prototype.toString.call-bigint"><reason>TODO</reason></test>
     <test id="built-ins/Object/prototype/toString/symbol-tag-non-str-bigint"><reason>TODO</reason></test>
-    <test id="built-ins/Object/prototype/toString/symbol-tag-non-str-builtin"><reason>TODO</reason></test>
     <test id="built-ins/Object/prototype/toString/symbol-tag-override-bigint"><reason>TODO</reason></test>
-    <test id="built-ins/Object/prototype/toString/symbol-tag-override-instances"><reason>TODO</reason></test>
     <test id="built-ins/Object/setPrototypeOf/bigint"><reason>TODO</reason></test>
     <test id="built-ins/Promise/all/invoke-resolve-get-error-close"><reason>TODO</reason></test>
     <test id="built-ins/Promise/all/invoke-resolve-get-once-multiple-calls"><reason>TODO</reason></test>
@@ -744,9 +742,9 @@
     <test id="built-ins/Proxy/construct/trap-is-undefined-proto-from-newtarget-realm"><reason>TODO</reason></test>
     <test id="built-ins/Proxy/defineProperty/targetdesc-not-configurable-writable-desc-not-writable"><reason>TODO</reason></test>
     <test id="built-ins/Proxy/deleteProperty/targetdesc-is-configurable-target-is-not-extensible"><reason>TODO</reason></test>
-    <test id="built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-not-configurable-not-writable-targetdesc-is-writable"><reason>TODO</reason></test>
     <test id="built-ins/Proxy/get-fn-realm"><reason>TODO</reason></test>
     <test id="built-ins/Proxy/get-fn-realm-recursive"><reason>TODO</reason></test>
+    <test id="built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-not-configurable-not-writable-targetdesc-is-writable"><reason>TODO</reason></test>
     <test id="built-ins/Proxy/revocable/revocation-function-name"><reason>TODO</reason></test>
     <test id="built-ins/Proxy/set/call-parameters-prototype-index"><reason>TODO</reason></test>
     <test id="built-ins/Reflect/get/return-value-from-receiver"><reason>TODO</reason></test>


### PR DESCRIPTION
* Object.prototype.toString is fixed to use [@@toStringTag] property or predefined string value
* isArray is updated as an internal method of Object
* legacy internalClassProperty is nowhere to be used, so entirely removed