### PR TITLE
[WIP] Optimize internal operations of Object and Array

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -2389,8 +2389,6 @@ NEVER_INLINE void ByteCodeInterpreter::classOperation(ExecutionState& state, Cre
         }
     }
 
-    constructorParent.asObject()->markAsPrototypeObject(state);
-
     ScriptClassConstructorPrototypeObject* proto = new ScriptClassConstructorPrototypeObject(state);
     proto->setPrototype(state, protoParent);
 

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -37,7 +37,8 @@ ArrayObject::ArrayObject(ExecutionState& state, Object* proto)
     , m_arrayLength(0)
     , m_fastModeData(nullptr)
 {
-    if (UNLIKELY(state.context()->vmInstance()->didSomePrototypeObjectDefineIndexedProperty())) {
+    ASSERT(!!proto && (proto->checkAllPrototypeChainHasArrayDescendantFlag(state) || !state.context()->vmInstance()->fastModeArrayEnabled()));
+    if (UNLIKELY(!state.context()->vmInstance()->fastModeArrayEnabled())) {
         ensureRareData()->m_isFastModeArrayObject = false;
     }
 }

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -97,16 +97,15 @@ public:
 private:
     ALWAYS_INLINE bool isFastModeArray()
     {
-        auto rd = rareData();
-        if (LIKELY(rd == nullptr)) {
-            return true;
+        if (UNLIKELY(hasRareData())) {
+            return rareData()->m_isFastModeArrayObject;
         }
-        return rd->m_isFastModeArrayObject;
+        return true;
     }
 
     bool isLengthPropertyWritable()
     {
-        return rareData() ? rareData()->m_isArrayObjectLengthWritable : true;
+        return hasRareData() ? rareData()->m_isArrayObjectLengthWritable : true;
     }
 
     void setFastModeArrayValueWithoutExpanding(ExecutionState& state, size_t idx, const Value& v)

--- a/src/runtime/EnumerateObject.cpp
+++ b/src/runtime/EnumerateObject.cpp
@@ -167,7 +167,7 @@ bool EnumerateObjectWithDestruction::checkIfModified(ExecutionState& state)
         if (UNLIKELY(m_object->length(state) != m_arrayLength)) {
             return true;
         }
-        if (UNLIKELY(m_object->rareData() && m_object->rareData()->m_shouldUpdateEnumerateObject)) {
+        if (UNLIKELY(m_object->hasRareData() && m_object->rareData()->m_shouldUpdateEnumerateObject)) {
             return true;
         }
     }
@@ -276,7 +276,7 @@ void EnumerateObjectWithIteration::executeEnumeration(ExecutionState& state, Sma
         }
     }
 
-    if (m_object->rareData()) {
+    if (m_object->hasRareData()) {
         m_object->rareData()->m_shouldUpdateEnumerateObject = false;
     }
 }
@@ -302,7 +302,7 @@ bool EnumerateObjectWithIteration::checkIfModified(ExecutionState& state)
         if (UNLIKELY(m_object->length(state) != m_arrayLength)) {
             return true;
         }
-        if (UNLIKELY(m_object->rareData() && m_object->rareData()->m_shouldUpdateEnumerateObject)) {
+        if (UNLIKELY(m_object->hasRareData() && m_object->rareData()->m_shouldUpdateEnumerateObject)) {
             return true;
         }
     }

--- a/src/runtime/GlobalObjectBuiltinArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinArray.cpp
@@ -61,6 +61,7 @@ Value builtinArrayConstructor(ExecutionState& state, Value thisValue, size_t arg
     Object* proto = Object::getPrototypeFromConstructor(state, newTarget.value(), [](ExecutionState& state, Context* constructorRealm) -> Object* {
         return constructorRealm->globalObject()->arrayPrototype();
     });
+    proto->markArrayDescendantInPrototypeChain(state);
     ArrayObject* array = new ArrayObject(state, proto, (uint64_t)size);
 
     if (interpretArgumentsAsElements) {
@@ -1869,7 +1870,8 @@ void GlobalObject::installArray(ExecutionState& state)
     }
 
     m_arrayPrototype = new ArrayPrototypeObject(state);
-    m_arrayPrototype->setGlobalIntrinsicObject(state, true);
+    m_arrayPrototype->setGlobalIntrinsicObject(state);
+    m_arrayPrototype->markArrayDescendantInPrototypeChain(state);
 
     m_arrayPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_array, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
@@ -1975,7 +1977,7 @@ void GlobalObject::installArray(ExecutionState& state)
     m_array->setFunctionPrototype(state, m_arrayPrototype);
 
     m_arrayIteratorPrototype = new Object(state, m_iteratorPrototype);
-    m_arrayIteratorPrototype->setGlobalIntrinsicObject(state, true);
+    m_arrayIteratorPrototype->setGlobalIntrinsicObject(state);
 
     m_arrayIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().next),
                                                                ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().next, builtinArrayIteratorNext, 0, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinAsyncFromSyncIterator.cpp
+++ b/src/runtime/GlobalObjectBuiltinAsyncFromSyncIterator.cpp
@@ -261,7 +261,7 @@ void GlobalObject::installAsyncFromSyncIterator(ExecutionState& state)
 {
     // https://www.ecma-international.org/ecma-262/10.0/#sec-%asyncfromsynciteratorprototype%-object
     m_asyncFromSyncIteratorPrototype = new Object(state, m_asyncIteratorPrototype);
-    m_asyncFromSyncIteratorPrototype->setGlobalIntrinsicObject(state, true);
+    m_asyncFromSyncIteratorPrototype->setGlobalIntrinsicObject(state);
 
     m_asyncFromSyncIteratorPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                                         ObjectPropertyDescriptor(String::fromASCII("Async-from-Sync Iterator"), ObjectPropertyDescriptor::ConfigurablePresent));

--- a/src/runtime/GlobalObjectBuiltinAsyncFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinAsyncFunction.cpp
@@ -51,7 +51,7 @@ void GlobalObject::installAsyncFunction(ExecutionState& state)
     m_asyncFunction->setPrototype(state, m_function);
 
     m_asyncFunctionPrototype = new Object(state, m_functionPrototype);
-    m_asyncFunctionPrototype->setGlobalIntrinsicObject(state, true);
+    m_asyncFunctionPrototype->setGlobalIntrinsicObject(state);
     m_asyncFunction->setFunctionPrototype(state, m_asyncFunctionPrototype);
 
     m_asyncFunctionPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor),

--- a/src/runtime/GlobalObjectBuiltinAsyncGeneratorFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinAsyncGeneratorFunction.cpp
@@ -68,7 +68,7 @@ void GlobalObject::installAsyncGeneratorFunction(ExecutionState& state)
 
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-properties-of-asyncgeneratorfunction-prototype
     m_asyncGenerator = new Object(state, m_functionPrototype);
-    m_asyncGenerator->setGlobalIntrinsicObject(state, true);
+    m_asyncGenerator->setGlobalIntrinsicObject(state);
 
     m_asyncGeneratorFunction->setFunctionPrototype(state, m_asyncGenerator);
 
@@ -80,7 +80,7 @@ void GlobalObject::installAsyncGeneratorFunction(ExecutionState& state)
 
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-properties-of-asyncgenerator-prototype
     m_asyncGeneratorPrototype = new Object(state, m_asyncIteratorPrototype);
-    m_asyncGeneratorPrototype->setGlobalIntrinsicObject(state, true);
+    m_asyncGeneratorPrototype->setGlobalIntrinsicObject(state);
 
     m_asyncGenerator->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().prototype), ObjectPropertyDescriptor(m_asyncGeneratorPrototype, ObjectPropertyDescriptor::ConfigurablePresent));
     m_asyncGeneratorPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_asyncGenerator, ObjectPropertyDescriptor::ConfigurablePresent));

--- a/src/runtime/GlobalObjectBuiltinAsyncIterator.cpp
+++ b/src/runtime/GlobalObjectBuiltinAsyncIterator.cpp
@@ -34,7 +34,7 @@ void GlobalObject::installAsyncIterator(ExecutionState& state)
 {
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-%iteratorprototype%-object
     m_asyncIteratorPrototype = new Object(state);
-    m_asyncIteratorPrototype->setGlobalIntrinsicObject(state, true);
+    m_asyncIteratorPrototype->setGlobalIntrinsicObject(state);
 
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-asynciteratorprototype-asynciterator
     m_asyncIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().asyncIterator),

--- a/src/runtime/GlobalObjectBuiltinBoolean.cpp
+++ b/src/runtime/GlobalObjectBuiltinBoolean.cpp
@@ -68,7 +68,7 @@ void GlobalObject::installBoolean(ExecutionState& state)
     m_boolean->setGlobalIntrinsicObject(state);
 
     m_booleanPrototype = new BooleanObject(state, m_objectPrototype, false);
-    m_booleanPrototype->setGlobalIntrinsicObject(state, true);
+    m_booleanPrototype->setGlobalIntrinsicObject(state);
     m_booleanPrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(m_boolean, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     // $19.3.3.2 Boolean.prototype.toString

--- a/src/runtime/GlobalObjectBuiltinDataView.cpp
+++ b/src/runtime/GlobalObjectBuiltinDataView.cpp
@@ -159,7 +159,7 @@ void GlobalObject::installDataView(ExecutionState& state)
     m_dataView->setGlobalIntrinsicObject(state);
 
     m_dataViewPrototype = new DataViewObject(state, m_objectPrototype);
-    m_dataViewPrototype->setGlobalIntrinsicObject(state, true);
+    m_dataViewPrototype->setGlobalIntrinsicObject(state);
     m_dataView->setFunctionPrototype(state, m_dataViewPrototype);
 
     m_dataViewPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_dataView, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinDate.cpp
+++ b/src/runtime/GlobalObjectBuiltinDate.cpp
@@ -511,7 +511,7 @@ void GlobalObject::installDate(ExecutionState& state)
     m_date->setGlobalIntrinsicObject(state);
 
     m_datePrototype = new Object(state);
-    m_datePrototype->setGlobalIntrinsicObject(state, true);
+    m_datePrototype->setGlobalIntrinsicObject(state);
 
     m_datePrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_date, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 

--- a/src/runtime/GlobalObjectBuiltinError.cpp
+++ b/src/runtime/GlobalObjectBuiltinError.cpp
@@ -124,7 +124,7 @@ void GlobalObject::installError(ExecutionState& state)
     m_error->setGlobalIntrinsicObject(state);
 
     m_errorPrototype = new Object(state);
-    m_errorPrototype->setGlobalIntrinsicObject(state, true);
+    m_errorPrototype->setGlobalIntrinsicObject(state);
 
     m_error->setFunctionPrototype(state, m_errorPrototype);
 
@@ -139,7 +139,7 @@ void GlobalObject::installError(ExecutionState& state)
     // http://www.ecma-international.org/ecma-262/5.1/#sec-13.2.3
     // 13.2.3 The [[ThrowTypeError]] Function Object
     m_throwTypeError = new NativeFunctionObject(state, NativeFunctionInfo(AtomicString(), builtinErrorThrowTypeError, 0, NativeFunctionInfo::Strict));
-    m_throwTypeError->setGlobalIntrinsicObject(state, false);
+    m_throwTypeError->setGlobalIntrinsicObject(state);
     m_throwTypeError->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().name),
                                         ObjectPropertyDescriptor(String::emptyString, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::NonWritablePresent | ObjectPropertyDescriptor::NonEnumerablePresent | ObjectPropertyDescriptor::NonConfigurablePresent)));
     m_throwTypeError->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().length),
@@ -153,7 +153,7 @@ void GlobalObject::installError(ExecutionState& state)
     m_##errorname##Error = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().bname##Error, builtin##bname##ErrorConstructor, 1), NativeFunctionObject::__ForBuiltinConstructor__);                                                                                                                    \
     m_##errorname##Error->setPrototype(state, m_error);                                                                                                                                                                                                                                                                                 \
     m_##errorname##ErrorPrototype = new bname##ErrorObject(state, m_errorPrototype, String::emptyString);                                                                                                                                                                                                                               \
-    m_##errorname##ErrorPrototype->setGlobalIntrinsicObject(state, true);                                                                                                                                                                                                                                                               \
+    m_##errorname##ErrorPrototype->setGlobalIntrinsicObject(state);                                                                                                                                                                                                                                                                     \
     m_##errorname##ErrorPrototype->defineOwnProperty(state, state.context()->staticStrings().constructor, ObjectPropertyDescriptor(m_##errorname##Error, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));                            \
     m_##errorname##ErrorPrototype->defineOwnProperty(state, state.context()->staticStrings().message, ObjectPropertyDescriptor(String::emptyString, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));                                 \
     m_##errorname##ErrorPrototype->defineOwnProperty(state, state.context()->staticStrings().name, ObjectPropertyDescriptor(state.context()->staticStrings().bname##Error.string(), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent))); \

--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -216,7 +216,7 @@ void GlobalObject::installFunction(ExecutionState& state)
 {
     m_functionPrototype = new NativeFunctionObject(state, new CodeBlock(state.context(), NativeFunctionInfo(AtomicString(), builtinFunctionEmptyFunction, 0, NativeFunctionInfo::Strict)),
                                                    NativeFunctionObject::__ForGlobalBuiltin__);
-    m_functionPrototype->setGlobalIntrinsicObject(state, true);
+    m_functionPrototype->setGlobalIntrinsicObject(state);
 
     m_function = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().Function, builtinFunctionConstructor, 1), NativeFunctionObject::__ForBuiltinConstructor__);
     m_function->setGlobalIntrinsicObject(state);

--- a/src/runtime/GlobalObjectBuiltinGeneratorFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinGeneratorFunction.cpp
@@ -67,7 +67,7 @@ void GlobalObject::installGenerator(ExecutionState& state)
 
     // %Generator% : The initial value of the prototype property of %GeneratorFunction%
     m_generator = new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().GeneratorFunction, nullptr, 0, NativeFunctionInfo::Strict));
-    m_generator->setGlobalIntrinsicObject(state, true);
+    m_generator->setGlobalIntrinsicObject(state);
     m_generatorFunction->setFunctionPrototype(state, m_generator);
 
 
@@ -76,7 +76,7 @@ void GlobalObject::installGenerator(ExecutionState& state)
 
     // %GeneratorPrototype% : The initial value of the prototype property of %Generator%
     m_generatorPrototype = new Object(state, m_iteratorPrototype);
-    m_generatorPrototype->setGlobalIntrinsicObject(state, true);
+    m_generatorPrototype->setGlobalIntrinsicObject(state);
 
     m_generator->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().prototype), ObjectPropertyDescriptor(m_generatorPrototype, ObjectPropertyDescriptor::ConfigurablePresent));
 

--- a/src/runtime/GlobalObjectBuiltinIntl.cpp
+++ b/src/runtime/GlobalObjectBuiltinIntl.cpp
@@ -762,7 +762,7 @@ void GlobalObject::installIntl(ExecutionState& state)
     m_intlLocale->setGlobalIntrinsicObject(state);
 
     m_intlLocalePrototype = m_intlLocale->getFunctionPrototype(state).asObject();
-    m_intlLocalePrototype->setGlobalIntrinsicObject(state, true);
+    m_intlLocalePrototype->setGlobalIntrinsicObject(state);
 
     m_intlLocalePrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                                             ObjectPropertyDescriptor(Value(state.context()->staticStrings().intlDotLocale.string()), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinIterator.cpp
+++ b/src/runtime/GlobalObjectBuiltinIterator.cpp
@@ -34,7 +34,7 @@ static Value builtinIteratorIterator(ExecutionState& state, Value thisValue, siz
 void GlobalObject::installIterator(ExecutionState& state)
 {
     m_iteratorPrototype = new Object(state);
-    m_iteratorPrototype->setGlobalIntrinsicObject(state, true);
+    m_iteratorPrototype->setGlobalIntrinsicObject(state);
 
     // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-%iteratorprototype%-@@iterator
     FunctionObject* fn = new NativeFunctionObject(state, NativeFunctionInfo(AtomicString(state, String::fromASCII("[Symbol.iterator]")), builtinIteratorIterator, 0, NativeFunctionInfo::Strict));

--- a/src/runtime/GlobalObjectBuiltinMap.cpp
+++ b/src/runtime/GlobalObjectBuiltinMap.cpp
@@ -207,7 +207,7 @@ void GlobalObject::installMap(ExecutionState& state)
     }
 
     m_mapPrototype = new MapObject(state, m_objectPrototype);
-    m_mapPrototype->setGlobalIntrinsicObject(state, true);
+    m_mapPrototype->setGlobalIntrinsicObject(state);
     m_mapPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_map, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_mapPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().clear),
@@ -251,7 +251,7 @@ void GlobalObject::installMap(ExecutionState& state)
     m_mapPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().size), desc);
 
     m_mapIteratorPrototype = new Object(state, m_iteratorPrototype);
-    m_mapIteratorPrototype->setGlobalIntrinsicObject(state, true);
+    m_mapIteratorPrototype->setGlobalIntrinsicObject(state);
 
     m_mapIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().next),
                                                              ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().next, builtinMapIteratorNext, 0, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinNumber.cpp
+++ b/src/runtime/GlobalObjectBuiltinNumber.cpp
@@ -382,7 +382,7 @@ void GlobalObject::installNumber(ExecutionState& state)
     m_number->setGlobalIntrinsicObject(state);
 
     m_numberPrototype = new NumberObject(state, m_objectPrototype, 0);
-    m_numberPrototype->setGlobalIntrinsicObject(state, true);
+    m_numberPrototype->setGlobalIntrinsicObject(state);
     m_number->setFunctionPrototype(state, m_numberPrototype);
 
     m_numberPrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(m_number, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinPromise.cpp
+++ b/src/runtime/GlobalObjectBuiltinPromise.cpp
@@ -388,7 +388,7 @@ void GlobalObject::installPromise(ExecutionState& state)
     }
 
     m_promisePrototype = new Object(state);
-    m_promisePrototype->setGlobalIntrinsicObject(state, true);
+    m_promisePrototype->setGlobalIntrinsicObject(state);
 
     m_promisePrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(m_promise, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
     m_promisePrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),

--- a/src/runtime/GlobalObjectBuiltinRegExp.cpp
+++ b/src/runtime/GlobalObjectBuiltinRegExp.cpp
@@ -739,7 +739,7 @@ void GlobalObject::installRegExp(ExecutionState& state)
 #undef DEFINE_ATTR
 
     m_regexpPrototype = new Object(state);
-    m_regexpPrototype->setGlobalIntrinsicObject(state, true);
+    m_regexpPrototype->setGlobalIntrinsicObject(state);
 
     {
         Value getter = new NativeFunctionObject(state, NativeFunctionInfo(strings->getFlags, builtinRegExpFlagsGetter, 0, NativeFunctionInfo::Strict));

--- a/src/runtime/GlobalObjectBuiltinSet.cpp
+++ b/src/runtime/GlobalObjectBuiltinSet.cpp
@@ -194,7 +194,7 @@ void GlobalObject::installSet(ExecutionState& state)
     }
 
     m_setPrototype = new Object(state);
-    m_setPrototype->setGlobalIntrinsicObject(state, true);
+    m_setPrototype->setGlobalIntrinsicObject(state);
     m_setPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_set, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_setPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().clear),
@@ -232,7 +232,7 @@ void GlobalObject::installSet(ExecutionState& state)
     m_setPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().size), desc);
 
     m_setIteratorPrototype = new Object(state, m_iteratorPrototype);
-    m_setIteratorPrototype->setGlobalIntrinsicObject(state, true);
+    m_setIteratorPrototype->setGlobalIntrinsicObject(state);
 
     m_setIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().next),
                                                              ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().next, builtinSetIteratorNext, 0, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinString.cpp
+++ b/src/runtime/GlobalObjectBuiltinString.cpp
@@ -1498,7 +1498,7 @@ void GlobalObject::installString(ExecutionState& state)
     m_string->setGlobalIntrinsicObject(state);
 
     m_stringPrototype = new StringObject(state, m_objectPrototype, String::emptyString);
-    m_stringPrototype->setGlobalIntrinsicObject(state, true);
+    m_stringPrototype->setGlobalIntrinsicObject(state);
     m_string->setFunctionPrototype(state, m_stringPrototype);
 
     m_stringPrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(m_string, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
@@ -1665,7 +1665,7 @@ void GlobalObject::installString(ExecutionState& state)
     m_string->setFunctionPrototype(state, m_stringPrototype);
 
     m_stringIteratorPrototype = new Object(state, m_iteratorPrototype);
-    m_stringIteratorPrototype->setGlobalIntrinsicObject(state, true);
+    m_stringIteratorPrototype->setGlobalIntrinsicObject(state);
 
     m_stringIteratorPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().next),
                                                                 ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().next, builtinStringIteratorNext, 0, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/GlobalObjectBuiltinSymbol.cpp
+++ b/src/runtime/GlobalObjectBuiltinSymbol.cpp
@@ -137,7 +137,7 @@ void GlobalObject::installSymbol(ExecutionState& state)
                                                          (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_symbolPrototype = new Object(state);
-    m_symbolPrototype->setGlobalIntrinsicObject(state, true);
+    m_symbolPrototype->setGlobalIntrinsicObject(state);
 
     m_symbolPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_symbol, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 

--- a/src/runtime/GlobalObjectBuiltinTypedArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinTypedArray.cpp
@@ -1625,7 +1625,7 @@ FunctionObject* GlobalObject::installTypedArray(ExecutionState& state, AtomicStr
 
     *proto = m_objectPrototype;
     Object* taPrototype = new TypedArrayPrototypeObject(state);
-    taPrototype->setGlobalIntrinsicObject(state, true);
+    taPrototype->setGlobalIntrinsicObject(state);
     taPrototype->setPrototype(state, typedArrayFunction->getFunctionPrototype(state));
 
     taConstructor->setPrototype(state, typedArrayFunction); // %TypedArray%
@@ -1690,7 +1690,7 @@ void GlobalObject::installTypedArray(ExecutionState& state)
                                                               (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_arrayBufferPrototype = new ArrayBufferObject(state, m_objectPrototype);
-    m_arrayBufferPrototype->setGlobalIntrinsicObject(state, true);
+    m_arrayBufferPrototype->setGlobalIntrinsicObject(state);
 
     m_arrayBufferPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_arrayBuffer, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
     m_arrayBufferPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
@@ -1736,7 +1736,7 @@ void GlobalObject::installTypedArray(ExecutionState& state)
 
     // %TypedArray%.prototype
     Object* typedArrayPrototype = typedArrayFunction->getFunctionPrototype(state).asObject();
-    typedArrayPrototype->setGlobalIntrinsicObject(state, true);
+    typedArrayPrototype->setGlobalIntrinsicObject(state);
     typedArrayPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(strings->subarray),
                                                           ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->subarray, builtinTypedArraySubArray, 2, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
     typedArrayPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(strings->set),

--- a/src/runtime/GlobalObjectBuiltinWeakMap.cpp
+++ b/src/runtime/GlobalObjectBuiltinWeakMap.cpp
@@ -144,7 +144,7 @@ void GlobalObject::installWeakMap(ExecutionState& state)
     m_weakMap->setGlobalIntrinsicObject(state);
 
     m_weakMapPrototype = new Object(state, m_objectPrototype);
-    m_weakMapPrototype->setGlobalIntrinsicObject(state, true);
+    m_weakMapPrototype->setGlobalIntrinsicObject(state);
     m_weakMapPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_weakMap, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_weakMapPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state.context()->staticStrings().stringDelete),

--- a/src/runtime/GlobalObjectBuiltinWeakSet.cpp
+++ b/src/runtime/GlobalObjectBuiltinWeakSet.cpp
@@ -132,7 +132,7 @@ void GlobalObject::installWeakSet(ExecutionState& state)
     m_weakSet->setGlobalIntrinsicObject(state);
 
     m_weakSetPrototype = new Object(state);
-    m_weakSetPrototype->setGlobalIntrinsicObject(state, true);
+    m_weakSetPrototype->setGlobalIntrinsicObject(state);
 
     m_weakSetPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().constructor), ObjectPropertyDescriptor(m_weakSet, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -434,7 +434,7 @@ Object::Object(ExecutionState& state, Object* proto)
 {
     // proto has been marked as a prototype object
     ASSERT(!!proto);
-    ASSERT(proto->rareData() && proto->rareData()->m_isEverSetAsPrototypeObject);
+    ASSERT(proto->hasRareData() && proto->rareData()->m_isEverSetAsPrototypeObject);
     // create a new ordinary object
     m_values.resizeWithUninitializedValues(0, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER);
 }
@@ -453,7 +453,7 @@ Object::Object(ExecutionState& state, Object* proto, size_t defaultSpace)
 {
     // proto has been marked as a prototype object
     ASSERT(!!proto);
-    ASSERT(proto->rareData() && proto->rareData()->m_isEverSetAsPrototypeObject);
+    ASSERT(proto->hasRareData() && proto->rareData()->m_isEverSetAsPrototypeObject);
     m_values.resizeWithUninitializedValues(0, defaultSpace);
 }
 
@@ -487,7 +487,7 @@ Object* Object::createBuiltinObjectPrototype(ExecutionState& state)
     Object* obj = new Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER, Object::__ForGlobalBuiltin__);
     obj->setPrototype(state, Value(Value::Null));
     obj->markThisObjectDontNeedStructureTransitionTable();
-    obj->ensureObjectRareData()->m_isEverSetAsPrototypeObject = true;
+    obj->ensureRareData()->m_isEverSetAsPrototypeObject = true;
 
     return obj;
 }
@@ -507,14 +507,14 @@ void Object::setGlobalIntrinsicObject(ExecutionState& state, bool isPrototype)
     // For initialization of GlobalObject's intrinsic objects
     // These objects have fixed properties, so transition table is not used for memory optimization
     ASSERT(m_prototype);
-    ASSERT(!rareData());
+    ASSERT(!hasRareData());
     ASSERT(!state.context()->vmInstance()->didSomePrototypeObjectDefineIndexedProperty());
     ASSERT(!structure()->hasIndexPropertyName());
 
     markThisObjectDontNeedStructureTransitionTable();
 
     if (isPrototype) {
-        ensureObjectRareData()->m_isEverSetAsPrototypeObject = true;
+        ensureRareData()->m_isEverSetAsPrototypeObject = true;
     }
 }
 
@@ -565,7 +565,7 @@ bool Object::setPrototype(ExecutionState& state, const Value& proto)
         o->markAsPrototypeObject(state);
     }
 
-    if (rareData()) {
+    if (hasRareData()) {
         rareData()->m_prototype = o;
     } else {
         m_prototype = o;
@@ -577,7 +577,7 @@ bool Object::setPrototype(ExecutionState& state, const Value& proto)
 
 void Object::markAsPrototypeObject(ExecutionState& state)
 {
-    ensureObjectRareData()->m_isEverSetAsPrototypeObject = true;
+    ensureRareData()->m_isEverSetAsPrototypeObject = true;
 
     if (UNLIKELY(!state.context()->vmInstance()->didSomePrototypeObjectDefineIndexedProperty() && (structure()->hasIndexPropertyName() || isProxyObject()))) {
         state.context()->vmInstance()->somePrototypeObjectDefineIndexedProperty(state);

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -704,7 +704,7 @@ enum class ElementTypes : uint8_t {
 };
 
 class Object : public PointerValue {
-    friend class VMInstance;
+    friend class ObjectRef;
     friend class GlobalObject;
     friend class ByteCodeInterpreter;
     friend class EnumerateObjectWithDestruction;
@@ -782,13 +782,13 @@ public:
     // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-isextensiblie
     virtual bool isExtensible(ExecutionState&)
     {
-        return rareData() == nullptr ? true : rareData()->m_isExtensible;
+        return hasRareData() ? rareData()->m_isExtensible : true;
     }
 
     // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
     virtual bool preventExtensions(ExecutionState&)
     {
-        ensureObjectRareData()->m_isExtensible = false;
+        ensureRareData()->m_isExtensible = false;
         return true;
     }
 
@@ -796,7 +796,7 @@ public:
     virtual Value getPrototype(ExecutionState&)
     {
         Object* prototype = m_prototype;
-        if (UNLIKELY(prototype != nullptr && prototype->isObjectRareData())) {
+        if (UNLIKELY(hasRareData())) {
             prototype = rareData()->m_prototype;
         }
         return prototype ? prototype : Value(Value::Null);
@@ -806,7 +806,7 @@ public:
     virtual Object* getPrototypeObject(ExecutionState&)
     {
         Object* prototype = m_prototype;
-        if (UNLIKELY(prototype != nullptr && prototype->isObjectRareData())) {
+        if (UNLIKELY(hasRareData())) {
             prototype = rareData()->m_prototype;
         }
         return prototype;
@@ -816,7 +816,7 @@ public:
     {
         Object* prototype = m_prototype;
 
-        if (UNLIKELY(prototype != nullptr && prototype->isObjectRareData())) {
+        if (UNLIKELY(hasRareData())) {
             prototype = rareData()->m_prototype;
         }
         return prototype;
@@ -911,11 +911,6 @@ public:
         }
     }
 
-    void markThisObjectDontNeedStructureTransitionTable()
-    {
-        m_structure = m_structure->convertToNonTransitionStructure();
-    }
-
     // returns existence of index
     static bool nextIndexForward(ExecutionState& state, Object* obj, const int64_t cur, const int64_t len, int64_t& nextIndex);
     static bool nextIndexBackward(ExecutionState& state, Object* obj, const int64_t cur, const int64_t end, int64_t& nextIndex);
@@ -927,17 +922,22 @@ public:
         return true;
     }
 
-    ObjectRareData* ensureObjectRareData()
+    ObjectRareData* ensureRareData()
     {
-        if (rareData() == nullptr) {
+        if (!hasRareData()) {
             m_prototype = (Object*)(new ObjectRareData(this));
         }
         return rareData();
     }
 
+    inline bool hasRareData() const
+    {
+        return (m_prototype != nullptr && m_prototype->isObjectRareData());
+    }
+
     bool isEverSetAsPrototypeObject() const
     {
-        if (LIKELY(rareData() == nullptr)) {
+        if (LIKELY(!hasRareData())) {
             return false;
         } else {
             return rareData()->m_isEverSetAsPrototypeObject;
@@ -946,7 +946,7 @@ public:
 
     bool isSpreadArray() const
     {
-        if (LIKELY(rareData() == nullptr)) {
+        if (LIKELY(!hasRareData())) {
             return false;
         }
         return isArrayObject() && rareData()->m_isSpreadArrayObject;
@@ -954,7 +954,7 @@ public:
 
     void* extraData()
     {
-        if (rareData()) {
+        if (hasRareData()) {
             return rareData()->m_extraData;
         }
         return nullptr;
@@ -962,13 +962,13 @@ public:
 
     void setExtraData(void* e)
     {
-        ensureObjectRareData()->m_extraData = e;
+        ensureRareData()->m_extraData = e;
     }
 
     Object* ensureInternalSlot(ExecutionState& state)
     {
         ASSERT(!isArrayObject());
-        ensureObjectRareData();
+        ensureRareData();
         if (!internalSlot()) {
             setInternalSlot(new Object(state, Object::PrototypeIsNull));
         }
@@ -978,7 +978,7 @@ public:
     Object* internalSlot()
     {
         ASSERT(!isArrayObject());
-        ASSERT(rareData());
+        ASSERT(hasRareData());
         return rareData()->m_internalSlot;
     }
 
@@ -987,13 +987,13 @@ public:
         if (isArrayObject()) {
             return false;
         }
-        return rareData() && rareData()->m_internalSlot;
+        return hasRareData() && rareData()->m_internalSlot;
     }
 
     void setInternalSlot(Object* object)
     {
         ASSERT(!isArrayObject());
-        ensureObjectRareData()->m_internalSlot = object;
+        ensureRareData()->m_internalSlot = object;
     }
 
     virtual Context* getFunctionRealm(ExecutionState& state)
@@ -1046,12 +1046,10 @@ protected:
     enum ForGlobalBuiltin { __ForGlobalBuiltin__ };
     explicit Object(ExecutionState& state, size_t defaultSpace, ForGlobalBuiltin);
 
-    ObjectRareData* rareData() const
+    inline ObjectRareData* rareData() const
     {
-        if ((size_t)m_prototype > 2 && m_prototype->isObjectRareData()) {
-            return (ObjectRareData*)m_prototype;
-        }
-        return nullptr;
+        ASSERT(hasRareData());
+        return (ObjectRareData*)m_prototype;
     }
     ObjectStructure* m_structure;
     Object* m_prototype;
@@ -1064,6 +1062,10 @@ protected:
         return m_structure;
     }
 
+    void markThisObjectDontNeedStructureTransitionTable()
+    {
+        m_structure = m_structure->convertToNonTransitionStructure();
+    }
 
     ALWAYS_INLINE Value uncheckedGetOwnDataProperty(ExecutionState& state, size_t idx)
     {

--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -195,7 +195,7 @@ void RegExpObject::initWithOption(ExecutionState& state, String* source, Option 
 
 void RegExpObject::setLastIndex(ExecutionState& state, const Value& v)
 {
-    if (UNLIKELY(rareData() && rareData()->m_hasNonWritableLastIndexRegexpObject && (m_option & (Option::Sticky | Option::Global)))) {
+    if (UNLIKELY(hasRareData() && rareData()->m_hasNonWritableLastIndexRegexpObject && (m_option & (Option::Sticky | Option::Global)))) {
         Object::throwCannotWriteError(state, ObjectStructurePropertyName(state.context()->staticStrings().lastIndex));
     }
     m_lastIndex = v;
@@ -206,9 +206,9 @@ bool RegExpObject::defineOwnProperty(ExecutionState& state, const ObjectProperty
     bool returnValue = Object::defineOwnProperty(state, P, desc);
     if (!P.isUIntType() && returnValue && P.objectStructurePropertyName() == ObjectStructurePropertyName(state.context()->staticStrings().lastIndex)) {
         if (!structure()->readProperty((size_t)ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER).m_descriptor.isWritable()) {
-            ensureObjectRareData()->m_hasNonWritableLastIndexRegexpObject = true;
+            ensureRareData()->m_hasNonWritableLastIndexRegexpObject = true;
         } else {
-            ensureObjectRareData()->m_hasNonWritableLastIndexRegexpObject = false;
+            ensureRareData()->m_hasNonWritableLastIndexRegexpObject = false;
         }
     }
     return returnValue;

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -255,7 +255,7 @@ VMInstance::VMInstance(Platform* platform, const char* locale, const char* timez
     : m_currentSandBox(nullptr)
     , m_randEngine((unsigned int)time(NULL))
     , m_isFinalized(false)
-    , m_didSomePrototypeObjectDefineIndexedProperty(false)
+    , m_fastModeArrayEnabled(true)
 #ifdef ESCARGOT_DEBUGGER
     , m_debuggerEnabled(false)
 #endif /* ESCARGOT_DEBUGGER */
@@ -445,9 +445,11 @@ void VMInstance::clearCaches()
     globalSymbolRegistry().clear();
 }
 
-void VMInstance::somePrototypeObjectDefineIndexedProperty(ExecutionState& state)
+void VMInstance::disableFastModeArray(ExecutionState& state)
 {
-    m_didSomePrototypeObjectDefineIndexedProperty = true;
+    // When a Proxy or Object with indexed properties is registered in any ArrayObject's prototype chain,
+    // we immediately disable the fast-mode optimization and revert all the status of allocated fast-mode arrays to non-fast-mode
+    m_fastModeArrayEnabled = false;
     std::vector<ArrayObject*> allOfArray;
     Escargot::HeapObjectIteratorCallback callback =
         [&allOfArray](Escargot::ExecutionState& state, void* obj) {

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -150,12 +150,12 @@ public:
     static Value regexpStickyNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
     static Value regexpUnicodeNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
 
-    bool didSomePrototypeObjectDefineIndexedProperty()
+    bool fastModeArrayEnabled()
     {
-        return m_didSomePrototypeObjectDefineIndexedProperty;
+        return m_fastModeArrayEnabled;
     }
 
-    void somePrototypeObjectDefineIndexedProperty(ExecutionState& state);
+    void disableFastModeArray(ExecutionState& state);
 
     ToStringRecursionPreventer& toStringRecursionPreventer()
     {
@@ -236,7 +236,8 @@ private:
 
     bool m_isFinalized;
     // this flag should affect VM-wide array object
-    bool m_didSomePrototypeObjectDefineIndexedProperty;
+    // represent use of fast mode array optimization (default: enabled)
+    bool m_fastModeArrayEnabled;
 #ifdef ESCARGOT_DEBUGGER
     bool m_debuggerEnabled;
 #endif /* ESCARGOT_DEBUGGER */


### PR DESCRIPTION
* Disable fast-mode array optimization by tracking prototype chains
    * Tracing prototype chains which have ArrayObjects in itself instead of marking every prototype objects,
    * When a ProxyObject or Object with index properties is registered in array-related prototype chains, fast-mode array optimization is immediately disabled
    * Reduce memory usage of ObjectRareData for each prototype object
    * Enable the fast mode optimization for more possible case
* Add hasRareData for Object
    * hasRareData is added to reduce repetitive check executions
    * rename ensureRareData

#623 should land first.