### PR TITLE
Fix memory tracing error in AsyncGeneratorObject

### DIFF
--- a/src/runtime/AsyncGeneratorObject.h
+++ b/src/runtime/AsyncGeneratorObject.h
@@ -90,6 +90,10 @@ private:
         GC_set_bit(desc, GC_WORD_OFFSET(AsyncGeneratorObject, m_executionPauser.m_registerFile));
         GC_set_bit(desc, GC_WORD_OFFSET(AsyncGeneratorObject, m_executionPauser.m_byteCodeBlock));
         GC_set_bit(desc, GC_WORD_OFFSET(AsyncGeneratorObject, m_executionPauser.m_resumeValue));
+        GC_set_bit(desc, GC_WORD_OFFSET(AsyncGeneratorObject, m_executionPauser.m_promiseCapability.m_promise));
+        GC_set_bit(desc, GC_WORD_OFFSET(AsyncGeneratorObject, m_executionPauser.m_promiseCapability.m_resolveFunction));
+        GC_set_bit(desc, GC_WORD_OFFSET(AsyncGeneratorObject, m_executionPauser.m_promiseCapability.m_rejectFunction));
+        GC_set_bit(desc, GC_WORD_OFFSET(AsyncGeneratorObject, m_asyncGeneratorQueue));
     }
 
     friend Value asyncGeneratorEnqueue(ExecutionState& state, const Value& generator, AsyncGeneratorObject::AsyncGeneratorEnqueueType type, const Value& value);

--- a/src/runtime/ExecutionPauser.cpp
+++ b/src/runtime/ExecutionPauser.cpp
@@ -48,8 +48,8 @@ void* ExecutionPauser::operator new(size_t size)
         GC_set_bit(desc, GC_WORD_OFFSET(ExecutionPauser, m_byteCodeBlock));
         GC_set_bit(desc, GC_WORD_OFFSET(ExecutionPauser, m_resumeValue));
         GC_set_bit(desc, GC_WORD_OFFSET(ExecutionPauser, m_promiseCapability.m_promise));
-        GC_set_bit(desc, GC_WORD_OFFSET(ExecutionPauser, m_promiseCapability.m_rejectFunction));
         GC_set_bit(desc, GC_WORD_OFFSET(ExecutionPauser, m_promiseCapability.m_resolveFunction));
+        GC_set_bit(desc, GC_WORD_OFFSET(ExecutionPauser, m_promiseCapability.m_rejectFunction));
         descr = GC_make_descriptor(desc, GC_WORD_LEN(ExecutionPauser));
         typeInited = true;
     }

--- a/src/runtime/ExecutionPauser.h
+++ b/src/runtime/ExecutionPauser.h
@@ -67,8 +67,8 @@ public:
         m_byteCodeBlock = nullptr;
         m_resumeValue = SmallValue();
         m_promiseCapability.m_promise = nullptr;
-        m_promiseCapability.m_rejectFunction = nullptr;
         m_promiseCapability.m_resolveFunction = nullptr;
+        m_promiseCapability.m_rejectFunction = nullptr;
     }
 
     enum StartFrom {


### PR DESCRIPTION
* fix to trace ExecutionPauser and AsyncGeneratorQueue vector members correctly

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>