### PR TITLE
Fix debugger support for arrow functions and var/let/const statements.

### DIFF
--- a/tools/debugger/debugger_tester.sh
+++ b/tools/debugger/debugger_tester.sh
@@ -8,7 +8,7 @@ sleep 1s
 RESULT_TEMP=`mktemp ${TEST_CASE}.out.XXXXXXXXXX`
 
 (cat "${TEST_CASE}.cmd" | ${DEBUGGER_CLIENT} --non-interactive) >${RESULT_TEMP} 2>&1
-diff -U0  ${RESULT_TEMP} ${TEST_CASE}.expected
+diff -u ${RESULT_TEMP} ${TEST_CASE}.expected
 STATUS_CODE=$?
 
 rm -f ${RESULT_TEMP}

--- a/tools/debugger/tests/do_step2.cmd
+++ b/tools/debugger/tests/do_step2.cmd
@@ -1,0 +1,12 @@
+step
+s
+s
+s
+s
+s
+s
+s
+s
+s
+s
+s

--- a/tools/debugger/tests/do_step2.expected
+++ b/tools/debugger/tests/do_step2.expected
@@ -1,0 +1,27 @@
+Connecting to: localhost:6501
+Connection created!!!
+Stopped at tools/debugger/tests/do_step2.js:20
+(escargot-debugger) step
+Stopped at tools/debugger/tests/do_step2.js:21
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:20 (in arr() at line:20, col:11)
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:27
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:28
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:29
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:35
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:36
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:37
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:39
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:40
+(escargot-debugger) s
+Stopped at tools/debugger/tests/do_step2.js:41
+(escargot-debugger) s
+Connection closed.

--- a/tools/debugger/tests/do_step2.js
+++ b/tools/debugger/tests/do_step2.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+var arr = (x) => x + x
+arr();
+
+var a;
+var b,
+    c;
+
+var d = 1;
+var e = 2,
+    f = 3;
+
+let g;
+let h,
+    i;
+
+let j = 4;
+let k = 5,
+    l = 6;
+
+const m = 7;
+const n = 8,
+      o = 9;


### PR DESCRIPTION
Declarations with assignment should insert breakpoints, while declarations without assignment should not.