### PR TITLE
Update length-related operations

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -466,7 +466,7 @@ Value ByteCodeInterpreter::interpret(ExecutionState* state, ByteCodeBlock* byteC
                 ArrayObject* arr = (ArrayObject*)v;
                 if (LIKELY(arr->isFastModeArray())) {
                     uint32_t idx = property.tryToUseAsArrayIndex(*state);
-                    if (LIKELY(idx != Value::InvalidArrayIndexValue) && LIKELY(idx < arr->getArrayLength(*state))) {
+                    if (LIKELY(idx != Value::InvalidArrayIndexValue) && LIKELY(idx < arr->arrayLength(*state))) {
                         const Value& v = arr->m_fastModeData[idx];
                         if (LIKELY(!v.isEmpty())) {
                             registerFile[code->m_storeRegisterIndex] = v;
@@ -490,7 +490,7 @@ Value ByteCodeInterpreter::interpret(ExecutionState* state, ByteCodeBlock* byteC
                 uint32_t idx = property.tryToUseAsArrayIndex(*state);
                 if (LIKELY(arr->isFastModeArray())) {
                     if (LIKELY(idx != Value::InvalidArrayIndexValue)) {
-                        uint32_t len = arr->getArrayLength(*state);
+                        uint32_t len = arr->arrayLength(*state);
                         if (UNLIKELY(len <= idx)) {
                             if (UNLIKELY(!arr->isExtensible(*state))) {
                                 JUMP_INSTRUCTION(SetObjectOpcodeSlowCase);
@@ -1736,7 +1736,7 @@ ALWAYS_INLINE Value ByteCodeInterpreter::getObjectPrecomputedCaseOperation(Execu
 NEVER_INLINE Value ByteCodeInterpreter::getObjectPrecomputedCaseOperationCacheMiss(ExecutionState& state, Object* obj, const Value& receiver, GetObjectPreComputedCase* code, ByteCodeBlock* block)
 {
     if (code->m_isLength && obj->isArrayObject()) {
-        return Value(obj->asArrayObject()->getArrayLength(state));
+        return Value(obj->asArrayObject()->arrayLength(state));
     }
 
     const int maxCacheMissCount = 16;
@@ -2864,7 +2864,7 @@ NEVER_INLINE void ByteCodeInterpreter::spreadFunctionArguments(ExecutionState& s
         if (arg.isObject() && arg.asObject()->isSpreadArray()) {
             ArrayObject* spreadArray = arg.asObject()->asArrayObject();
             ASSERT(spreadArray->isFastModeArray());
-            for (size_t i = 0; i < spreadArray->getArrayLength(state); i++) {
+            for (size_t i = 0; i < spreadArray->arrayLength(state); i++) {
                 argVector.push_back(spreadArray->m_fastModeData[i]);
             }
         } else {
@@ -3094,13 +3094,13 @@ NEVER_INLINE void ByteCodeInterpreter::arrayDefineOwnPropertyBySpreadElementOper
     ArrayObject* arr = registerFile[code->m_objectRegisterIndex].asObject()->asArrayObject();
 
     if (LIKELY(arr->isFastModeArray())) {
-        size_t baseIndex = arr->getArrayLength(state);
+        size_t baseIndex = arr->arrayLength(state);
         size_t elementLength = code->m_count;
         for (size_t i = 0; i < code->m_count; i++) {
             if (code->m_loadRegisterIndexs[i] != REGISTER_LIMIT) {
                 Value element = registerFile[code->m_loadRegisterIndexs[i]];
                 if (element.isObject() && element.asObject()->isSpreadArray()) {
-                    elementLength = elementLength + element.asObject()->asArrayObject()->getArrayLength(state) - 1;
+                    elementLength = elementLength + element.asObject()->asArrayObject()->arrayLength(state) - 1;
                 }
             }
         }
@@ -3116,7 +3116,7 @@ NEVER_INLINE void ByteCodeInterpreter::arrayDefineOwnPropertyBySpreadElementOper
                 if (element.isObject() && element.asObject()->isSpreadArray()) {
                     ArrayObject* spreadArray = element.asObject()->asArrayObject();
                     ASSERT(spreadArray->isFastModeArray());
-                    for (size_t spreadIndex = 0; spreadIndex < spreadArray->getArrayLength(state); spreadIndex++) {
+                    for (size_t spreadIndex = 0; spreadIndex < spreadArray->arrayLength(state); spreadIndex++) {
                         arr->m_fastModeData[baseIndex + elementIndex] = spreadArray->m_fastModeData[spreadIndex];
                         elementIndex++;
                     }
@@ -3138,7 +3138,7 @@ NEVER_INLINE void ByteCodeInterpreter::arrayDefineOwnPropertyBySpreadElementOper
         ArrayObject* arr = registerFile[objectRegisterIndex].asObject()->asArrayObject();
         ASSERT(!arr->isFastModeArray());
 
-        size_t baseIndex = arr->getArrayLength(state);
+        size_t baseIndex = arr->arrayLength(state);
         size_t elementIndex = 0;
 
         for (size_t i = 0; i < count; i++) {
@@ -3148,7 +3148,7 @@ NEVER_INLINE void ByteCodeInterpreter::arrayDefineOwnPropertyBySpreadElementOper
                     ArrayObject* spreadArray = element.asObject()->asArrayObject();
                     ASSERT(spreadArray->isFastModeArray());
                     Value spreadElement;
-                    for (size_t spreadIndex = 0; spreadIndex < spreadArray->getArrayLength(state); spreadIndex++) {
+                    for (size_t spreadIndex = 0; spreadIndex < spreadArray->arrayLength(state); spreadIndex++) {
                         spreadElement = spreadArray->m_fastModeData[spreadIndex];
                         arr->defineOwnProperty(state, ObjectPropertyName(state, baseIndex + elementIndex), ObjectPropertyDescriptor(spreadElement, ObjectPropertyDescriptor::AllPresent));
                         elementIndex++;

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -34,6 +34,8 @@ class ArrayIteratorObject;
 class ArrayObject : public Object {
     friend class VMInstance;
     friend class ByteCodeInterpreter;
+    friend class EnumerateObjectWithDestruction;
+    friend class EnumerateObjectWithIteration;
     friend Value builtinArrayConstructor(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget);
     friend void initializeCustomAllocators();
     friend int getValidValueInArrayObject(void* ptr, GC_mark_custom_result* arr);
@@ -66,10 +68,6 @@ public:
     }
     virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
-    virtual uint64_t length(ExecutionState& state) override
-    {
-        return getArrayLength(state);
-    }
     virtual void sort(ExecutionState& state, int64_t length, const std::function<bool(const Value& a, const Value& b)>& comp) override;
     virtual ObjectGetResult getIndexedProperty(ExecutionState& state, const Value& property) override;
     virtual ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override;
@@ -86,7 +84,7 @@ public:
 
     void defineOwnIndexedPropertyWithExpandedLength(ExecutionState& state, const size_t& index, const Value& value)
     {
-        ASSERT(index < getArrayLength(state));
+        ASSERT(index < arrayLength(state));
         if (LIKELY(isFastModeArray())) {
             setFastModeArrayValueWithoutExpanding(state, index, value);
         } else {
@@ -112,11 +110,11 @@ private:
     void setFastModeArrayValueWithoutExpanding(ExecutionState& state, size_t idx, const Value& v)
     {
         ASSERT(isFastModeArray());
-        ASSERT(idx < getArrayLength(state));
+        ASSERT(idx < arrayLength(state));
         m_fastModeData[idx] = v;
     }
 
-    ALWAYS_INLINE uint32_t getArrayLength(ExecutionState&)
+    ALWAYS_INLINE uint32_t arrayLength(ExecutionState&)
     {
         return m_arrayLength;
     }

--- a/src/runtime/EnumerateObject.cpp
+++ b/src/runtime/EnumerateObject.cpp
@@ -20,6 +20,7 @@
 #include "Escargot.h"
 #include "EnumerateObject.h"
 #include "runtime/SmallValue.h"
+#include "runtime/ArrayObject.h"
 
 namespace Escargot {
 
@@ -113,7 +114,7 @@ void EnumerateObjectWithDestruction::executeEnumeration(ExecutionState& state, S
     ASSERT(!!m_object);
 
     if (m_object->isArrayObject()) {
-        m_arrayLength = m_object->length(state);
+        m_arrayLength = m_object->asArrayObject()->arrayLength(state);
     }
 
     m_hiddenClass = m_object->structure();
@@ -164,7 +165,7 @@ bool EnumerateObjectWithDestruction::checkIfModified(ExecutionState& state)
     }
 
     if (m_object->isArrayObject()) {
-        if (UNLIKELY(m_object->length(state) != m_arrayLength)) {
+        if (UNLIKELY(m_object->asArrayObject()->arrayLength(state) != m_arrayLength)) {
             return true;
         }
         if (UNLIKELY(m_object->rareData() && m_object->rareData()->m_shouldUpdateEnumerateObject)) {
@@ -181,7 +182,7 @@ void EnumerateObjectWithIteration::executeEnumeration(ExecutionState& state, Sma
     m_hiddenClassChain.clear();
 
     if (m_object->isArrayObject()) {
-        m_arrayLength = m_object->length(state);
+        m_arrayLength = m_object->asArrayObject()->arrayLength(state);
     }
 
     bool shouldSearchProto = false;
@@ -299,7 +300,7 @@ bool EnumerateObjectWithIteration::checkIfModified(ExecutionState& state)
     }
 
     if (m_object->isArrayObject()) {
-        if (UNLIKELY(m_object->length(state) != m_arrayLength)) {
+        if (UNLIKELY(m_object->asArrayObject()->arrayLength(state) != m_arrayLength)) {
             return true;
         }
         if (UNLIKELY(m_object->rareData() && m_object->rareData()->m_shouldUpdateEnumerateObject)) {

--- a/src/runtime/GlobalObjectBuiltinArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinArray.cpp
@@ -161,7 +161,7 @@ static int64_t flattenIntoArray(ExecutionState& state, Value target, Value sourc
                 element = Object::call(state, mappedValue, thisArg, 3, args);
             }
             if (depth > 0 && element.isObject() && element.asObject()->isArray(state)) {
-                int64_t elementLen = element.asObject()->lengthES6(state);
+                int64_t elementLen = element.asObject()->length(state);
                 targetIndex = flattenIntoArray(state, target, element, elementLen, targetIndex, depth - 1);
 
             } else {
@@ -286,7 +286,7 @@ static Value builtinArrayFrom(ExecutionState& state, Value thisValue, size_t arg
     // Let arrayLike be ! ToObject(items).
     Object* arrayLike = items.toObject(state);
     // Let len be ? ToLength(? Get(arrayLike, "length")).
-    int64_t len = arrayLike->lengthES6(state);
+    int64_t len = arrayLike->length(state);
     // If IsConstructor(C) is true, then
     Object* A;
     if (C.isConstructor()) {
@@ -357,7 +357,7 @@ static Value builtinArrayOf(ExecutionState& state, Value thisValue, size_t argc,
 static Value builtinArrayJoin(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
     RESOLVE_THIS_BINDING_TO_OBJECT(thisBinded, Array, join);
-    int64_t len = thisBinded->lengthES6(state);
+    int64_t len = thisBinded->length(state);
     Value separator = argv[0];
     String* sep;
 
@@ -447,7 +447,7 @@ static Value builtinArrayJoin(ExecutionState& state, Value thisValue, size_t arg
 static Value builtinArrayReverse(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, reverse);
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
     int64_t middle = std::floor(len / 2);
     int64_t lower = 0;
     while (middle > lower) {
@@ -508,7 +508,7 @@ static Value builtinArraySort(ExecutionState& state, Value thisValue, size_t arg
     }
     bool defaultSort = (argc == 0) || cmpfn.isUndefined();
 
-    int64_t len = thisObject->lengthES6(state);
+    int64_t len = thisObject->length(state);
 
     thisObject->sort(state, len, [defaultSort, &cmpfn, &state](const Value& a, const Value& b) -> bool {
         if (a.isEmpty() && b.isUndefined())
@@ -542,7 +542,7 @@ static Value builtinArraySplice(ExecutionState& state, Value thisValue, size_t a
 
     // Let lenVal be the result of calling the [[Get]] internal method of O with argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // Let relativeStart be ToInteger(start).
     double relativeStart = argv[0].toInteger(state);
@@ -731,7 +731,7 @@ static Value builtinArrayConcat(ExecutionState& state, Value thisValue, size_t a
                 // Let k be 0.
                 int64_t k = 0;
                 // Let len be the result of calling the [[Get]] internal method of E with argument "length".
-                int64_t len = arr->lengthES6(state);
+                int64_t len = arr->length(state);
 
                 // If n + len > 2^53 - 1, throw a TypeError exception.
                 CHECK_ARRAY_LENGTH(n + len > Value::maximumLength());
@@ -770,7 +770,7 @@ static Value builtinArrayConcat(ExecutionState& state, Value thisValue, size_t a
 static Value builtinArraySlice(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
     RESOLVE_THIS_BINDING_TO_OBJECT(thisObject, Array, slice);
-    int64_t len = thisObject->lengthES6(state);
+    int64_t len = thisObject->length(state);
     double relativeStart = argv[0].toInteger(state);
     int64_t k = (relativeStart < 0) ? std::max((double)len + relativeStart, 0.0) : std::min(relativeStart, (double)len);
     int64_t kStart = k;
@@ -806,7 +806,7 @@ static Value builtinArraySlice(ExecutionState& state, Value thisValue, size_t ar
 static Value builtinArrayForEach(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
     RESOLVE_THIS_BINDING_TO_OBJECT(thisObject, Array, forEach);
-    int64_t len = thisObject->lengthES6(state);
+    int64_t len = thisObject->length(state);
 
     Value callbackfn = argv[0];
     if (!callbackfn.isCallable()) {
@@ -844,7 +844,7 @@ static Value builtinArrayIndexOf(ExecutionState& state, Value thisValue, size_t 
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, indexOf);
     // Let lenValue be the result of calling the [[Get]] internal method of O with the argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // If len is 0, return -1.
     if (len == 0) {
@@ -915,7 +915,7 @@ static Value builtinArrayLastIndexOf(ExecutionState& state, Value thisValue, siz
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, lastIndexOf);
     // Let lenValue be the result of calling the [[Get]] internal method of O with the argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // If len is 0, return -1.
     if (len == 0) {
@@ -973,7 +973,7 @@ static Value builtinArrayEvery(ExecutionState& state, Value thisValue, size_t ar
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, every);
     // Let lenValue be the result of calling the [[Get]] internal method of O with the argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // If IsCallable(callbackfn) is false, throw a TypeError exception.
     Value callbackfn = argv[0];
@@ -1023,7 +1023,7 @@ static Value builtinArrayFill(ExecutionState& state, Value thisValue, size_t arg
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, fill);
     // Let lenValue be the result of calling the [[Get]] internal method of O with the argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // Let relativeStart be ToInteger(start).
     double relativeStart = 0;
@@ -1059,7 +1059,7 @@ static Value builtinArrayFilter(ExecutionState& state, Value thisValue, size_t a
 
     // Let lenValue be the result of calling the [[Get]] internal method of O with the argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // If IsCallable(callbackfn) is false, throw a TypeError exception.
     Value callbackfn = argv[0];
@@ -1122,7 +1122,7 @@ static Value builtinArrayMap(ExecutionState& state, Value thisValue, size_t argc
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, map);
     // Let lenValue be the result of calling the [[Get]] internal method of O with the argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // If IsCallable(callbackfn) is false, throw a TypeError exception.
     Value callbackfn = argv[0];
@@ -1174,7 +1174,7 @@ static Value builtinArraySome(ExecutionState& state, Value thisValue, size_t arg
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, some);
     // Let lenValue be the result of calling the [[Get]] internal method of O with the argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // If IsCallable(callbackfn) is false, throw a TypeError exception.
     Value callbackfn = argv[0];
@@ -1226,7 +1226,7 @@ static Value builtinArrayIncludes(ExecutionState& state, Value thisValue, size_t
     // Let O be ? ToObject(this value).
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, includes);
     // Let len be ? ToLength(? Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // If len is 0, return false.
     if (len == 0) {
@@ -1282,7 +1282,7 @@ static Value builtinArrayToLocaleString(ExecutionState& state, Value thisValue, 
     ToStringRecursionPreventerItemAutoHolder holder(state, array);
 
     // Let len be ? ToLength(? Get(array, "length")).
-    uint64_t len = array->lengthES6(state);
+    uint64_t len = array->length(state);
 
     // Let separator be the String value for the list-separator String appropriate for the host environment’s current locale (this is derived in an implementation-defined way).
     String* separator = state.context()->staticStrings().asciiTable[(size_t)','].string();
@@ -1328,7 +1328,7 @@ static Value builtinArrayReduce(ExecutionState& state, Value thisValue, size_t a
 {
     // Let O be the result of calling ToObject passing the this value as the argument.
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, reduce);
-    int64_t len = O->lengthES6(state); // 2-3
+    int64_t len = O->length(state); // 2-3
     Value callbackfn = argv[0];
     Value initialValue = Value(Value::EmptyValue);
     if (argc > 1) {
@@ -1381,7 +1381,7 @@ static Value builtinArrayReduceRight(ExecutionState& state, Value thisValue, siz
 
     // Let lenValue be the result of calling the [[Get]] internal method of O with the argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // If IsCallable(callbackfn) is false, throw a TypeError exception.
     Value callbackfn = argv[0];
@@ -1464,7 +1464,7 @@ static Value builtinArrayPop(ExecutionState& state, Value thisValue, size_t argc
 
     // Let lenVal be the result of calling the [[Get]] internal method of O with argument "length".
     // Let len be ToUint32(lenVal).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // If len is zero,
     if (len == 0) {
@@ -1495,7 +1495,7 @@ static Value builtinArrayPush(ExecutionState& state, Value thisValue, size_t arg
 
     // Let lenVal be the result of calling the [[Get]] internal method of O with argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t n = O->lengthES6(state);
+    int64_t n = O->length(state);
 
     // If len + argCount > 2^53 - 1, throw a TypeError exception.
     CHECK_ARRAY_LENGTH((uint64_t)n + argc > Value::maximumLength());
@@ -1522,7 +1522,7 @@ static Value builtinArrayPush(ExecutionState& state, Value thisValue, size_t arg
 static Value builtinArrayFlat(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, flat);
-    int64_t sourceLen = O->lengthES6(state);
+    int64_t sourceLen = O->length(state);
     double depthNum = 1;
     if (argc > 0 && !argv[0].isUndefined()) {
         depthNum = argv[0].toInteger(state);
@@ -1538,7 +1538,7 @@ static Value builtinArrayFlat(ExecutionState& state, Value thisValue, size_t arg
 static Value builtinArrayFlatMap(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, flatMap);
-    int64_t sourceLen = O->lengthES6(state);
+    int64_t sourceLen = O->length(state);
     if (!argv[0].isCallable()) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Array.string(), true, state.context()->staticStrings().flatMap.string(), ErrorObject::Messages::GlobalObject_FirstArgumentNotCallable);
     }
@@ -1557,7 +1557,7 @@ static Value builtinArrayShift(ExecutionState& state, Value thisValue, size_t ar
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, shift);
     // Let lenVal be the result of calling the [[Get]] internal method of O with argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
     // If len is zero, then
     if (len == 0) {
         // Call the [[Put]] internal method of O with arguments "length", 0, and true.
@@ -1618,7 +1618,7 @@ static Value builtinArrayUnshift(ExecutionState& state, Value thisValue, size_t 
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, unshift);
     // Let lenVal be the result of calling the [[Get]] internal method of O with argument "length".
     // Let len be ToLength(Get(O, "length")).
-    int64_t len = O->lengthES6(state);
+    int64_t len = O->length(state);
 
     // Let argCount be the number of actual arguments.
     int64_t argCount = argc;
@@ -1698,7 +1698,7 @@ static Value builtinArrayFind(ExecutionState& state, Value thisValue, size_t arg
     // Let O be ? ToObject(this value).
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, find);
     // Let len be ? ToLength(? Get(O, "length")).
-    double len = O->lengthES6(state);
+    double len = O->length(state);
     // If IsCallable(predicate) is false, throw a TypeError exception.
     if (!argv[0].isCallable()) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Array.string(), true, state.context()->staticStrings().find.string(), ErrorObject::Messages::GlobalObject_CallbackNotCallable);
@@ -1735,7 +1735,7 @@ static Value builtinArrayFindIndex(ExecutionState& state, Value thisValue, size_
     // Let O be ? ToObject(this value).
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, findIndex);
     // Let len be ? ToLength(? Get(O, "length")).
-    double len = O->lengthES6(state);
+    double len = O->length(state);
     // If IsCallable(predicate) is false, throw a TypeError exception.
     if (!argv[0].isCallable()) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Array.string(), true, state.context()->staticStrings().findIndex.string(), ErrorObject::Messages::GlobalObject_CallbackNotCallable);
@@ -1772,7 +1772,7 @@ static Value builtinArrayCopyWithin(ExecutionState& state, Value thisValue, size
     // Let O be ToObject(this value).
     RESOLVE_THIS_BINDING_TO_OBJECT(O, Array, copyWithin);
     // Let len be ToLength(Get(O, "length")).
-    double len = O->lengthES6(state);
+    double len = O->length(state);
     // Let relativeTarget be ToInteger(target).
     double relativeTarget = argv[0].toInteger(state);
     // If relativeTarget < 0, let to be max((len + relativeTarget),0); else let to be min(relativeTarget, len).

--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -113,22 +113,13 @@ static Value builtinFunctionApply(ExecutionState& state, Value thisValue, size_t
     Value argArray = argv[1];
     size_t arrlen = 0;
     Value* arguments = nullptr;
+    ValueVector argList;
     if (argArray.isUndefinedOrNull()) {
-        // do nothing
-    } else if (argArray.isObject()) {
-        Object* obj = argArray.asObject();
-        arrlen = obj->length(state);
-        arguments = ALLOCA(sizeof(Value) * arrlen, Value, state);
-        for (size_t i = 0; i < arrlen; i++) {
-            auto re = obj->getIndexedProperty(state, Value(i));
-            if (re.hasValue()) {
-                arguments[i] = re.value(state, obj);
-            } else {
-                arguments[i] = Value();
-            }
-        }
+        // TODO
     } else {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Function.string(), true, state.context()->staticStrings().apply.string(), ErrorObject::Messages::GlobalObject_SecondArgumentNotObject);
+        argList = Object::createListFromArrayLike(state, argArray);
+        arrlen = argList.size();
+        arguments = argList.data();
     }
 
     return Object::call(state, thisValue, thisArg, arrlen, arguments);

--- a/src/runtime/GlobalObjectBuiltinJSON.cpp
+++ b/src/runtime/GlobalObjectBuiltinJSON.cpp
@@ -222,7 +222,7 @@ static Value builtinJSONParse(ExecutionState& state, Value thisValue, size_t arg
                 if (val.asObject()->isArray(state)) {
                     Object* object = val.asObject();
                     uint32_t i = 0;
-                    uint32_t len = object->lengthES6(state);
+                    uint32_t len = object->length(state);
                     while (i < len) {
                         Value newElement = Walk(val, ObjectPropertyName(state, Value(i).toString(state)));
                         if (newElement.isUndefined()) {
@@ -350,7 +350,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
         } else if (replacer.asObject()->isArray(state)) {
             propertyListTouched = true;
             Object* replacerObj = replacer.asObject();
-            uint64_t len = replacerObj->lengthES6(state);
+            uint64_t len = replacerObj->length(state);
             uint64_t k = 0;
 
             while (k < len) {
@@ -508,7 +508,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
         // 5
         VectorWithInlineStorage<32, String*, GCUtil::gc_malloc_allocator<String*>> partial;
         // 6, 7
-        uint32_t len = obj->lengthES6(state);
+        uint32_t len = obj->length(state);
 
         // Each array element requires at least 1 character for the value, and 1 character for the separator
         if (len / 2 > STRING_MAXIMUM_LENGTH) {

--- a/src/runtime/GlobalObjectBuiltinReflect.cpp
+++ b/src/runtime/GlobalObjectBuiltinReflect.cpp
@@ -42,24 +42,10 @@ static Value builtinReflectApply(ExecutionState& state, Value thisValue, size_t 
     }
 
     // 2. Let args be CreateListFromArrayLike(argumentsList).
-    if (!argList.isObject()) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, strings->Reflect.string(), false, String::emptyString, "%s: argumentsList is not an object");
-    }
-    Object* argObject = argList.asObject();
-    size_t arglen = argObject->length(state);
-    Value* args = ALLOCA(sizeof(Value) * arglen, Value, state);
-    for (size_t i = 0; i < arglen; i++) {
-        auto element = argObject->getIndexedProperty(state, Value(i));
-        if (element.hasValue()) {
-            args[i] = element.value(state, argObject);
-        } else {
-            args[i] = Value();
-        }
-    }
+    auto args = Object::createListFromArrayLike(state, argList);
 
-    // TODO 4. Perform PrepareForTailCall().
     // 5. Return Call(target, thisArgument, args).
-    return Object::call(state, target, thisArgument, arglen, args);
+    return Object::call(state, target, thisArgument, args.size(), args.data());
 }
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-reflect.construct
@@ -82,23 +68,9 @@ static Value builtinReflectConstruct(ExecutionState& state, Value thisValue, siz
     }
 
     // 4. Let args be CreateListFromArrayLike(argumentsList).
-    if (!argList.isObject()) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, strings->Reflect.string(), false, String::emptyString, "%s: argumentsList is not an object");
-    }
-    Object* argObject = argList.asObject();
-    size_t arglen = argObject->length(state);
-    Value* args = ALLOCA(sizeof(Value) * arglen, Value, state);
-    for (size_t i = 0; i < arglen; i++) {
-        auto element = argObject->getIndexedProperty(state, Value(i));
-        if (element.hasValue()) {
-            args[i] = element.value(state, argObject);
-        } else {
-            args[i] = Value();
-        }
-    }
-
+    auto args = Object::createListFromArrayLike(state, argList);
     // 6. Return Construct(target, args, newTarget).
-    return Object::construct(state, target, arglen, args, newTargetArg.asObject());
+    return Object::construct(state, target, args.size(), args.data(), newTargetArg.asObject());
 }
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-reflect.defineproperty

--- a/src/runtime/GlobalObjectBuiltinRegExp.cpp
+++ b/src/runtime/GlobalObjectBuiltinRegExp.cpp
@@ -86,7 +86,7 @@ static Value builtinRegExpExec(ExecutionState& state, Value thisValue, size_t ar
     RegExpObject* regexp = thisObject->asRegExpObject();
     unsigned int option = regexp->option();
     String* str = argv[0].toString(state);
-    double lastIndex = 0;
+    uint64_t lastIndex = 0;
     if (option & (RegExpObject::Global | RegExpObject::Sticky)) {
         lastIndex = regexp->computedLastIndex(state);
         if (lastIndex > str->length()) {
@@ -147,17 +147,13 @@ static Value builtinRegExpTest(ExecutionState& state, Value thisValue, size_t ar
     RegExpObject* regexp = thisObject->asRegExpObject();
     unsigned int option = regexp->option();
     String* str = argv[0].toString(state);
-    double lastIndex = 0;
+    uint64_t lastIndex = 0;
     if (option & (RegExpObject::Global | RegExpObject::Sticky)) {
         lastIndex = regexp->computedLastIndex(state);
         if (lastIndex > str->length()) {
             regexp->setLastIndex(state, Value(0));
             return Value(false);
         }
-    }
-
-    if (lastIndex < 0) {
-        lastIndex = 0;
     }
 
     RegexMatchResult result;

--- a/src/runtime/GlobalObjectBuiltinString.cpp
+++ b/src/runtime/GlobalObjectBuiltinString.cpp
@@ -1218,7 +1218,7 @@ static Value builtinStringRaw(ExecutionState& state, Value thisValue, size_t arg
     // Let raw be ? ToObject(? Get(cooked, "raw")).
     Object* raw = cooked->get(state, ObjectPropertyName(state.context()->staticStrings().raw)).value(state, cooked).toObject(state);
     // Let literalSegments be ? ToLength(? Get(raw, "length")).
-    double literalSegments = raw->lengthES6(state);
+    double literalSegments = raw->length(state);
     // If literalSegments ≤ 0, return the empty string.
     if (literalSegments <= 0) {
         return String::emptyString;

--- a/src/runtime/GlobalObjectBuiltinTypedArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinTypedArray.cpp
@@ -249,7 +249,7 @@ static Value builtinTypedArrayFrom(ExecutionState& state, Value thisValue, size_
     }
 
     Object* arrayLike = source.toObject(state);
-    uint64_t len = arrayLike->lengthES6(state);
+    uint64_t len = arrayLike->length(state);
 
     // TODO Let targetObj be ? TypedArrayCreate(C, « len »).
     Value arg[1] = { Value(len) };
@@ -505,7 +505,7 @@ Value builtinTypedArrayConstructor(ExecutionState& state, Value thisValue, size_
             // Let arrayLike be object.
             Object* arrayLike = inputObj;
             // Let len be ? ToLength(? Get(arrayLike, "length")).
-            uint64_t len = arrayLike->lengthES6(state);
+            uint64_t len = arrayLike->length(state);
             // Perform ? AllocateTypedArrayBuffer(O, len).
             unsigned elementSize = obj->elementSize();
             uint64_t bufferSize = len * elementSize;
@@ -815,7 +815,7 @@ static Value builtinTypedArraySet(ExecutionState& state, Value thisValue, size_t
     int targetElementSize = ArrayBufferView::getElementSize(wrapper->typedArrayType());
     if (!arg0->isTypedArrayObject()) {
         Object* src = arg0;
-        uint64_t srcLength = src->lengthES6(state);
+        uint64_t srcLength = src->length(state);
         if (srcLength + (uint64_t)offset > targetLength) {
             const StaticStrings* strings = &state.context()->staticStrings();
             ErrorObject::throwBuiltinError(state, ErrorObject::RangeError, strings->TypedArray.string(), true, strings->set.string(), ErrorObject::Messages::GlobalObject_InvalidArrayLength);

--- a/src/runtime/Intl.cpp
+++ b/src/runtime/Intl.cpp
@@ -1248,7 +1248,7 @@ ValueVector Intl::canonicalizeLocaleList(ExecutionState& state, Value locales)
         O = locales.toObject(state);
     }
 
-    uint64_t len = O->lengthES6(state);
+    uint64_t len = O->length(state);
     // Let k be 0.
     // Repeat, while k < len
     uint64_t k = 0;

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -1286,7 +1286,7 @@ ValueVector Object::createListFromArrayLike(ExecutionState& state, Value obj, ui
     // 4. Let len be ToLength(Get(obj, "length")).
     // 5. ReturnIfAbrupt(len).
     Object* o = obj.asObject();
-    auto len = o->lengthES6(state);
+    auto len = o->length(state);
 
     // Honorate "length" property: If length>2^32-1, throw a RangeError exception.
     if (len > ((1LL << 32LL) - 1LL)) {
@@ -1296,7 +1296,7 @@ ValueVector Object::createListFromArrayLike(ExecutionState& state, Value obj, ui
     // 6. Let list be an empty List.
     ValueVector list;
     // 7. Let index be 0.
-    size_t index = 0;
+    uint64_t index = 0;
     //8. Repeat while index < len
     while (index < len) {
         // a. Let indexName be ToString(index).
@@ -1312,7 +1312,7 @@ ValueVector Object::createListFromArrayLike(ExecutionState& state, Value obj, ui
         // e. Append next as the last element of list.
         list.pushBack(next);
         // f. Set index to index + 1.
-        index += 1;
+        index++;
     }
 
     // 9. Return list.
@@ -1329,11 +1329,7 @@ void Object::deleteOwnProperty(ExecutionState& state, size_t idx)
 
 uint64_t Object::length(ExecutionState& state)
 {
-    return get(state, state.context()->staticStrings().length).value(state, this).toUint32(state);
-}
-
-uint64_t Object::lengthES6(ExecutionState& state)
-{
+    // ToLength(Get(obj, "length"))
     return get(state, state.context()->staticStrings().length).value(state, this).toLength(state);
 }
 

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -847,8 +847,8 @@ public:
     virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
     // callback function should skip un-Enumerable property if needs
     virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
-    virtual uint64_t length(ExecutionState& state);
-    uint64_t lengthES6(ExecutionState& state);
+    // ToLength(Get(obj, "length"))
+    uint64_t length(ExecutionState& state);
 
     // https://www.ecma-international.org/ecma-262/10.0/#sec-isarray
     bool isArray(ExecutionState& state);

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -94,11 +94,11 @@ public:
     void init(ExecutionState& state, String* source, String* option = String::emptyString);
     void initWithOption(ExecutionState& state, String* source, Option option);
 
-    double computedLastIndex(ExecutionState& state)
+    uint64_t computedLastIndex(ExecutionState& state)
     {
         // NOTE(ES6): if global is false and sticy is false, let lastIndex be 0
         // Compute the result first with toInteger() and then examine if it is global or sticky
-        double res = lastIndex().toLength(state);
+        auto res = lastIndex().toLength(state);
         if (!(option() & (Option::Global | Option::Sticky)))
             return 0;
         return res;

--- a/src/runtime/StringObject.h
+++ b/src/runtime/StringObject.h
@@ -52,10 +52,6 @@ public:
     virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
     virtual ObjectGetResult getIndexedProperty(ExecutionState& state, const Value& property) override;
     virtual ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override;
-    virtual uint64_t length(ExecutionState& state) override
-    {
-        return m_primitiveValue->length();
-    }
 
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -202,7 +202,7 @@ public:
     inline bool toBoolean(ExecutionState& ec) const; // $7.1.2 ToBoolean
     double toNumber(ExecutionState& ec) const; // $7.1.3 ToNumber
     double toInteger(ExecutionState& ec) const; // $7.1.4 ToInteger
-    double toLength(ExecutionState& ec) const;
+    uint64_t toLength(ExecutionState& ec) const;
     int32_t toInt32(ExecutionState& ec) const; // $7.1.5 ToInt32
     uint32_t toUint32(ExecutionState& ec) const; // http://www.ecma-international.org/ecma-262/5.1/#sec-9.6
     String* toString(ExecutionState& ec) const // $7.1.12 ToString

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -253,7 +253,7 @@ def run_spidermonkey(engine, arch):
 
     run([join(SPIDERMONKEY_DIR, 'jstests.py'),
          '--no-progress', '-s',
-         '--timeout', '300',
+         '--timeout', '500',
          '--xul-info', '%s-gcc3:Linux:false' % arch,
          '--exclude-file', join(SPIDERMONKEY_OVERRIDE_DIR, 'excludelist.txt'),
          engine,


### PR DESCRIPTION
* remove each unnecessary length method
* lengthES6 has been renamed as getLength
* return type of toLength is changed to uint64_t
* use createListFromArrayLike for more cases

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>