### PR TITLE
Each InterpretedCodeBlock has its children in a vector

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -1610,10 +1610,11 @@ static void markEvalToCodeblock(InterpretedCodeBlock* cb)
     cb->setHasEval();
     cb->computeVariables();
 
-    InterpretedCodeBlock* child = cb->firstChild();
-    while (child) {
-        markEvalToCodeblock(child);
-        child = child->nextSibling();
+    if (cb->hasChildren()) {
+        InterpretedCodeBlockVector& childrenVector = cb->children();
+        for (size_t i = 0; i < childrenVector.size(); i++) {
+            markEvalToCodeblock(childrenVector[i]);
+        }
     }
 }
 

--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -125,18 +125,16 @@ int getValidValueInInterpretedCodeBlock(void* ptr, GC_mark_custom_result* arr)
     arr[1].to = (GC_word*)current->m_script;
     arr[2].from = (GC_word*)&current->m_byteCodeBlock;
     arr[2].to = (GC_word*)current->m_byteCodeBlock;
-    arr[3].from = (GC_word*)&current->m_parentCodeBlock;
-    arr[3].to = (GC_word*)current->m_parentCodeBlock;
-    arr[4].from = (GC_word*)&current->m_firstChild;
-    arr[4].to = (GC_word*)current->m_firstChild;
-    arr[5].from = (GC_word*)&current->m_nextSibling;
-    arr[5].to = (GC_word*)current->m_nextSibling;
-    arr[6].from = (GC_word*)&current->m_parameterNames;
-    arr[6].to = (GC_word*)current->m_parameterNames.data();
-    arr[7].from = (GC_word*)&current->m_identifierInfos;
-    arr[7].to = (GC_word*)current->m_identifierInfos.data();
-    arr[8].from = (GC_word*)&current->m_blockInfos;
-    arr[8].to = (GC_word*)current->m_blockInfos.data();
+    arr[3].from = (GC_word*)&current->m_parent;
+    arr[3].to = (GC_word*)current->m_parent;
+    arr[4].from = (GC_word*)&current->m_children;
+    arr[4].to = (GC_word*)current->m_children;
+    arr[5].from = (GC_word*)&current->m_parameterNames;
+    arr[5].to = (GC_word*)current->m_parameterNames.data();
+    arr[6].from = (GC_word*)&current->m_identifierInfos;
+    arr[6].to = (GC_word*)current->m_identifierInfos.data();
+    arr[7].from = (GC_word*)&current->m_blockInfos;
+    arr[7].to = (GC_word*)current->m_blockInfos.data();
     return 0;
 }
 
@@ -149,20 +147,18 @@ int getValidValueInInterpretedCodeBlockWithRareData(void* ptr, GC_mark_custom_re
     arr[1].to = (GC_word*)current->m_script;
     arr[2].from = (GC_word*)&current->m_byteCodeBlock;
     arr[2].to = (GC_word*)current->m_byteCodeBlock;
-    arr[3].from = (GC_word*)&current->m_parentCodeBlock;
-    arr[3].to = (GC_word*)current->m_parentCodeBlock;
-    arr[4].from = (GC_word*)&current->m_firstChild;
-    arr[4].to = (GC_word*)current->m_firstChild;
-    arr[5].from = (GC_word*)&current->m_nextSibling;
-    arr[5].to = (GC_word*)current->m_nextSibling;
-    arr[6].from = (GC_word*)&current->m_parameterNames;
-    arr[6].to = (GC_word*)current->m_parameterNames.data();
-    arr[7].from = (GC_word*)&current->m_identifierInfos;
-    arr[7].to = (GC_word*)current->m_identifierInfos.data();
-    arr[8].from = (GC_word*)&current->m_blockInfos;
-    arr[8].to = (GC_word*)current->m_blockInfos.data();
-    arr[9].from = (GC_word*)&current->m_rareData;
-    arr[9].to = (GC_word*)current->m_rareData;
+    arr[3].from = (GC_word*)&current->m_parent;
+    arr[3].to = (GC_word*)current->m_parent;
+    arr[4].from = (GC_word*)&current->m_children;
+    arr[4].to = (GC_word*)current->m_children;
+    arr[5].from = (GC_word*)&current->m_parameterNames;
+    arr[5].to = (GC_word*)current->m_parameterNames.data();
+    arr[6].from = (GC_word*)&current->m_identifierInfos;
+    arr[6].to = (GC_word*)current->m_identifierInfos.data();
+    arr[7].from = (GC_word*)&current->m_blockInfos;
+    arr[7].to = (GC_word*)current->m_blockInfos.data();
+    arr[8].from = (GC_word*)&current->m_rareData;
+    arr[8].to = (GC_word*)current->m_rareData;
     return 0;
 }
 
@@ -224,12 +220,12 @@ void initializeCustomAllocators()
 #endif
 
     s_gcKinds[HeapObjectKind::InterpretedCodeBlockKind] = GC_new_kind(GC_new_free_list(),
-                                                                      GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 9>), 0),
+                                                                      GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 8>), 0),
                                                                       FALSE,
                                                                       TRUE);
 
     s_gcKinds[HeapObjectKind::InterpretedCodeBlockWithRareDataKind] = GC_new_kind(GC_new_free_list(),
-                                                                                  GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlockWithRareData, 10>), 0),
+                                                                                  GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlockWithRareData, 9>), 0),
                                                                                   FALSE,
                                                                                   TRUE);
 

--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -219,8 +219,13 @@ ExtendedNodeLOC ByteCodeBlock::computeNodeLOC(StringView src, ExtendedNodeLOC so
 void ByteCodeBlock::initFunctionDeclarationWithinBlock(ByteCodeGenerateContext* context, InterpretedCodeBlock::BlockInfo* bi, Node* node)
 {
     InterpretedCodeBlock* codeBlock = context->m_codeBlock;
-    InterpretedCodeBlock* child = codeBlock->firstChild();
-    while (child) {
+    if (!codeBlock->hasChildren()) {
+        return;
+    }
+
+    InterpretedCodeBlockVector& childrenVector = codeBlock->children();
+    for (size_t i = 0; i < childrenVector.size(); i++) {
+        InterpretedCodeBlock* child = childrenVector[i];
         if (child->isFunctionDeclaration() && child->lexicalBlockIndexFunctionLocatedIn() == context->m_lexicalBlockIndex) {
             IdentifierNode* id = new (alloca(sizeof(IdentifierNode))) IdentifierNode(child->functionName());
             id->m_loc = node->m_loc;
@@ -251,8 +256,6 @@ void ByteCodeBlock::initFunctionDeclarationWithinBlock(ByteCodeGenerateContext* 
 
             context->giveUpRegister(); // give up useless register
         }
-
-        child = child->nextSibling();
     }
 }
 

--- a/src/parser/ScriptParser.h
+++ b/src/parser/ScriptParser.h
@@ -75,7 +75,7 @@ private:
 #endif
 
 #ifdef ESCARGOT_DEBUGGER
-    void recursivelyGenerateByteCode(InterpretedCodeBlock* topCodeBlock);
+    void recursivelyGenerateChildrenByteCode(InterpretedCodeBlock* topCodeBlock);
     InitializeScriptResult initializeScriptWithDebugger(StringView scriptSource, String* fileName, bool isModule, InterpretedCodeBlock* parentCodeBlock, bool strictFromOutside, bool isEvalCodeInFunction, bool isEvalMode, bool inWithOperation, bool allowSuperCall, bool allowSuperProperty, bool allowNewTarget);
 #endif /* ESCARGOT_DEBUGGER */
 

--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -255,6 +255,17 @@ struct ASTScopeContext {
         return m_nextSibling;
     }
 
+    size_t childCount()
+    {
+        size_t count = 0;
+        ASTScopeContext *child = m_firstChild;
+        while (child) {
+            count++;
+            child = child->nextSibling();
+        }
+        return count;
+    }
+
     size_t findVarName(const AtomicString &name)
     {
         if (UNLIKELY(hasVarNamesMap())) {

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -30,7 +30,7 @@ class ByteCodeBlock;
 class InterpretedCodeBlock;
 struct ByteCodeGenerateContext;
 
-enum ASTNodeType {
+enum ASTNodeType : uint16_t {
     /* Note: These 4 types must be in this order */
     Program,
     ArrowFunctionExpression,

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -162,7 +162,7 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
     String* scriptSource = src.finalize(&state);
 
     Script* script = parser.initializeScript(StringView(scriptSource, 0, scriptSource->length()), new ASCIIString("Function Constructor input"), false, nullptr, false, false, false, false, SIZE_MAX, false, allowSuperCall, false, true).scriptThrowsExceptionIfParseError(state);
-    InterpretedCodeBlock* cb = script->topCodeBlock()->firstChild();
+    InterpretedCodeBlock* cb = script->topCodeBlock()->childBlockAt(0);
     LexicalEnvironment* globalEnvironment = new LexicalEnvironment(new GlobalEnvironmentRecord(state, script->topCodeBlock(), state.context()->globalObject(), state.context()->globalDeclarativeRecord(), state.context()->globalDeclarativeStorage()), nullptr);
 
     FunctionObject::FunctionSource fs;

--- a/src/util/TightVector.h
+++ b/src/util/TightVector.h
@@ -246,6 +246,20 @@ public:
         }
     }
 
+    void* operator new(size_t size)
+    {
+        static bool typeInited = false;
+        static GC_descr descr;
+        if (!typeInited) {
+            GC_word desc[GC_BITMAP_SIZE(TightVector)] = { 0 };
+            GC_set_bit(desc, GC_WORD_OFFSET(TightVector, m_buffer));
+            descr = GC_make_descriptor(desc, GC_WORD_LEN(TightVector));
+            typeInited = true;
+        }
+        return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
+    }
+    void* operator new[](size_t size) = delete;
+
 protected:
     T* m_buffer;
     size_t m_size;


### PR DESCRIPTION
* reduce the whole size of InterpretedCodeBlock instances
* iterate fastly on children

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>