### PR TITLE
Fixup minor things

### DIFF
--- a/src/runtime/GlobalObjectBuiltinArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinArray.cpp
@@ -598,14 +598,9 @@ static Value builtinArraySplice(ExecutionState& state, Value thisValue, size_t a
             k++;
         } else {
             int64_t result;
-            bool exist = Object::nextIndexForward(state, O, actualStart + k, len, result);
-            if (!exist) {
-                A->setThrowsException(state, ObjectPropertyName(state.context()->staticStrings().length), Value(actualDeleteCount), A);
-                break;
-            } else {
-                k = result - actualStart;
-                A->setThrowsException(state, ObjectPropertyName(state.context()->staticStrings().length), Value(k), A);
-            }
+            Object::nextIndexForward(state, O, actualStart + k, len, result);
+            k = result - actualStart;
+            A->setThrowsException(state, ObjectPropertyName(state.context()->staticStrings().length), Value(k), A);
         }
     }
     // Let setStatus be Set(A, "length", actualDeleteCount, true).
@@ -789,17 +784,17 @@ static Value builtinArraySlice(ExecutionState& state, Value thisValue, size_t ar
             k++;
             n++;
         } else {
-            int64_t tmp;
-            bool exist = Object::nextIndexForward(state, thisObject, k, len, tmp);
-            if (!exist) {
-                n = finalEnd - kStart;
-                break;
-            }
-            n += tmp - k;
-            k = tmp;
+            int64_t result;
+            Object::nextIndexForward(state, thisObject, k, len, result);
+            n += result - k;
+            k = result;
         }
     }
-    ArrayObject->setThrowsException(state, ObjectPropertyName(state.context()->staticStrings().length), Value(n), Value(ArrayObject));
+    if (finalEnd - kStart > 0) {
+        ArrayObject->setThrowsException(state, ObjectPropertyName(state.context()->staticStrings().length), Value(finalEnd - kStart), Value(ArrayObject));
+    } else {
+        ArrayObject->setThrowsException(state, ObjectPropertyName(state.context()->staticStrings().length), Value(0), Value(ArrayObject));
+    }
     return ArrayObject;
 }
 

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -916,9 +916,8 @@ public:
         m_structure = m_structure->convertToNonTransitionStructure();
     }
 
-    // returns existence of index
-    static bool nextIndexForward(ExecutionState& state, Object* obj, const int64_t cur, const int64_t len, int64_t& nextIndex);
-    static bool nextIndexBackward(ExecutionState& state, Object* obj, const int64_t cur, const int64_t end, int64_t& nextIndex);
+    static void nextIndexForward(ExecutionState& state, Object* obj, const int64_t cur, const int64_t len, int64_t& nextIndex);
+    static void nextIndexBackward(ExecutionState& state, Object* obj, const int64_t cur, const int64_t end, int64_t& nextIndex);
 
     virtual void sort(ExecutionState& state, int64_t length, const std::function<bool(const Value& a, const Value& b)>& comp);
 

--- a/src/runtime/SandBox.cpp
+++ b/src/runtime/SandBox.cpp
@@ -142,7 +142,7 @@ void SandBox::createStackTraceData(StackTraceDataVector& stackTraceData, Executi
         bool alreadyExists = false;
 
         for (size_t i = 0; i < stackTraceData.size(); i++) {
-            if (stackTraceData[i].first == es) {
+            if (stackTraceData[i].first == es || stackTraceData[i].first->lexicalEnvironment() == es->lexicalEnvironment()) {
                 alreadyExists = true;
                 break;
             }
@@ -228,6 +228,18 @@ void SandBox::createStackTraceData(StackTraceDataVector& stackTraceData, Executi
 
 void SandBox::throwException(ExecutionState& state, Value exception)
 {
+    createStackTraceData(m_stackTraceData, state);
+
+    // We MUST save thrown exception Value.
+    // because bdwgc cannot track `thrown value`(may turned off by GC_DONT_REGISTER_MAIN_STATIC_DATA)
+    m_exception = exception;
+    throw exception;
+}
+
+void SandBox::rethrowPreviouslyCaughtException(ExecutionState& state, Value exception, const StackTraceDataVector& stackTraceData)
+{
+    m_stackTraceData = stackTraceData;
+    // update stack trace data if needs
     createStackTraceData(m_stackTraceData, state);
 
     // We MUST save thrown exception Value.

--- a/src/runtime/SandBox.h
+++ b/src/runtime/SandBox.h
@@ -72,6 +72,12 @@ public:
     SandBoxResult run(Value (*runner)(ExecutionState&, void*), void* data);
     static void createStackTraceData(StackTraceDataVector& stackTraceData, ExecutionState& state);
     void throwException(ExecutionState& state, Value exception);
+    void rethrowPreviouslyCaughtException(ExecutionState& state, Value exception, const StackTraceDataVector& stackTraceData);
+
+    StackTraceDataVector& stackTraceData()
+    {
+        return m_stackTraceData;
+    }
 
     Context* context()
     {

--- a/src/util/Vector.h
+++ b/src/util/Vector.h
@@ -169,6 +169,24 @@ public:
         return *this;
     }
 
+    const Vector<T, Allocator, ComputeReservedCapacityFunction>& operator=(Vector<T, Allocator, ComputeReservedCapacityFunction>&& other)
+    {
+        if (&other == this)
+            return *this;
+
+        if (other.size()) {
+            m_size = other.size();
+            m_buffer = other.m_buffer;
+            m_capacity = other.m_capacity;
+            other.m_buffer = nullptr;
+            other.m_size = 0;
+            other.m_capacity = 0;
+        } else {
+            clear();
+        }
+        return *this;
+    }
+
     Vector(const Vector<T, Allocator, ComputeReservedCapacityFunction>& other, const T& newItem)
     {
         m_size = other.size() + 1;

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -48,7 +48,6 @@
     <test id="built-ins/AggregateError/prototype/prop-desc"><reason>TODO</reason></test>
     <test id="built-ins/AggregateError/prototype/proto"><reason>TODO</reason></test>
     <test id="built-ins/AggregateError/toString"><reason>TODO</reason></test>
-    <test id="built-ins/Array/prototype/reverse/length-exceeding-integer-limit-with-proxy"><reason>TODO</reason></test>
     <test id="built-ins/Array/prototype/splice/create-species-length-exceeding-integer-limit"><reason>TODO</reason></test>
     <test id="built-ins/Array/prototype/splice/length-exceeding-integer-limit-shrink-array"><reason>TODO</reason></test>
     <test id="built-ins/Array/prototype/toLocaleString/primitive_this_value"><reason>TODO</reason></test>
@@ -1812,7 +1811,6 @@
     <test id="intl402/Locale/constructor-non-iana-canon"><reason>TODO</reason></test>
     <test id="intl402/Locale/constructor-options-region-valid"><reason>TODO</reason></test>
     <test id="intl402/Locale/likely-subtags-grandfathered"><reason>TODO</reason></test>
-    <test id="intl402/NumberFormat/constructor-locales-hasproperty"><reason>TODO</reason></test>
     <test id="intl402/NumberFormat/constructor-unit"><reason>TODO</reason></test>
     <test id="intl402/RelativeTimeFormat/constructor/constructor/locales-invalid"><reason>TODO</reason></test>
     <test id="intl402/RelativeTimeFormat/constructor/constructor/locales-valid"><reason>TODO</reason></test>


### PR DESCRIPTION
* If we use Object::nextIndexBackward, Object::nextIndexForward with non ordinal object,
  we should not test existence of value for index(we would not call user-defined function)
* Generate more user-friendly callstack

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>