### PR TITLE
Remove infinity loop in regexp replace and match

### DIFF
--- a/src/runtime/GlobalObjectBuiltinRegExp.cpp
+++ b/src/runtime/GlobalObjectBuiltinRegExp.cpp
@@ -106,7 +106,7 @@ static Value builtinRegExpExec(ExecutionState& state, Value thisValue, size_t ar
             size_t eUTF = str->find(new ASCIIString((const char*)&utfRes), 0);
             if (eUTF >= str->length()) {
                 e = str->length();
-            } else {
+            } else if ((int)eUTF > e || e == (int)str->length()) {
                 e = eUTF;
             }
         }


### PR DESCRIPTION
if we use a regexp that contains Unicode and Global flag
and we match a string that contains more then one of the same letter
then the last index is going to be set wrongfully

for example :

var a = /t/ug;
print("ttt".match(a))

output should be: t,t,t

Signed-off-by: bence gabor kis <kisbg@inf.u-szeged.hu>