### PR TITLE
Statements LOC info should not be modified when the debugger is enabled

### DIFF
--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -88,9 +88,12 @@ void ByteCodeGenerateContext::morphJumpPositionIntoComplexCase(ByteCodeBlock* cb
 }
 
 #ifdef ESCARGOT_DEBUGGER
-void ByteCodeGenerateContext::insertBreakpoint(size_t line, Node* node)
+void ByteCodeGenerateContext::insertBreakpoint(size_t index, Node* node)
 {
     ASSERT(m_breakpointContext != nullptr);
+
+    index -= m_codeBlock->asInterpretedCodeBlock()->functionStart().index;
+    size_t line = m_byteCodeBlock->computeNodeLOC(m_codeBlock->asInterpretedCodeBlock()->src(), m_codeBlock->asInterpretedCodeBlock()->functionStart(), index).line;
 
     if (line != 0 && line != m_breakpointContext->m_lastBreakpointLine) {
         m_breakpointContext->m_breakpointLocations.push_back(Debugger::BreakpointLocation(line, (uint32_t)m_byteCodeBlock->currentCodeSize()));

--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -336,7 +336,7 @@ struct ByteCodeGenerateContext {
     }
 
 #ifdef ESCARGOT_DEBUGGER
-    void insertBreakpoint(size_t line, Node* node);
+    void insertBreakpoint(size_t index, Node* node);
 #endif /* ESCARGOT_DEBUGGER */
 
     // NOTE this is counter! not index!!!!!!

--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -399,12 +399,6 @@ public:
         return this;
     }
 
-#ifdef ESCARGOT_DEBUGGER
-    void setBreakpointInfo(size_t, size_t)
-    {
-    }
-#endif /* ESCARGOT_DEBUGGER */
-
     void setASTNode(const SyntaxNode& node)
     {
         // dummy function for setASTNode() of ASTSentinelNode

--- a/src/parser/ast/ExpressionStatementNode.h
+++ b/src/parser/ast/ExpressionStatementNode.h
@@ -38,7 +38,9 @@ public:
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
 #ifdef ESCARGOT_DEBUGGER
-        insertBreakpoint(context);
+        if (m_expression->type() != Escargot::InitializeParameterExpression) {
+            insertBreakpoint(context);
+        }
 #endif /* ESCARGOT_DEBUGGER */
 
         if (!context->shouldCareScriptExecutionResult()) {

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -535,12 +535,6 @@ public:
         fn(this);
     }
 
-#ifdef ESCARGOT_DEBUGGER
-    virtual void setBreakpointInfo(size_t loc_index, size_t line)
-    {
-    }
-#endif /* ESCARGOT_DEBUGGER */
-
     NodeLOC m_loc;
 };
 

--- a/src/parser/ast/StatementNode.h
+++ b/src/parser/ast/StatementNode.h
@@ -48,12 +48,6 @@ public:
     }
 
 #ifdef ESCARGOT_DEBUGGER
-    virtual void setBreakpointInfo(size_t loc_index, size_t line)
-    {
-        m_loc.index = loc_index;
-        m_line = line;
-    }
-
     virtual bool isEmptyStatement(void)
     {
         return false;
@@ -61,7 +55,7 @@ public:
 
     inline void insertBreakpoint(ByteCodeGenerateContext* context)
     {
-        context->insertBreakpoint(m_line, this);
+        context->insertBreakpoint(m_loc.index, this);
     }
 
     void insertEmptyStatementBreakpoint(ByteCodeGenerateContext* context, Node* node)
@@ -73,7 +67,7 @@ public:
         if (node->type() == ASTNodeType::EmptyStatement || node->type() == ASTNodeType::BlockStatement) {
             StatementNode* statementNode = reinterpret_cast<StatementNode*>(node);
             if (statementNode->isEmptyStatement()) {
-                context->insertBreakpoint(statementNode->m_line, node);
+                context->insertBreakpoint(statementNode->m_loc.index, node);
             }
         }
     }

--- a/src/parser/ast/VariableDeclaratorNode.h
+++ b/src/parser/ast/VariableDeclaratorNode.h
@@ -51,7 +51,9 @@ public:
 
         if (m_init) {
 #ifdef ESCARGOT_DEBUGGER
-            context->insertBreakpoint(m_line, this);
+            if (!addFakeUndefinedLiteralNode) {
+                context->insertBreakpoint(m_id->m_loc.index, this);
+            }
 #endif /* ESCARGOT_DEBUGGER */
 
             context->getRegister();
@@ -72,21 +74,10 @@ public:
         }
     }
 
-#ifdef ESCARGOT_DEBUGGER
-    virtual void setBreakpointInfo(size_t loc_index, size_t line)
-    {
-        m_loc.index = loc_index;
-        m_line = line;
-    }
-#endif /* ESCARGOT_DEBUGGER */
-
 private:
     EscargotLexer::KeywordKind m_kind;
     Node* m_id; // id: Pattern;
     Node* m_init; // init: Expression | null;
-#ifdef ESCARGOT_DEBUGGER
-    size_t m_line;
-#endif /* ESCARGOT_DEBUGGER */
 };
 }
 

--- a/tools/debugger/tests/do_backtrace.expected
+++ b/tools/debugger/tests/do_backtrace.expected
@@ -13,12 +13,12 @@ Stopped at tools/debugger/tests/do_backtrace.js:27 (in g() at line:26, col:1)
 Stopped at tools/debugger/tests/do_backtrace.js:23 (in f() at line:22, col:1)
 (escargot-debugger) bt t
 Total number of frames: 4
-tools/debugger/tests/do_backtrace.js:24:2 (in f)
+tools/debugger/tests/do_backtrace.js:23:5 (in f)
 tools/debugger/tests/do_backtrace.js:27:5 (in g)
 tools/debugger/tests/do_backtrace.js:31:5 (in h)
 tools/debugger/tests/do_backtrace.js:34:1
 (escargot-debugger) bt 2
-tools/debugger/tests/do_backtrace.js:24:2 (in f)
+tools/debugger/tests/do_backtrace.js:23:5 (in f)
 tools/debugger/tests/do_backtrace.js:27:5 (in g)
 (escargot-debugger) bt 1 3
 tools/debugger/tests/do_backtrace.js:27:5 (in g)

--- a/tools/debugger/tests/do_exception.expected
+++ b/tools/debugger/tests/do_exception.expected
@@ -3,7 +3,7 @@ Connection created!!!
 Stopped at tools/debugger/tests/do_exception.js:28
 (escargot-debugger) c
 Exception: RangeError: Test exception
-tools/debugger/tests/do_exception.js:22:2 (in g)
+tools/debugger/tests/do_exception.js:21:4 (in g)
 tools/debugger/tests/do_exception.js:25:4 (in f)
 tools/debugger/tests/do_exception.js:28:1
 Connection closed.


### PR DESCRIPTION
The line info for each breakpoint can be calculated from the LOC index.
This patch resolves the problem, mentioned in #649.

Signed-off-by: Robert Fancsik <frobert@inf.u-szeged.hu>