### PR TITLE
Rename ASTContext structure

### DIFF
--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -147,11 +147,10 @@ void ByteCodeBlock::fillLocDataIfNeeded(Context* c)
     // TODO give correct stack limit to parser
     if (m_codeBlock->asInterpretedCodeBlock()->isGlobalScopeCodeBlock()) {
         ProgramNode* nd = esprima::parseProgram(c, m_codeBlock->asInterpretedCodeBlock()->src(), m_codeBlock->script()->isModule(), m_codeBlock->asInterpretedCodeBlock()->isStrict(), m_codeBlock->inWith(), SIZE_MAX, false, false, false);
-        block = ByteCodeGenerator::generateByteCode(c, m_codeBlock->asInterpretedCodeBlock(), nd, nd->scopeContext(), m_isEvalMode, m_isOnGlobal, false, true);
+        block = ByteCodeGenerator::generateByteCode(c, m_codeBlock->asInterpretedCodeBlock(), nd, m_isEvalMode, m_isOnGlobal, false, true);
     } else {
-        ASTFunctionScopeContext* scopeContext = nullptr;
-        auto body = esprima::parseSingleFunction(c, m_codeBlock->asInterpretedCodeBlock(), scopeContext, SIZE_MAX);
-        block = ByteCodeGenerator::generateByteCode(c, m_codeBlock->asInterpretedCodeBlock(), body, scopeContext, m_isEvalMode, m_isOnGlobal, false, true);
+        auto body = esprima::parseSingleFunction(c, m_codeBlock->asInterpretedCodeBlock(), SIZE_MAX);
+        block = ByteCodeGenerator::generateByteCode(c, m_codeBlock->asInterpretedCodeBlock(), body, m_isEvalMode, m_isOnGlobal, false, true);
     }
     m_locData = block->m_locData;
     block->m_locData = nullptr;

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -155,7 +155,7 @@ static const uint8_t byteCodeLengths[] = {
 #undef ITER_BYTE_CODE
 };
 
-ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBlock* codeBlock, Node* ast, ASTFunctionScopeContext* scopeCtx, bool isEvalMode, bool isOnGlobal, bool inWithFromRuntime, bool shouldGenerateLOCData)
+ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBlock* codeBlock, Node* ast, bool isEvalMode, bool isOnGlobal, bool inWithFromRuntime, bool shouldGenerateLOCData)
 {
     ByteCodeBlock* block = new ByteCodeBlock(codeBlock);
     block->m_isEvalMode = isEvalMode;

--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -405,7 +405,7 @@ struct ByteCodeGenerateContext {
 
 class ByteCodeGenerator {
 public:
-    static ByteCodeBlock* generateByteCode(Context* c, InterpretedCodeBlock* codeBlock, Node* ast, ASTFunctionScopeContext* scopeCtx, bool isEvalMode = false, bool isOnGlobal = false, bool inWithFromRuntime = false, bool shouldGenerateLOCData = false);
+    static ByteCodeBlock* generateByteCode(Context* c, InterpretedCodeBlock* codeBlock, Node* ast, bool isEvalMode = false, bool isOnGlobal = false, bool inWithFromRuntime = false, bool shouldGenerateLOCData = false);
 };
 }
 

--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -342,12 +342,12 @@ public:
         return *tempVector;
     }
 
-    ASTFunctionScopeContext* scopeContext()
+    ASTScopeContext* scopeContext()
     {
         // dummy function for scopeContext() of FunctionDeclarationNode
         // this function should never be invoked
         RELEASE_ASSERT_NOT_REACHED();
-        ASTFunctionScopeContext* scopeContext;
+        ASTScopeContext* scopeContext;
         return scopeContext;
     }
 
@@ -528,7 +528,7 @@ public:
         return SyntaxNode(ASTNodeType::Function);
     }
 
-    ALWAYS_INLINE SyntaxNode createProgramNode(StatementContainer* body, ASTFunctionScopeContext* scopeContext, Script::ModuleData* moduleData, NumeralLiteralVector&& numeralLiteralVector)
+    ALWAYS_INLINE SyntaxNode createProgramNode(StatementContainer* body, ASTScopeContext* scopeContext, Script::ModuleData* moduleData, NumeralLiteralVector&& numeralLiteralVector)
     {
         return SyntaxNode(ASTNodeType::Program);
     }
@@ -596,7 +596,7 @@ public:
         return node;
     }
 
-    SyntaxNode convertTaggedTemplateExpressionToCallExpression(SyntaxNode templateLiteral, SyntaxNode taggedTemplateExpressionNode, size_t taggedTemplateExpressionIndex, ASTFunctionScopeContext* scopeContext, AtomicString raw)
+    SyntaxNode convertTaggedTemplateExpressionToCallExpression(SyntaxNode templateLiteral, SyntaxNode taggedTemplateExpressionNode, size_t taggedTemplateExpressionIndex, ASTScopeContext* scopeContext, AtomicString raw)
     {
         return SyntaxNode(CallExpression);
     }
@@ -663,7 +663,7 @@ public:
         return new (m_allocator) FunctionNode(params, body, std::forward<NumeralLiteralVector>(numeralLiteralVector));
     }
 
-    ProgramNode* createProgramNode(StatementContainer* body, ASTFunctionScopeContext* scopeContext, Script::ModuleData* moduleData, NumeralLiteralVector&& numeralLiteralVector)
+    ProgramNode* createProgramNode(StatementContainer* body, ASTScopeContext* scopeContext, Script::ModuleData* moduleData, NumeralLiteralVector&& numeralLiteralVector)
     {
         return new (m_allocator) ProgramNode(body, scopeContext, moduleData, std::forward<NumeralLiteralVector>(numeralLiteralVector));
     }
@@ -754,7 +754,7 @@ public:
         return paramNode;
     }
 
-    Node* convertTaggedTemplateExpressionToCallExpression(Node* templateLiteral, Node* taggedTemplateExpressionNode, size_t taggedTemplateExpressionIndex, ASTFunctionScopeContext* scopeContext, AtomicString raw)
+    Node* convertTaggedTemplateExpressionToCallExpression(Node* templateLiteral, Node* taggedTemplateExpressionNode, size_t taggedTemplateExpressionIndex, ASTScopeContext* scopeContext, AtomicString raw)
     {
         TemplateLiteralNode* templateLiteralNode = (TemplateLiteralNode*)templateLiteral;
         NodeList args;

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -163,9 +163,9 @@ CodeBlock::CodeBlock(Context* ctx, AtomicString name, size_t argc, bool isStrict
 {
 }
 
-void InterpretedCodeBlock::initBlockScopeInformation(ASTFunctionScopeContext* scopeCtx)
+void InterpretedCodeBlock::initBlockScopeInformation(ASTScopeContext* scopeCtx)
 {
-    const ASTBlockScopeContextVector& blockScopes = scopeCtx->m_childBlockScopes;
+    const ASTBlockContextVector& blockScopes = scopeCtx->m_childBlockScopes;
     m_blockInfos.resizeWithUninitializedValues(blockScopes.size());
     for (size_t i = 0; i < blockScopes.size(); i++) {
         BlockInfo* info = new BlockInfo(
@@ -199,7 +199,7 @@ void InterpretedCodeBlock::initBlockScopeInformation(ASTFunctionScopeContext* sc
     }
 }
 
-InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTFunctionScopeContext* scopeCtx, bool isEvalCode, bool isEvalCodeInFunction)
+InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTScopeContext* scopeCtx, bool isEvalCode, bool isEvalCodeInFunction)
     : m_script(script)
     , m_src(src)
     , m_parameterCount(0)
@@ -259,7 +259,7 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     m_allowSuperCall = scopeCtx->m_allowSuperCall;
     m_allowSuperProperty = scopeCtx->m_allowSuperProperty;
 
-    const ASTFunctionScopeContextNameInfoVector& innerIdentifiers = scopeCtx->m_varNames;
+    const ASTScopeContextNameInfoVector& innerIdentifiers = scopeCtx->m_varNames;
     m_identifierInfos.resize(innerIdentifiers.size());
 
     for (size_t i = 0; i < innerIdentifiers.size(); i++) {
@@ -277,7 +277,7 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     initBlockScopeInformation(scopeCtx);
 }
 
-InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTFunctionScopeContext* scopeCtx, InterpretedCodeBlock* parentBlock, bool isEvalCode, bool isEvalCodeInFunction)
+InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTScopeContext* scopeCtx, InterpretedCodeBlock* parentBlock, bool isEvalCode, bool isEvalCodeInFunction)
     : m_script(script)
     , m_src(StringView(src, scopeCtx->m_functionStartLOC.index, scopeCtx->m_bodyEndLOC.index))
     , m_parameterCount(scopeCtx->m_parameterCount)
@@ -351,7 +351,7 @@ InterpretedCodeBlock::InterpretedCodeBlock(Context* ctx, Script* script, StringV
     m_canAllocateVariablesOnStack = true;
     m_hasDescendantUsesNonIndexedVariableStorage = false;
 
-    const ASTFunctionScopeContextNameInfoVector& innerIdentifiers = scopeCtx->m_varNames;
+    const ASTScopeContextNameInfoVector& innerIdentifiers = scopeCtx->m_varNames;
     m_identifierInfos.resize(innerIdentifiers.size());
     for (size_t i = 0; i < innerIdentifiers.size(); i++) {
         IdentifierInfo info;

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -733,7 +733,7 @@ public:
 #endif
 
 #ifndef NDEBUG
-    ASTFunctionScopeContext* scopeContext()
+    ASTScopeContext* scopeContext()
     {
         return m_scopeContext;
     }
@@ -774,12 +774,12 @@ public:
 
 protected:
     // init global codeBlock
-    InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTFunctionScopeContext* scopeCtx, bool isEvalCode, bool isEvalCodeInFunction);
+    InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTScopeContext* scopeCtx, bool isEvalCode, bool isEvalCodeInFunction);
     // init function codeBlock
-    InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTFunctionScopeContext* scopeCtx, InterpretedCodeBlock* parentBlock, bool isEvalCode, bool isEvalCodeInFunction);
+    InterpretedCodeBlock(Context* ctx, Script* script, StringView src, ASTScopeContext* scopeCtx, InterpretedCodeBlock* parentBlock, bool isEvalCode, bool isEvalCodeInFunction);
 
     void computeBlockVariables(LexicalBlockIndex currentBlockIndex, size_t currentStackAllocatedVariableIndex, size_t& maxStackAllocatedVariableDepth);
-    void initBlockScopeInformation(ASTFunctionScopeContext* scopeCtx);
+    void initBlockScopeInformation(ASTScopeContext* scopeCtx);
 
     // You can use this function on ScriptParser only
     std::tuple<bool, size_t, size_t> findNameWithinBlock(LexicalBlockIndex blockIndex, AtomicString name)
@@ -852,7 +852,7 @@ protected:
     ExtendedNodeLOC m_bodyEndLOC;
 #endif
 #ifndef NDEBUG
-    ASTFunctionScopeContext* m_scopeContext;
+    ASTScopeContext* m_scopeContext;
 #endif
 };
 }

--- a/src/parser/ScriptParser.h
+++ b/src/parser/ScriptParser.h
@@ -26,7 +26,7 @@
 
 namespace Escargot {
 
-struct ASTFunctionScopeContext;
+struct ASTScopeContext;
 class CodeBlock;
 class InterpretedCodeBlock;
 class Context;
@@ -68,7 +68,7 @@ public:
 
 private:
     InterpretedCodeBlock* generateCodeBlockTreeFromAST(Context* ctx, StringView source, Script* script, ProgramNode* program, bool isEvalCode, bool isEvalCodeInFunction);
-    InterpretedCodeBlock* generateCodeBlockTreeFromASTWalker(Context* ctx, StringView source, Script* script, ASTFunctionScopeContext* scopeCtx, InterpretedCodeBlock* parentCodeBlock, bool isEvalCode, bool isEvalCodeInFunction);
+    InterpretedCodeBlock* generateCodeBlockTreeFromASTWalker(Context* ctx, StringView source, Script* script, ASTScopeContext* scopeCtx, InterpretedCodeBlock* parentCodeBlock, bool isEvalCode, bool isEvalCodeInFunction);
     void generateCodeBlockTreeFromASTWalkerPostProcess(InterpretedCodeBlock* cb);
 #ifndef NDEBUG
     void dumpCodeBlockTree(InterpretedCodeBlock* topCodeBlock);

--- a/src/parser/ast/ProgramNode.h
+++ b/src/parser/ast/ProgramNode.h
@@ -29,7 +29,7 @@ namespace Escargot {
 
 class ProgramNode : public StatementNode {
 public:
-    ProgramNode(StatementContainer* body, ASTFunctionScopeContext* scopeContext, Script::ModuleData* moduleData, NumeralLiteralVector&& numeralLiteralVector)
+    ProgramNode(StatementContainer* body, ASTScopeContext* scopeContext, Script::ModuleData* moduleData, NumeralLiteralVector&& numeralLiteralVector)
         : StatementNode()
         , m_container(body)
         , m_scopeContext(scopeContext)
@@ -39,7 +39,7 @@ public:
     }
 
     virtual ASTNodeType type() override { return ASTNodeType::Program; }
-    ASTFunctionScopeContext* scopeContext() { return m_scopeContext; }
+    ASTScopeContext* scopeContext() { return m_scopeContext; }
     Script::ModuleData* moduleData() { return m_moduleData; }
     NumeralLiteralVector& numeralLiteralVector() { return m_numeralLiteralVector; }
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
@@ -73,7 +73,7 @@ public:
 
 private:
     StatementContainer* m_container;
-    ASTFunctionScopeContext* m_scopeContext;
+    ASTScopeContext* m_scopeContext;
     Script::ModuleData* m_moduleData;
     NumeralLiteralVector m_numeralLiteralVector;
 };

--- a/src/parser/esprima_cpp/esprima.h
+++ b/src/parser/esprima_cpp/esprima.h
@@ -62,7 +62,7 @@ struct Error : public gc {
 #define ESPRIMA_RECURSIVE_LIMIT 1024
 
 ProgramNode* parseProgram(::Escargot::Context* ctx, StringView source, bool isModule, bool strictFromOutside, bool inWith, size_t stackRemain, bool allowSuperCallFromOutside, bool allowSuperPropertyFromOutside, bool allowNewTargetFromOutside);
-FunctionNode* parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock* codeBlock, ASTFunctionScopeContext*& scopeContext, size_t stackRemain);
+FunctionNode* parseSingleFunction(::Escargot::Context* ctx, InterpretedCodeBlock* codeBlock, size_t stackRemain);
 }
 }
 

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -32,7 +32,7 @@ typedef std::unordered_set<String*, std::hash<String*>, std::equal_to<String*>, 
 class AtomicString : public gc {
     friend class StaticStrings;
     friend class ObjectStructurePropertyName;
-    friend class ASTBlockScopeContextNameInfo;
+    friend class ASTBlockContextNameInfo;
     friend class AtomicStringRef;
     inline explicit AtomicString(String* str)
     {


### PR DESCRIPTION
* rename to ASTScopeContext and ASTBlockContext
* remove redundant ASTScopeContext parameter

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>