### PR TITLE
Fix minor bugs in Proxy and toLocaleString

### DIFF
--- a/src/runtime/GlobalObjectBuiltinNumber.cpp
+++ b/src/runtime/GlobalObjectBuiltinNumber.cpp
@@ -269,14 +269,8 @@ static Value builtinNumberToLocaleString(ExecutionState& state, Value thisValue,
     }
 
 #if defined(ENABLE_ICU) && defined(ENABLE_INTL)
-    Value locales, options;
-
-    if (argc >= 1) {
-        locales = argv[0];
-    }
-    if (argc >= 2) {
-        options = argv[1];
-    }
+    Value locales = argc > 0 ? argv[0] : Value();
+    Value options = argc > 1 ? argv[1] : Value();
     Object* numberFormat = IntlNumberFormat::create(state, state.context(), locales, options);
     double x = 0;
     if (thisValue.isNumber()) {

--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -258,10 +258,6 @@ static Value builtinObjectToLocaleString(ExecutionState& state, Value thisValue,
     // Let toString be the result of calling the [[Get]] internal method of O passing "toString" as the argument.
     Value toString = O->get(state, ObjectPropertyName(state.context()->staticStrings().toString)).value(state, O);
 
-    // If IsCallable(toString) is false, throw a TypeError exception.
-    if (!toString.isCallable())
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Object.string(), true, state.context()->staticStrings().toLocaleString.string(), ErrorObject::Messages::GlobalObject_ToLocaleStringNotCallable);
-
     // Return the result of calling the [[Call]] internal method of toString passing O as the this value and no arguments.
     return Object::call(state, toString, Value(O), 0, nullptr);
 }

--- a/src/runtime/GlobalObjectBuiltinProxy.cpp
+++ b/src/runtime/GlobalObjectBuiltinProxy.cpp
@@ -84,7 +84,7 @@ static Value builtinProxyRevocable(ExecutionState& state, Value thisValue, size_
 
     // 3. Let revoker be a new built-in function object as defined in 26.2.2.1.1.
     // 4. Set the [[RevocableProxy]] internal slot of revoker to p.
-    RevokeFunctionObject* revoker = new RevokeFunctionObject(state, NativeFunctionInfo(strings->revoke, builtinProxyRevoke, 0, NativeFunctionInfo::Strict), proxy.asObject()->asProxyObject());
+    RevokeFunctionObject* revoker = new RevokeFunctionObject(state, NativeFunctionInfo(AtomicString(), builtinProxyRevoke, 0, NativeFunctionInfo::Strict), proxy.asObject()->asProxyObject());
 
     // 5. Let result be ObjectCreate(%ObjectPrototype%).
     Object* result = new Object(state);

--- a/src/runtime/GlobalObjectBuiltinReflect.cpp
+++ b/src/runtime/GlobalObjectBuiltinReflect.cpp
@@ -159,8 +159,7 @@ static Value builtinReflectGet(ExecutionState& state, Value thisValue, size_t ar
     Value receiver = argc > 2 ? argv[2] : target;
 
     // 5. Return target.[[Get]](key, receiver).
-    // FIXME receiver in [[Get]](key, receiver)
-    return target.asObject()->get(state, ObjectPropertyName(state, key)).value(state, target);
+    return target.asObject()->get(state, ObjectPropertyName(state, key)).value(state, receiver);
 }
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-reflect.getownpropertydescriptor

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -579,7 +579,7 @@ void Object::markAsPrototypeObject(ExecutionState& state)
 {
     ensureObjectRareData()->m_isEverSetAsPrototypeObject = true;
 
-    if (UNLIKELY(!state.context()->vmInstance()->didSomePrototypeObjectDefineIndexedProperty() && structure()->hasIndexPropertyName())) {
+    if (UNLIKELY(!state.context()->vmInstance()->didSomePrototypeObjectDefineIndexedProperty() && (structure()->hasIndexPropertyName() || isProxyObject()))) {
         state.context()->vmInstance()->somePrototypeObjectDefineIndexedProperty(state);
     }
 }

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -640,9 +640,6 @@
     <test id="built-ins/Proxy/defineProperty/targetdesc-not-configurable-writable-desc-not-writable"><reason>TODO</reason></test>
     <test id="built-ins/Proxy/deleteProperty/targetdesc-is-configurable-target-is-not-extensible"><reason>TODO</reason></test>
     <test id="built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-not-configurable-not-writable-targetdesc-is-writable"><reason>TODO</reason></test>
-    <test id="built-ins/Proxy/revocable/revocation-function-name"><reason>TODO</reason></test>
-    <test id="built-ins/Proxy/set/call-parameters-prototype-index"><reason>TODO</reason></test>
-    <test id="built-ins/Reflect/get/return-value-from-receiver"><reason>TODO</reason></test>
     <test id="built-ins/RegExp/lookBehind/alternations"><reason>TODO</reason></test>
     <test id="built-ins/RegExp/lookBehind/back-references"><reason>TODO</reason></test>
     <test id="built-ins/RegExp/lookBehind/back-references-to-captures"><reason>TODO</reason></test>


### PR DESCRIPTION
* Fix minor bugs in Proxy and Reflect 
    * when a Proxy object is allocated as prototype of ArrayObject, fastmode optimization is immediately turn off
    * revoker should be anonymous function
* Update toLocaleString builtin method based on ES10