### PR TITLE
Adding ExecutionState depth to backtrace info

### DIFF
--- a/src/debugger/Debugger.cpp
+++ b/src/debugger/Debugger.cpp
@@ -112,7 +112,7 @@ void Debugger::sendBreakpointLocations(std::vector<Debugger::BreakpointLocation>
     send(ESCARGOT_MESSAGE_BREAKPOINT_LOCATION, ptr, length * sizeof(BreakpointLocation));
 }
 
-void Debugger::sendBacktraceInfo(uint8_t type, ByteCodeBlock* byteCodeBlock, uint32_t line, uint32_t column)
+void Debugger::sendBacktraceInfo(uint8_t type, ByteCodeBlock* byteCodeBlock, uint32_t line, uint32_t column, uint32_t executionStateDepth)
 {
     BacktraceInfo backtraceInfo;
 
@@ -120,6 +120,7 @@ void Debugger::sendBacktraceInfo(uint8_t type, ByteCodeBlock* byteCodeBlock, uin
     memcpy(&backtraceInfo.byteCode, &byteCode, sizeof(void*));
     memcpy(&backtraceInfo.line, &line, sizeof(uint32_t));
     memcpy(&backtraceInfo.column, &column, sizeof(uint32_t));
+    memcpy(&backtraceInfo.executionStateDepth, &executionStateDepth, sizeof(uint32_t));
 
     send(type, &backtraceInfo, sizeof(BacktraceInfo));
 }
@@ -287,7 +288,7 @@ void Debugger::getBacktrace(ExecutionState* state, uint32_t minDepth, uint32_t m
 
             ExtendedNodeLOC loc = byteCodeBlock->computeNodeLOCFromByteCode(state->context(), byteCodePosition, byteCodeBlock->m_codeBlock);
 
-            sendBacktraceInfo(ESCARGOT_MESSAGE_BACKTRACE, byteCodeBlock, (uint32_t)loc.line, (uint32_t)loc.column);
+            sendBacktraceInfo(ESCARGOT_MESSAGE_BACKTRACE, byteCodeBlock, (uint32_t)loc.line, (uint32_t)loc.column, (uint32_t)stackTraceData[i].second.executionStateDepth);
 
             if (!enabled()) {
                 return;

--- a/src/debugger/Debugger.h
+++ b/src/debugger/Debugger.h
@@ -211,7 +211,7 @@ public:
     void sendPointer(uint8_t type, const void* ptr);
     void sendFunctionInfo(InterpretedCodeBlock* codeBlock);
     void sendBreakpointLocations(std::vector<Debugger::BreakpointLocation>& locations);
-    void sendBacktraceInfo(uint8_t type, ByteCodeBlock* byteCodeBlock, uint32_t line, uint32_t column);
+    void sendBacktraceInfo(uint8_t type, ByteCodeBlock* byteCodeBlock, uint32_t line, uint32_t column, uint32_t executionStateDepth);
     void stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state);
     void releaseFunction(const void* ptr);
     String* getClientSource(String** sourceName);
@@ -266,6 +266,7 @@ private:
         uint8_t byteCode[sizeof(void*)];
         uint8_t line[sizeof(uint32_t)];
         uint8_t column[sizeof(uint32_t)];
+        uint8_t executionStateDepth[sizeof(uint32_t)];
     };
 
     bool doEval(ExecutionState* state, ByteCodeBlock* byteCodeBlock, uint8_t* buffer, size_t length);

--- a/src/runtime/SandBox.h
+++ b/src/runtime/SandBox.h
@@ -38,6 +38,9 @@ public:
         String* sourceCode;
         ExtendedNodeLOC loc;
         String* functionName;
+#ifdef ESCARGOT_DEBUGGER
+        uint32_t executionStateDepth;
+#endif /* ESCARGOT_DEBUGGER */
         bool isFunction;
         bool isConstructor;
         bool isAssociatedWithJavaScriptCode;

--- a/tools/debugger/debugger_core.py
+++ b/tools/debugger/debugger_core.py
@@ -429,10 +429,9 @@ class Debugger(object):
 
             elif buffer_type in [ESCARGOT_MESSAGE_BACKTRACE,
                                  ESCARGOT_MESSAGE_EXCEPTION_BACKTRACE]:
-                backtrace_info = struct.unpack(self.byte_order + self.pointer_format + self.idx_format + self.idx_format, data[1:])
+                backtrace_info = struct.unpack(self.byte_order + self.pointer_format + self.idx_format + self.idx_format + self.idx_format, data[1:])
                 function = self.function_list[backtrace_info[0]]
-
-                result = "%s:%d:%d" % (function.source_name, backtrace_info[1], backtrace_info[2])
+                result = "%s:%d:%d [depth:%d]" % (function.source_name, backtrace_info[1], backtrace_info[2],backtrace_info[3])
                 if function.name != "":
                     result += " (in %s)" % (function.name)
 

--- a/tools/debugger/tests/do_backtrace.expected
+++ b/tools/debugger/tests/do_backtrace.expected
@@ -4,7 +4,7 @@ Stopped at tools/debugger/tests/do_backtrace.js:20
 (escargot-debugger) s
 Stopped at tools/debugger/tests/do_backtrace.js:34
 (escargot-debugger) backtrace
-tools/debugger/tests/do_backtrace.js:34:1
+tools/debugger/tests/do_backtrace.js:34:1 [depth:0]
 (escargot-debugger) s
 Stopped at tools/debugger/tests/do_backtrace.js:31 (in h() at line:30, col:1)
 (escargot-debugger) s
@@ -13,15 +13,15 @@ Stopped at tools/debugger/tests/do_backtrace.js:27 (in g() at line:26, col:1)
 Stopped at tools/debugger/tests/do_backtrace.js:23 (in f() at line:22, col:1)
 (escargot-debugger) bt t
 Total number of frames: 4
-tools/debugger/tests/do_backtrace.js:23:5 (in f)
-tools/debugger/tests/do_backtrace.js:27:5 (in g)
-tools/debugger/tests/do_backtrace.js:31:5 (in h)
-tools/debugger/tests/do_backtrace.js:34:1
+tools/debugger/tests/do_backtrace.js:23:5 [depth:0] (in f)
+tools/debugger/tests/do_backtrace.js:27:5 [depth:1] (in g)
+tools/debugger/tests/do_backtrace.js:31:5 [depth:2] (in h)
+tools/debugger/tests/do_backtrace.js:34:1 [depth:3]
 (escargot-debugger) bt 2
-tools/debugger/tests/do_backtrace.js:23:5 (in f)
-tools/debugger/tests/do_backtrace.js:27:5 (in g)
+tools/debugger/tests/do_backtrace.js:23:5 [depth:0] (in f)
+tools/debugger/tests/do_backtrace.js:27:5 [depth:1] (in g)
 (escargot-debugger) bt 1 3
-tools/debugger/tests/do_backtrace.js:27:5 (in g)
-tools/debugger/tests/do_backtrace.js:31:5 (in h)
+tools/debugger/tests/do_backtrace.js:27:5 [depth:1] (in g)
+tools/debugger/tests/do_backtrace.js:31:5 [depth:2] (in h)
 (escargot-debugger) c
 Connection closed.

--- a/tools/debugger/tests/do_exception.expected
+++ b/tools/debugger/tests/do_exception.expected
@@ -3,7 +3,7 @@ Connection created!!!
 Stopped at tools/debugger/tests/do_exception.js:28
 (escargot-debugger) c
 Exception: RangeError: Test exception
-tools/debugger/tests/do_exception.js:21:4 (in g)
-tools/debugger/tests/do_exception.js:25:4 (in f)
-tools/debugger/tests/do_exception.js:28:1
+tools/debugger/tests/do_exception.js:21:4 [depth:0] (in g)
+tools/debugger/tests/do_exception.js:25:4 [depth:1] (in f)
+tools/debugger/tests/do_exception.js:28:1 [depth:2]
 Connection closed.


### PR DESCRIPTION
The new member is needed to Escargot debugger backtrace function

Signed-off-by: bence gabor kis <kisbg@inf.u-szeged.hu>