### PR TITLE
Fix NativeCodeBlock to directly store the native function point

### DIFF
--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -1117,6 +1117,10 @@ public:
     // in constructor call, function must return newly created object && thisValue is always undefined
     typedef ValueRef* (*NativeFunctionPointer)(ExecutionStateRef* state, ValueRef* thisValue, size_t argc, ValueRef** argv, bool isConstructCall);
 
+    enum BuiltinFunctionSlot : size_t {
+        PublicFunctionIndex = 0,
+    };
+
     struct NativeFunctionInfo {
         bool m_isStrict;
         bool m_isConstructor;

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -34,7 +34,6 @@ void* NativeCodeBlock::operator new(size_t size)
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(NativeCodeBlock)] = { 0 };
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(NativeCodeBlock, m_context));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(NativeCodeBlock, m_nativeFunctionData));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(NativeCodeBlock));
         typeInited = true;
     }

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -61,16 +61,6 @@ struct NativeFunctionInfo {
     }
 };
 
-class CallNativeFunctionData : public gc {
-public:
-    CallNativeFunctionData(NativeFunctionPointer fn)
-        : m_fn(fn)
-    {
-    }
-
-    NativeFunctionPointer m_fn;
-};
-
 class NativeCodeBlock;
 class InterpretedCodeBlock;
 
@@ -136,17 +126,7 @@ public:
         , m_isStrict(info.m_isStrict)
         , m_functionLength(info.m_argumentCount)
         , m_functionName(info.m_name)
-        , m_nativeFunctionData((CallNativeFunctionData*)(new (PointerFreeGC) CallNativeFunctionData(info.m_nativeFunction)))
-    {
-    }
-
-    NativeCodeBlock(Context* ctx, const NativeFunctionInfo& info, CallNativeFunctionData* nativeData)
-        : CodeBlock(ctx)
-        , m_isNativeConstructor(info.m_isConstructor)
-        , m_isStrict(info.m_isStrict)
-        , m_functionLength(info.m_argumentCount)
-        , m_functionName(info.m_name)
-        , m_nativeFunctionData(nativeData)
+        , m_nativeFunction(info.m_nativeFunction)
     {
     }
 
@@ -175,9 +155,9 @@ public:
         return m_isStrict;
     }
 
-    CallNativeFunctionData* nativeFunctionData()
+    NativeFunctionPointer nativeFunction()
     {
-        return m_nativeFunctionData;
+        return m_nativeFunction;
     }
 
 private:
@@ -185,7 +165,7 @@ private:
     bool m_isStrict : 1;
     uint16_t m_functionLength;
     AtomicString m_functionName;
-    CallNativeFunctionData* m_nativeFunctionData;
+    NativeFunctionPointer m_nativeFunction;
 };
 
 struct InterpretedCodeBlockRareData : public gc {

--- a/src/runtime/ExtendedNativeFunctionObject.h
+++ b/src/runtime/ExtendedNativeFunctionObject.h
@@ -26,11 +26,6 @@ namespace Escargot {
 
 class ExtendedNativeFunctionObject : public NativeFunctionObject {
 public:
-    ExtendedNativeFunctionObject(ExecutionState& state, NativeFunctionInfo info)
-        : NativeFunctionObject(state, info)
-    {
-    }
-
     virtual bool isExtendedNativeFunctionObject() const
     {
         return true;
@@ -81,6 +76,22 @@ protected:
         {
         }
     };
+
+    ExtendedNativeFunctionObject(ExecutionState& state, NativeFunctionInfo info)
+        : NativeFunctionObject(state, info)
+    {
+    }
+
+    ExtendedNativeFunctionObject(ExecutionState& state, NativeFunctionInfo info, NativeFunctionObject::ForBuiltinConstructor flag)
+        : NativeFunctionObject(state, info, flag)
+    {
+    }
+
+    ExtendedNativeFunctionObject(Context* context, ObjectStructure* structure, ObjectPropertyValueVector&& values, const NativeFunctionInfo& info)
+        : NativeFunctionObject(context, structure, std::forward<ObjectPropertyValueVector>(values), info)
+    {
+    }
+
 #ifndef NDEBUG
     virtual size_t slotCount() const = 0;
 #endif
@@ -92,6 +103,23 @@ class ExtendedNativeFunctionObjectImpl : public ExtendedNativeFunctionObject {
 public:
     ExtendedNativeFunctionObjectImpl(ExecutionState& state, NativeFunctionInfo info)
         : ExtendedNativeFunctionObject(state, info)
+#ifndef NDEBUG
+        , m_slotCount(slotNumber)
+#endif
+    {
+    }
+
+    ExtendedNativeFunctionObjectImpl(ExecutionState& state, NativeFunctionInfo info, NativeFunctionObject::ForBuiltinConstructor flag)
+        : ExtendedNativeFunctionObject(state, info, flag)
+#ifndef NDEBUG
+        , m_slotCount(slotNumber)
+#endif
+    {
+    }
+
+    // used only for FunctionTemplate instantiation
+    ExtendedNativeFunctionObjectImpl(Context* context, ObjectStructure* structure, ObjectPropertyValueVector&& values, const NativeFunctionInfo& info)
+        : ExtendedNativeFunctionObject(context, structure, std::forward<ObjectPropertyValueVector>(values), info)
 #ifndef NDEBUG
         , m_slotCount(slotNumber)
 #endif

--- a/src/runtime/FunctionTemplate.h
+++ b/src/runtime/FunctionTemplate.h
@@ -27,8 +27,14 @@
 
 namespace Escargot {
 
+class CallTemplateFunctionData;
+
 class FunctionTemplate : public Template {
 public:
+    enum BuiltinFunctionSlot : size_t {
+        CallTemplateFunctionDataIndex = 0,
+    };
+
     FunctionTemplate(AtomicString name, size_t argumentCount, bool isStrict, bool isConstructor,
                      NativeFunctionPointer fn, Optional<ObjectTemplate*> instanceTemplate);
 
@@ -74,7 +80,7 @@ protected:
     size_t m_argumentCount;
     bool m_isStrict;
     bool m_isConstructor;
-    CallNativeFunctionData* m_nativeFunctionData;
+    CallTemplateFunctionData* m_nativeFunctionData;
     ObjectTemplate* m_prototypeTemplate;
     Optional<ObjectTemplate*> m_instanceTemplate;
     Optional<FunctionTemplate*> m_parent;

--- a/src/runtime/NativeFunctionObject.h
+++ b/src/runtime/NativeFunctionObject.h
@@ -25,23 +25,17 @@
 namespace Escargot {
 
 class NativeFunctionObject : public FunctionObject {
-    friend class FunctionTemplate;
-
 public:
     NativeFunctionObject(ExecutionState& state, NativeFunctionInfo info);
-    NativeFunctionObject(ExecutionState& state, NativeFunctionInfo info, CallNativeFunctionData* nativeData);
 
     enum ForGlobalBuiltin { __ForGlobalBuiltin__ };
     NativeFunctionObject(ExecutionState& state, NativeFunctionInfo info, ForGlobalBuiltin);
 
     enum ForBuiltinConstructor { __ForBuiltinConstructor__ };
     NativeFunctionObject(ExecutionState& state, NativeFunctionInfo info, ForBuiltinConstructor);
-    NativeFunctionObject(ExecutionState& state, NativeFunctionInfo info, CallNativeFunctionData* nativeData, ForBuiltinConstructor);
 
     enum ForBuiltinProxyConstructor { __ForBuiltinProxyConstructor__ };
     NativeFunctionObject(ExecutionState& state, NativeFunctionInfo info, ForBuiltinProxyConstructor);
-
-    NativeFunctionObject(Context* context, ObjectStructure* structure, ObjectPropertyValueVector&& values, NativeFunctionInfo info, CallNativeFunctionData* nativeData);
 
     virtual bool isNativeFunctionObject() const override
     {
@@ -60,6 +54,8 @@ public:
     }
 
 protected:
+    NativeFunctionObject(Context* context, ObjectStructure* structure, ObjectPropertyValueVector&& values, const NativeFunctionInfo& info);
+
     template <bool isConstruct>
     ALWAYS_INLINE Value processNativeFunctionCall(ExecutionState& state, const Value& receiver, const size_t argc, Value* argv, Optional<Object*> newTarget);
 };


### PR DESCRIPTION
* remove CallNativeFunctionData
* FunctionTemplate and native APIs allocate ExtendedNativeFunctionObject in itself

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>