### PR TITLE
Statements LOC info should not be modified when the debugger is enabled

### DIFF
--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -72,8 +72,15 @@ struct ByteCodeGenerateError {
 
 #ifdef ESCARGOT_DEBUGGER
 struct ByteCodeBreakpointContext {
-    size_t m_lastBreakpointLine;
+    size_t m_lastBreakpointLineOffset;
+    size_t m_lastBreakpointIndexOffset;
     std::vector<Debugger::BreakpointLocation> m_breakpointLocations;
+
+    ByteCodeBreakpointContext()
+        : m_lastBreakpointLineOffset(0)
+        , m_lastBreakpointIndexOffset(0)
+    {
+    }
 };
 #endif /* ESCARGOT_DEBUGGER */
 
@@ -336,7 +343,9 @@ struct ByteCodeGenerateContext {
     }
 
 #ifdef ESCARGOT_DEBUGGER
-    void insertBreakpoint(size_t line, Node* node);
+    size_t calculateBreakpointLineOffset(size_t index, ExtendedNodeLOC sourceElementStart);
+    void insertBreakpoint(size_t index, Node* node);
+    void insertBreakpointAt(size_t line, Node* node);
 #endif /* ESCARGOT_DEBUGGER */
 
     // NOTE this is counter! not index!!!!!!

--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -400,12 +400,6 @@ public:
         return this;
     }
 
-#ifdef ESCARGOT_DEBUGGER
-    void setBreakpointInfo(size_t, size_t)
-    {
-    }
-#endif /* ESCARGOT_DEBUGGER */
-
     void setASTNode(const SyntaxNode& node)
     {
         // dummy function for setASTNode() of ASTSentinelNode

--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -212,7 +212,7 @@ struct ASTFunctionScopeContext {
     ASTBlockScopeContextVector m_childBlockScopes;
 
     ExtendedNodeLOC m_functionStartLOC;
-#if !(defined NDEBUG) || defined ESCARGOT_DEBUGGER
+#if !(defined NDEBUG)
     ExtendedNodeLOC m_bodyEndLOC;
 #else
     NodeLOC m_bodyEndLOC;

--- a/src/parser/ast/ExpressionStatementNode.h
+++ b/src/parser/ast/ExpressionStatementNode.h
@@ -38,7 +38,9 @@ public:
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
 #ifdef ESCARGOT_DEBUGGER
-        insertBreakpoint(context);
+        if (m_expression->type() != Escargot::InitializeParameterExpression) {
+            insertBreakpoint(context);
+        }
 #endif /* ESCARGOT_DEBUGGER */
 
         if (!context->shouldCareScriptExecutionResult()) {

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -536,12 +536,6 @@ public:
         fn(this);
     }
 
-#ifdef ESCARGOT_DEBUGGER
-    virtual void setBreakpointInfo(size_t loc_index, size_t line)
-    {
-    }
-#endif /* ESCARGOT_DEBUGGER */
-
     NodeLOC m_loc;
 };
 

--- a/src/parser/ast/ProgramNode.h
+++ b/src/parser/ast/ProgramNode.h
@@ -54,7 +54,11 @@ public:
 
 #ifdef ESCARGOT_DEBUGGER
         if (context->m_breakpointContext->m_breakpointLocations.size() == 0) {
-            insertBreakpoint(context);
+            if (codeBlock->m_isEvalMode) {
+                context->insertBreakpointAt(1, this);
+            } else {
+                insertBreakpoint(context);
+            }
         }
 #endif /* ESCARGOT_DEBUGGER */
         codeBlock->pushCode(End(ByteCodeLOC(SIZE_MAX), 0), context, this);

--- a/src/parser/ast/ReturnStatementNode.h
+++ b/src/parser/ast/ReturnStatementNode.h
@@ -36,7 +36,15 @@ public:
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
 #ifdef ESCARGOT_DEBUGGER
-        insertBreakpoint(context);
+        if (context->m_breakpointContext->m_breakpointLocations.size() == 0) {
+            ASSERT(context->m_breakpointContext->m_lastBreakpointLineOffset == 0);
+            ASSERT(context->m_breakpointContext->m_breakpointLocations.size() == 0);
+            ExtendedNodeLOC sourceElementStart = context->m_codeBlock->asInterpretedCodeBlock()->functionStart();
+            size_t lastLineOffset = context->calculateBreakpointLineOffset(m_loc.index, sourceElementStart);
+            context->insertBreakpointAt(lastLineOffset + sourceElementStart.line, this);
+        } else {
+            insertBreakpoint(context);
+        }
 #endif /* ESCARGOT_DEBUGGER */
 
         if (context->tryCatchWithBlockStatementCount() != 0) {

--- a/src/parser/ast/StatementNode.h
+++ b/src/parser/ast/StatementNode.h
@@ -48,12 +48,6 @@ public:
     }
 
 #ifdef ESCARGOT_DEBUGGER
-    virtual void setBreakpointInfo(size_t loc_index, size_t line)
-    {
-        m_loc.index = loc_index;
-        m_line = line;
-    }
-
     virtual bool isEmptyStatement(void)
     {
         return false;
@@ -61,19 +55,18 @@ public:
 
     inline void insertBreakpoint(ByteCodeGenerateContext* context)
     {
-        context->insertBreakpoint(m_line, this);
+        context->insertBreakpoint(m_loc.index, this);
     }
 
     void insertEmptyStatementBreakpoint(ByteCodeGenerateContext* context, Node* node)
     {
         // The first statement of a loop always stops (even if it is an empty statement).
         // Otherwise the debugger may not be able to track the iterations of a loop.
-        context->m_breakpointContext->m_lastBreakpointLine = 0;
 
         if (node->type() == ASTNodeType::EmptyStatement || node->type() == ASTNodeType::BlockStatement) {
             StatementNode* statementNode = reinterpret_cast<StatementNode*>(node);
             if (statementNode->isEmptyStatement()) {
-                context->insertBreakpoint(statementNode->m_line, node);
+                context->insertBreakpoint(statementNode->m_loc.index, node);
             }
         }
     }

--- a/src/parser/ast/VariableDeclaratorNode.h
+++ b/src/parser/ast/VariableDeclaratorNode.h
@@ -51,7 +51,9 @@ public:
 
         if (m_init) {
 #ifdef ESCARGOT_DEBUGGER
-            context->insertBreakpoint(m_line, this);
+            if (!addFakeUndefinedLiteralNode) {
+                context->insertBreakpoint(m_id->m_loc.index, this);
+            }
 #endif /* ESCARGOT_DEBUGGER */
 
             context->getRegister();
@@ -72,21 +74,10 @@ public:
         }
     }
 
-#ifdef ESCARGOT_DEBUGGER
-    virtual void setBreakpointInfo(size_t loc_index, size_t line)
-    {
-        m_loc.index = loc_index;
-        m_line = line;
-    }
-#endif /* ESCARGOT_DEBUGGER */
-
 private:
     EscargotLexer::KeywordKind m_kind;
     Node* m_id; // id: Pattern;
     Node* m_init; // init: Expression | null;
-#ifdef ESCARGOT_DEBUGGER
-    size_t m_line;
-#endif /* ESCARGOT_DEBUGGER */
 };
 }
 

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -3248,11 +3248,6 @@ public:
         ASTNode idNode = nullptr;
         bool isIdentifier;
         AtomicString name;
-#ifdef ESCARGOT_DEBUGGER
-        size_t loc_index = this->lookahead.start;
-        size_t line = this->lookahead.lineNumber;
-        bool hasAssignment = false;
-#endif /* ESCARGOT_DEBUGGER */
 
         idNode = this->parsePattern(builder, params, kind, true);
         isIdentifier = (idNode->type() == Identifier);
@@ -3270,16 +3265,10 @@ public:
             if (!this->matchKeyword(KeywordKind::InKeyword) && !this->matchContextualKeyword("of")) {
                 this->expect(Substitution);
                 init = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
-#ifdef ESCARGOT_DEBUGGER
-                hasAssignment = true;
-#endif /* ESCARGOT_DEBUGGER */
             }
         } else if ((!inFor && !isIdentifier) || this->match(Substitution)) {
             this->expect(Substitution);
             init = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
-#ifdef ESCARGOT_DEBUGGER
-            hasAssignment = true;
-#endif /* ESCARGOT_DEBUGGER */
         }
 
         if (init && isIdentifier) {
@@ -3287,12 +3276,6 @@ public:
         }
 
         ASTNode variableNode = this->finalize(node, builder.createVariableDeclaratorNode(kind, idNode, init));
-#ifdef ESCARGOT_DEBUGGER
-        if (!hasAssignment) {
-            line = 0;
-        }
-        variableNode->setBreakpointInfo(loc_index, line);
-#endif /* ESCARGOT_DEBUGGER */
         return variableNode;
     }
 
@@ -3430,11 +3413,7 @@ public:
         ASTNode idNode = nullptr;
         bool isIdentifier;
         AtomicString name;
-#ifdef ESCARGOT_DEBUGGER
-        size_t loc_index = this->lookahead.start;
-        size_t line = this->lookahead.lineNumber;
-        bool hasAssignment = false;
-#endif /* ESCARGOT_DEBUGGER */
+        MetaNode node = this->createNode();
 
         idNode = this->parsePattern(builder, params, options.kind, true);
         leftSideType = idNode->type();
@@ -3459,9 +3438,6 @@ public:
             this->nextToken();
             ASTNodeType type = ASTNodeType::ASTNodeTypeError;
             initNode = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
-#ifdef ESCARGOT_DEBUGGER
-            hasAssignment = true;
-#endif /* ESCARGOT_DEBUGGER */
             if (isIdentifier) {
                 this->addImplicitName(initNode, name);
             }
@@ -3475,14 +3451,7 @@ public:
             }
         }
 
-        ASTNode node = this->finalize(this->createNode(), builder.createVariableDeclaratorNode(options.kind, idNode, initNode));
-#ifdef ESCARGOT_DEBUGGER
-        if (!hasAssignment) {
-            line = 0;
-        }
-        node->setBreakpointInfo(loc_index, line);
-#endif /* ESCARGOT_DEBUGGER */
-        return node;
+        return this->finalize(node, builder.createVariableDeclaratorNode(options.kind, idNode, initNode));
     }
 
     template <class ASTBuilder>
@@ -4004,6 +3973,7 @@ public:
             this->throwError(Messages::IllegalReturn);
         }
 
+        MetaNode node = this->createNode();
         this->expectKeyword(ReturnKeyword);
 
         bool hasArgument = !this->match(SemiColon) && !this->match(RightBrace) && !this->hasLineTerminator && this->lookahead.type != EOFToken;
@@ -4013,7 +3983,7 @@ public:
         }
         this->consumeSemicolon();
 
-        return this->finalize(this->createNode(), builder.createReturnStatementNode(argument));
+        return this->finalize(node, builder.createReturnStatementNode(argument));
     }
 
     // ECMA-262 13.11 The with statement
@@ -4323,10 +4293,6 @@ public:
     {
         checkRecursiveLimit();
         ASTNode statement = nullptr;
-#ifdef ESCARGOT_DEBUGGER
-        size_t loc_index = this->lookahead.start;
-        size_t line = this->lookahead.lineNumber;
-#endif /* ESCARGOT_DEBUGGER */
 
         switch (this->lookahead.type) {
         case Token::BooleanLiteralToken:
@@ -4426,9 +4392,6 @@ public:
             this->throwUnexpectedToken(this->lookahead);
         }
 
-#ifdef ESCARGOT_DEBUGGER
-        statement->setBreakpointInfo(loc_index, line);
-#endif /* ESCARGOT_DEBUGGER */
         return statement;
     }
 
@@ -4524,8 +4487,9 @@ public:
         bool isEndedWithReturnNode = referNode && referNode->type() == ASTNodeType::ReturnStatement;
         if (!isEndedWithReturnNode) {
             referNode = body->appendChild(builder.createReturnStatementNode(nullptr));
+
 #ifdef ESCARGOT_DEBUGGER
-            referNode->setBreakpointInfo(this->lookahead.start, this->lookahead.lineNumber);
+            referNode->m_loc.index = this->startMarker.index + this->baseMarker.index;
 #endif /* ESCARGOT_DEBUGGER */
         }
 
@@ -5944,14 +5908,11 @@ public:
 
         MetaNode endNode = this->createNode();
         this->currentScopeContext->m_bodyEndLOC.index = endNode.index;
-#if !(defined NDEBUG) || defined ESCARGOT_DEBUGGER
+#if !(defined NDEBUG)
         this->currentScopeContext->m_bodyEndLOC.line = endNode.line;
         this->currentScopeContext->m_bodyEndLOC.column = endNode.column;
 #endif
         ProgramNode* programNode = builder.createProgramNode(container, this->currentScopeContext, this->moduleData, std::move(this->numeralLiteralVector));
-#ifdef ESCARGOT_DEBUGGER
-        programNode->setBreakpointInfo(this->lookahead.start, this->lookahead.lineNumber);
-#endif /* ESCARGOT_DEBUGGER */
         return this->finalize(startNode, programNode);
     }
 
@@ -6073,9 +6034,6 @@ public:
                 Node* expr = this->isolateCoverGrammar(builder, &Parser::parseAssignmentExpression<NodeGenerator, false>);
 
                 Node* node = this->finalize(nodeStart, builder.createReturnStatementNode(expr));
-#ifdef ESCARGOT_DEBUGGER
-                node->setBreakpointInfo(loc_index, line);
-#endif /* ESCARGOT_DEBUGGER */
                 container->appendChild(node, nullptr);
 
                 /*

--- a/tools/debugger/tests/do_backtrace.expected
+++ b/tools/debugger/tests/do_backtrace.expected
@@ -13,12 +13,12 @@ Stopped at tools/debugger/tests/do_backtrace.js:27 (in g() at line:26, col:1)
 Stopped at tools/debugger/tests/do_backtrace.js:23 (in f() at line:22, col:1)
 (escargot-debugger) bt t
 Total number of frames: 4
-tools/debugger/tests/do_backtrace.js:24:2 (in f)
+tools/debugger/tests/do_backtrace.js:23:5 (in f)
 tools/debugger/tests/do_backtrace.js:27:5 (in g)
 tools/debugger/tests/do_backtrace.js:31:5 (in h)
 tools/debugger/tests/do_backtrace.js:34:1
 (escargot-debugger) bt 2
-tools/debugger/tests/do_backtrace.js:24:2 (in f)
+tools/debugger/tests/do_backtrace.js:23:5 (in f)
 tools/debugger/tests/do_backtrace.js:27:5 (in g)
 (escargot-debugger) bt 1 3
 tools/debugger/tests/do_backtrace.js:27:5 (in g)

--- a/tools/debugger/tests/do_exception.expected
+++ b/tools/debugger/tests/do_exception.expected
@@ -3,7 +3,7 @@ Connection created!!!
 Stopped at tools/debugger/tests/do_exception.js:28
 (escargot-debugger) c
 Exception: RangeError: Test exception
-tools/debugger/tests/do_exception.js:22:2 (in g)
+tools/debugger/tests/do_exception.js:21:4 (in g)
 tools/debugger/tests/do_exception.js:25:4 (in f)
 tools/debugger/tests/do_exception.js:28:1
 Connection closed.


### PR DESCRIPTION
The line info for each breakpoint can be calculated from the LOC index.
This patch resolves the problem, mentioned in #649.

Signed-off-by: Robert Fancsik <frobert@inf.u-szeged.hu>