### PR TITLE
Reduce memory allocation during bytecode generation

### DIFF
--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -1601,7 +1601,7 @@ public:
         ScriptRef* fetchScriptThrowsExceptionIfParseError(ExecutionStateRef* state);
     };
 
-    InitializeScriptResult initializeScript(StringRef* scriptSource, StringRef* srcName, bool isModule = false);
+    InitializeScriptResult initializeScript(StringRef* source, StringRef* srcName, bool isModule = false);
 };
 
 class ESCARGOT_EXPORT ScriptRef {

--- a/src/codecache/CodeCache.cpp
+++ b/src/codecache/CodeCache.cpp
@@ -318,7 +318,7 @@ InterpretedCodeBlock* CodeCache::loadCodeBlockTree(Context* context, Script* scr
     tempCodeBlockMap.clear();
     m_reader->clear();
 
-    ASSERT(topCodeBlock->isGlobalScopeCodeBlock());
+    ASSERT(topCodeBlock->isGlobalCodeBlock());
     // return topCodeBlock
     return topCodeBlock;
 }

--- a/src/codecache/CodeCacheReaderWriter.cpp
+++ b/src/codecache/CodeCacheReaderWriter.cpp
@@ -267,9 +267,7 @@ void CodeCacheWriter::storeByteCodeBlock(ByteCodeBlock* block)
 
     size_t size;
 
-    m_buffer.ensureSize(4 * sizeof(bool) + sizeof(uint16_t));
-    m_buffer.put(block->m_isEvalMode);
-    m_buffer.put(block->m_isOnGlobal);
+    m_buffer.ensureSize(2 * sizeof(bool) + sizeof(uint16_t));
     m_buffer.put(block->m_shouldClearStack);
     m_buffer.put(block->m_isOwnerMayFreed);
     m_buffer.put((uint16_t)block->m_requiredRegisterFileSizeInValueSize);
@@ -715,8 +713,6 @@ ByteCodeBlock* CodeCacheReader::loadByteCodeBlock(Context* context, Script* scri
     size_t size;
     ByteCodeBlock* block = new ByteCodeBlock(script->topCodeBlock());
 
-    block->m_isEvalMode = m_buffer.get<bool>();
-    block->m_isOnGlobal = m_buffer.get<bool>();
     block->m_shouldClearStack = m_buffer.get<bool>();
     block->m_isOwnerMayFreed = m_buffer.get<bool>();
     block->m_requiredRegisterFileSizeInValueSize = m_buffer.get<uint16_t>();

--- a/src/debugger/Debugger.h
+++ b/src/debugger/Debugger.h
@@ -171,19 +171,9 @@ public:
         return m_enabled;
     }
 
-    bool computeLocation(void)
-    {
-        return m_computeLocation;
-    }
-
     bool pendingWait(void)
     {
         return m_pendingWait;
-    }
-
-    void setComputeLocation(bool value)
-    {
-        m_computeLocation = value;
     }
 
     inline void processDisabledBreakpoint(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state)
@@ -210,7 +200,7 @@ public:
 
     void sendType(uint8_t type);
     void sendSubtype(uint8_t type, uint8_t subType);
-    void sendString(uint8_t type, StringView* string);
+    void sendString(uint8_t type, String* string);
     void sendPointer(uint8_t type, const void* ptr);
     void sendFunctionInfo(InterpretedCodeBlock* codeBlock);
     void sendBreakpointLocations(std::vector<Debugger::BreakpointLocation>& locations);
@@ -225,7 +215,6 @@ protected:
     Debugger()
         : m_enabled(false)
         , m_delay(ESCARGOT_DEBUGGER_MESSAGE_PROCESS_DELAY)
-        , m_computeLocation(false)
         , m_pendingWait(false)
         , m_waitForResume(false)
         , m_stopState(ESCARGOT_DEBUGGER_ALWAYS_STOP)
@@ -286,7 +275,6 @@ private:
     bool processIncomingMessages(ExecutionState* state, ByteCodeBlock* byteCodeBlock);
 
     uint8_t m_delay;
-    bool m_computeLocation : 1;
     bool m_pendingWait : 1;
     bool m_waitForResume : 1;
     ExecutionState* m_stopState;

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -435,7 +435,7 @@ void InterpretedCodeBlock::captureArguments()
 {
     AtomicString arguments = m_context->staticStrings().arguments;
     ASSERT(!hasParameterName(arguments));
-    ASSERT(!isGlobalScopeCodeBlock() && !isArrowFunctionExpression());
+    ASSERT(!isGlobalCodeBlock() && !isArrowFunctionExpression());
 
     if (m_usesArgumentsObject) {
         return;
@@ -613,8 +613,8 @@ void InterpretedCodeBlock::computeVariables()
         }
     }
 
-    if (canUseIndexedVariableStorage() && !isGlobalScopeCodeBlock()) {
-        size_t s = isGlobalScopeCodeBlock() ? 1 : 2;
+    if (canUseIndexedVariableStorage() && !isGlobalCodeBlock()) {
+        size_t s = isGlobalCodeBlock() ? 1 : 2;
         size_t h = 0;
 
         for (size_t i = 0; i < m_identifierInfos.size(); i++) {
@@ -654,7 +654,7 @@ void InterpretedCodeBlock::computeVariables()
 
         m_identifierOnStackCount = s;
         m_identifierOnHeapCount = h;
-    } else if (isGlobalScopeCodeBlock() && script()->isModule()) {
+    } else if (isGlobalCodeBlock() && script()->isModule()) {
         size_t s = 1;
         size_t h = 0;
         for (size_t i = 0; i < m_identifierInfos.size(); i++) {
@@ -678,7 +678,7 @@ void InterpretedCodeBlock::computeVariables()
                 }
             }
         } else {
-            ASSERT(isGlobalScopeCodeBlock());
+            ASSERT(isGlobalCodeBlock());
 
             size_t currentStackAllocatedVariableIndex = 0;
             size_t maxStackAllocatedVariableDepth = 0;
@@ -713,7 +713,7 @@ void InterpretedCodeBlock::computeVariables()
             }
         }
 
-        size_t s = isGlobalScopeCodeBlock() ? 1 : 2;
+        size_t s = isGlobalCodeBlock() ? 1 : 2;
         size_t h = 0;
         for (size_t i = 0; i < m_identifierInfos.size(); i++) {
             m_identifierInfos[i].m_needToAllocateOnStack = false;
@@ -746,7 +746,7 @@ void InterpretedCodeBlock::computeVariables()
                 }
             }
         } else {
-            ASSERT(isGlobalScopeCodeBlock());
+            ASSERT(isGlobalCodeBlock());
 
             size_t currentStackAllocatedVariableIndex = 0;
             size_t maxStackAllocatedVariableDepth = 0;
@@ -754,7 +754,7 @@ void InterpretedCodeBlock::computeVariables()
             m_lexicalBlockStackAllocatedIdentifierMaximumDepth = maxStackAllocatedVariableDepth;
         }
 
-        if (isGlobalScopeCodeBlock()) {
+        if (isGlobalCodeBlock()) {
             InterpretedCodeBlock::BlockInfo* bi = nullptr;
             for (size_t i = 0; i < m_blockInfos.size(); i++) {
                 if (m_blockInfos[i]->m_blockIndex == 0) {
@@ -828,7 +828,7 @@ InterpretedCodeBlock::IndexedIdentifierInfo InterpretedCodeBlock::indexedIdentif
                     info.m_type = IndexedIdentifierInfo::DeclarationType::LexicallyDeclared;
                     info.m_blockIndex = bi->m_blockIndex;
 
-                    if (blk->isGlobalScopeCodeBlock() && !blk->script()->isModule() && bi->m_parentBlockIndex == LEXICAL_BLOCK_INDEX_MAX) {
+                    if (blk->isGlobalCodeBlock() && !blk->script()->isModule() && bi->m_parentBlockIndex == LEXICAL_BLOCK_INDEX_MAX) {
                         info.m_isGlobalLexicalVariable = true;
                     } else {
                         info.m_isGlobalLexicalVariable = false;
@@ -848,7 +848,7 @@ InterpretedCodeBlock::IndexedIdentifierInfo InterpretedCodeBlock::indexedIdentif
             blockIndex = bi->m_parentBlockIndex;
         }
 
-        if (blk->isGlobalScopeCodeBlock() && !blk->script()->isModule()) {
+        if (blk->isGlobalCodeBlock() && !blk->script()->isModule()) {
             break;
         }
 

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -653,9 +653,16 @@ public:
 
     bool needsToLoadThisBindingFromEnvironment();
 
-    bool isGlobalScopeCodeBlock() const
+    bool isGlobalCodeBlock() const
     {
         return m_parent == nullptr;
+    }
+
+    bool isGlobalScope() const
+    {
+        // For eval code which is not called inside a function
+        // it is handled in the global scope
+        return m_isEvalCode ? !m_isEvalCodeInFunction : isGlobalCodeBlock();
     }
 
     bool hasAncestorUsesNonIndexedVariableStorage()

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -35,6 +35,22 @@
 
 namespace Escargot {
 
+void* Script::operator new(size_t size)
+{
+    static bool typeInited = false;
+    static GC_descr descr;
+    if (!typeInited) {
+        GC_word obj_bitmap[GC_BITMAP_SIZE(Script)] = { 0 };
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(Script, m_srcName));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(Script, m_sourceCode));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(Script, m_topCodeBlock));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(Script, m_moduleData));
+        descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(Script));
+        typeInited = true;
+    }
+    return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
+}
+
 bool Script::isExecuted()
 {
     if (isModule()) {

--- a/src/parser/Script.h
+++ b/src/parser/Script.h
@@ -119,6 +119,9 @@ public:
         }
     };
 
+    void* operator new(size_t size);
+    void* operator new[](size_t size) = delete;
+
     Value execute(ExecutionState& state, bool isExecuteOnEvalFunction = false, bool inStrictMode = false);
     String* srcName()
     {

--- a/src/parser/ScriptParser.h
+++ b/src/parser/ScriptParser.h
@@ -58,10 +58,10 @@ public:
         }
     };
 
-    InitializeScriptResult initializeScript(StringView scriptSource, String* srcName, bool isModule, InterpretedCodeBlock* parentCodeBlock, bool strictFromOutside, bool isEvalCodeInFunction, bool isEvalMode, bool inWithOperation, size_t stackSizeRemain, bool needByteCodeGeneration, bool allowSuperCall, bool allowSuperProperty, bool allowNewTarget);
-    InitializeScriptResult initializeScript(String* scriptSource, String* srcName, bool isModule, bool strictFromOutside = false, bool isRunningEvalOnFunction = false, bool isEvalMode = false, size_t stackSizeRemain = SIZE_MAX)
+    InitializeScriptResult initializeScript(String* source, String* srcName, InterpretedCodeBlock* parentCodeBlock, bool isModule, bool isEvalMode = false, bool isEvalCodeInFunction = false, bool inWithOperation = false, bool strictFromOutside = false, bool allowSuperCall = false, bool allowSuperProperty = false, bool allowNewTarget = false, bool needByteCodeGeneration = true, size_t stackSizeRemain = SIZE_MAX);
+    InitializeScriptResult initializeScript(String* source, String* srcName, bool isModule)
     {
-        return initializeScript(StringView(scriptSource, 0, scriptSource->length()), srcName, isModule, nullptr, strictFromOutside, isRunningEvalOnFunction, isEvalMode, false, stackSizeRemain, true, false, false, false);
+        return initializeScript(source, srcName, nullptr, isModule);
     }
 
     void generateFunctionByteCode(ExecutionState& state, InterpretedCodeBlock* codeBlock, size_t stackSizeRemain);
@@ -76,7 +76,7 @@ private:
 
 #ifdef ESCARGOT_DEBUGGER
     void recursivelyGenerateChildrenByteCode(InterpretedCodeBlock* topCodeBlock);
-    InitializeScriptResult initializeScriptWithDebugger(StringView scriptSource, String* srcName, bool isModule, InterpretedCodeBlock* parentCodeBlock, bool strictFromOutside, bool isEvalCodeInFunction, bool isEvalMode, bool inWithOperation, bool allowSuperCall, bool allowSuperProperty, bool allowNewTarget);
+    InitializeScriptResult initializeScriptWithDebugger(String* source, String* srcName, InterpretedCodeBlock* parentCodeBlock, bool isModule, bool isEvalMode, bool isEvalCodeInFunction, bool inWithOperation, bool strictFromOutside, bool allowSuperCall, bool allowSuperProperty, bool allowNewTarget);
 #endif /* ESCARGOT_DEBUGGER */
 
     Context* m_context;

--- a/src/parser/ast/ProgramNode.h
+++ b/src/parser/ast/ProgramNode.h
@@ -54,7 +54,7 @@ public:
 
 #ifdef ESCARGOT_DEBUGGER
         if (context->m_breakpointContext->m_breakpointLocations.size() == 0) {
-            if (codeBlock->m_isEvalMode) {
+            if (context->m_isEvalCode) {
                 context->insertBreakpointAt(1, this);
             } else {
                 insertBreakpoint(context);

--- a/src/parser/ast/UnaryExpressionTypeOfNode.h
+++ b/src/parser/ast/UnaryExpressionTypeOfNode.h
@@ -46,7 +46,7 @@ public:
                 }
             }
             if (nameCase) {
-                if (name.string()->equals("arguments") && !context->isGlobalScope()) {
+                if (name.string()->equals("arguments") && !context->m_isGlobalScope) {
                     size_t srcIndex = m_argument->getRegister(codeBlock, context);
                     m_argument->generateExpressionByteCode(codeBlock, context, srcIndex);
                     context->giveUpRegister();

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -161,7 +161,7 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
     ScriptParser parser(state.context());
     String* scriptSource = src.finalize(&state);
 
-    Script* script = parser.initializeScript(StringView(scriptSource, 0, scriptSource->length()), state.context()->staticStrings().lazyFunctionInput().string(), false, nullptr, false, false, false, false, SIZE_MAX, false, allowSuperCall, false, true).scriptThrowsExceptionIfParseError(state);
+    Script* script = parser.initializeScript(scriptSource, state.context()->staticStrings().lazyFunctionInput().string(), nullptr, false, false, false, false, false, allowSuperCall, false, true, false).scriptThrowsExceptionIfParseError(state);
     InterpretedCodeBlock* cb = script->topCodeBlock()->childBlockAt(0);
     LexicalEnvironment* globalEnvironment = new LexicalEnvironment(new GlobalEnvironmentRecord(state, script->topCodeBlock(), state.context()->globalObject(), state.context()->globalDeclarativeRecord(), state.context()->globalDeclarativeStorage()), nullptr);
 

--- a/src/runtime/GlobalObject.cpp
+++ b/src/runtime/GlobalObject.cpp
@@ -201,7 +201,8 @@ Value GlobalObject::eval(ExecutionState& state, const Value& arg)
 #else
         size_t stackRemainApprox = state.stackLimit() - currentStackBase;
 #endif
-        Script* script = parser.initializeScript(StringView(arg.asString(), 0, arg.asString()->length()), state.context()->staticStrings().lazyEvalInput().string(), false, nullptr, strictFromOutside, false, true, false, stackRemainApprox, true, false, false, false).scriptThrowsExceptionIfParseError(state);
+
+        Script* script = parser.initializeScript(arg.asString(), state.context()->staticStrings().lazyEvalInput().string(), nullptr, false, true, false, false, strictFromOutside, false, false, false, true, stackRemainApprox).scriptThrowsExceptionIfParseError(state);
         // In case of indirect call, use global execution context
         ExecutionState stateForNewGlobal(m_context);
         return script->execute(stateForNewGlobal, true, script->topCodeBlock()->isStrict());
@@ -250,7 +251,7 @@ Value GlobalObject::evalLocal(ExecutionState& state, const Value& arg, Value thi
         size_t stackRemainApprox = state.stackLimit() - currentStackBase;
 #endif
 
-        Script* script = parser.initializeScript(StringView(arg.asString(), 0, arg.asString()->length()), state.context()->staticStrings().lazyEvalInput().string(), false, parentCodeBlock, strictFromOutside, isRunningEvalOnFunction, true, inWithOperation, stackRemainApprox, true, parentCodeBlock->allowSuperCall(), parentCodeBlock->allowSuperProperty(), allowNewTarget).scriptThrowsExceptionIfParseError(state);
+        Script* script = parser.initializeScript(arg.asString(), state.context()->staticStrings().lazyEvalInput().string(), parentCodeBlock, false, true, isRunningEvalOnFunction, inWithOperation, strictFromOutside, parentCodeBlock->allowSuperCall(), parentCodeBlock->allowSuperProperty(), allowNewTarget, true, stackRemainApprox).scriptThrowsExceptionIfParseError(state);
         return script->executeLocal(state, thisValue, parentCodeBlock, script->topCodeBlock()->isStrict(), isRunningEvalOnFunction);
     }
     return arg;

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -563,13 +563,13 @@ public:
     }
 };
 
-static bool evalScript(ContextRef* context, StringRef* str, StringRef* srcName, bool shouldPrintScriptResult, bool isModule)
+static bool evalScript(ContextRef* context, StringRef* source, StringRef* srcName, bool shouldPrintScriptResult, bool isModule)
 {
     if (stringEndsWith(srcName->toStdUTF8String(), "mjs")) {
         isModule = isModule || true;
     }
 
-    auto scriptInitializeResult = context->scriptParser()->initializeScript(str, srcName, isModule);
+    auto scriptInitializeResult = context->scriptParser()->initializeScript(source, srcName, isModule);
     if (!scriptInitializeResult.script) {
         fprintf(stderr, "Script parsing error: ");
         switch (scriptInitializeResult.parseErrorCode) {


### PR DESCRIPTION
* ByteCodeBlock does not hold location data info anymore
* location data of each bytecode is manually allocated only for stack-tracing or debugger mode
* duplicated String allocation for source code is removed

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>