### PR TITLE
Fix ArrayBuffer allocation

### DIFF
--- a/src/runtime/ArrayBufferObject.h
+++ b/src/runtime/ArrayBufferObject.h
@@ -47,14 +47,11 @@ public:
     explicit ArrayBufferObject(ExecutionState& state);
     explicit ArrayBufferObject(ExecutionState& state, Object* proto);
 
-    static ArrayBufferObject* allocateArrayBuffer(ExecutionState& state, Object* constructor);
+    static ArrayBufferObject* allocateArrayBuffer(ExecutionState& state, Object* constructor, size_t byteLength);
+    static ArrayBufferObject* cloneArrayBuffer(ExecutionState& state, ArrayBufferObject* srcBuffer, size_t srcByteOffset, size_t srcLength, Object* constructor);
 
     static const uint32_t maxArrayBufferSize = 210000000;
 
-    // Clone srcBuffer's srcByteOffset ~ end.
-    bool cloneBuffer(ExecutionState& state, ArrayBufferObject* srcBuffer, size_t srcByteOffset);
-    // Clone srcBuffer's srcByteOffset ~ (srcByteOffset + cloneLength).
-    bool cloneBuffer(ExecutionState& state, ArrayBufferObject* srcBuffer, size_t srcByteOffset, size_t cloneLength);
     void allocateBuffer(ExecutionState& state, size_t bytelength);
     void attachBuffer(ExecutionState& state, void* buffer, size_t bytelength);
     void detachArrayBuffer(ExecutionState& state);

--- a/src/runtime/DataViewObject.h
+++ b/src/runtime/DataViewObject.h
@@ -43,7 +43,6 @@ public:
     Value getViewValue(ExecutionState& state, Value index, Value _isLittleEndian, TypedArrayType type)
     {
         double numberIndex = index.toIndex(state);
-
         if (numberIndex == Value::InvalidIndexValue)
             ErrorObject::throwBuiltinError(state, ErrorObject::RangeError, state.context()->staticStrings().DataView.string(), false, String::emptyString, ErrorObject::Messages::GlobalObject_InvalidArrayBufferOffset);
 
@@ -91,7 +90,6 @@ public:
     Value setViewValue(ExecutionState& state, Value index, Value _isLittleEndian, TypedArrayType type, Value val)
     {
         double numberIndex = index.toIndex(state);
-
         if (numberIndex == Value::InvalidIndexValue)
             ErrorObject::throwBuiltinError(state, ErrorObject::RangeError, state.context()->staticStrings().DataView.string(), false, String::emptyString, ErrorObject::Messages::GlobalObject_InvalidArrayBufferOffset);
 

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -480,8 +480,7 @@ protected:
             if (length == std::numeric_limits<unsigned>::max()) {                                                                                      \
                 obj->setBuffer(nullptr, 0, 0, 0);                                                                                                      \
             } else {                                                                                                                                   \
-                auto buffer = ArrayBufferObject::allocateArrayBuffer(state, state.context()->globalObject()->arrayBuffer());                           \
-                buffer->allocateBuffer(state, length* siz);                                                                                            \
+                auto buffer = ArrayBufferObject::allocateArrayBuffer(state, state.context()->globalObject()->arrayBuffer(), length * siz);             \
                 obj->setBuffer(buffer, 0, length* siz, length);                                                                                        \
             }                                                                                                                                          \
             return obj;                                                                                                                                \

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -1201,7 +1201,6 @@
     <test id="built-ins/TypedArray/prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tostring"><reason>TODO</reason></test>
     <test id="built-ins/TypedArray/prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-valueof"><reason>TODO</reason></test>
     <test id="built-ins/TypedArray/prototype/toLocaleString/BigInt/return-result"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArray/prototype/toString"><reason>TODO</reason></test>
     <test id="built-ins/TypedArray/prototype/toString/BigInt/detached-buffer"><reason>TODO</reason></test>
     <test id="built-ins/TypedArray/prototype/values/BigInt/detached-buffer"><reason>TODO</reason></test>
     <test id="built-ins/TypedArray/prototype/values/BigInt/iter-prototype"><reason>TODO</reason></test>
@@ -1382,18 +1381,6 @@
     <test id="built-ins/TypedArrayConstructors/ctors/buffer-arg/typedarray-backed-by-sharedarraybuffer"><reason>TODO</reason></test>
     <test id="built-ins/TypedArrayConstructors/ctors/buffer-arg/use-custom-proto-if-object-sab"><reason>TODO</reason></test>
     <test id="built-ins/TypedArrayConstructors/ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/detached-when-species-retrieved-different-type"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/detached-when-species-retrieved-same-type"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/same-ctor-buffer-ctor-access-throws"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws"><reason>TODO</reason></test>
-    <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws"><reason>TODO</reason></test>
     <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/src-typedarray-big-throws"><reason>TODO</reason></test>
     <test id="built-ins/TypedArrayConstructors/from/BigInt/arylk-get-length-error"><reason>TODO</reason></test>
     <test id="built-ins/TypedArrayConstructors/from/BigInt/arylk-to-length-error"><reason>TODO</reason></test>


### PR DESCRIPTION
* toString builtin method of TypedArray is initialized to the value of Array.prototype.toString
* allocateArrayBuffer and cloneArrayBuffer are revised according to ES10 standard

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>