### PR TITLE
Handle exception cases in CodeCache

### DIFF
--- a/.github/workflows/es-actions.yml
+++ b/.github/workflows/es-actions.yml
@@ -24,7 +24,11 @@ jobs:
       run: |
         cmake -H. -Bout/linux/x64/codecache $BUILD_OPTIONS
         ninja -Cout/linux/x64/codecache
-    - name: Run SunSpider [Cache Store]
-      run: $RUNNER --arch=x86_64 --engine="./out/linux/x64/codecache/escargot" sunspider-js
-    - name: Run SunSpider [Cache Load]
-      run: $RUNNER --arch=x86_64 --engine="./out/linux/x64/codecache/escargot" sunspider-js
+    - name: Run sunspider-js
+      run: |
+        $RUNNER --arch=x86_64 --engine="./out/linux/x64/codecache/escargot" sunspider-js
+        $RUNNER --arch=x86_64 --engine="./out/linux/x64/codecache/escargot" sunspider-js
+    - name: Run new-es 
+      run: |
+        $RUNNER --arch=x86_64 --engine="./out/linux/x64/codecache/escargot" new-es 
+        $RUNNER --arch=x86_64 --engine="./out/linux/x64/codecache/escargot" new-es

--- a/src/codecache/CodeCacheReaderWriter.cpp
+++ b/src/codecache/CodeCacheReaderWriter.cpp
@@ -433,8 +433,8 @@ void CodeCacheWriter::storeByteCodeStream(ByteCodeBlock* block)
                 STORE_ATOMICSTRING_RELOC(m_propertyName);
                 break;
             }
-            case LoadRegexpOpcode: {
-                LoadRegexp* bc = (LoadRegexp*)currentCode;
+            case LoadRegExpOpcode: {
+                LoadRegExp* bc = (LoadRegExp*)currentCode;
 
                 String* bodyString = bc->m_body;
                 String* optionString = bc->m_option;
@@ -785,8 +785,8 @@ void CodeCacheReader::loadByteCodeStream(Context* context, ByteCodeBlock* block)
 
         InterpretedCodeBlock* codeBlock = block->codeBlock();
 
-        // mark for LoadRegexp bytecode
-        bool bodyStringForLoadRegexp = true;
+        // mark for LoadRegExp bytecode
+        bool bodyStringForLoadRegExp = true;
 
         for (size_t i = 0; i < relocInfoVector.size(); i++) {
             ByteCodeRelocInfo& info = relocInfoVector[i];
@@ -890,20 +890,20 @@ void CodeCacheReader::loadByteCodeStream(Context* context, ByteCodeBlock* block)
                 LOAD_ATOMICSTRING_RELOC(m_propertyName);
                 break;
             }
-            case LoadRegexpOpcode: {
-                LoadRegexp* bc = (LoadRegexp*)currentCode;
+            case LoadRegExpOpcode: {
+                LoadRegExp* bc = (LoadRegExp*)currentCode;
 
                 String* bodyString = bc->m_body;
                 String* optionString = bc->m_option;
 
-                if (bodyStringForLoadRegexp) {
+                if (bodyStringForLoadRegExp) {
                     ASSERT(info.dataOffset < stringLiteralData.size());
                     bc->m_body = stringLiteralData[info.dataOffset];
-                    bodyStringForLoadRegexp = false;
+                    bodyStringForLoadRegExp = false;
                 } else {
                     ASSERT(info.dataOffset < stringLiteralData.size());
                     bc->m_option = stringLiteralData[info.dataOffset];
-                    bodyStringForLoadRegexp = true;
+                    bodyStringForLoadRegExp = true;
                 }
                 break;
             }

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -118,7 +118,7 @@ struct GlobalVariableAccessCacheItem;
     F(MarkEnumerateKey, 2, 0)                               \
     F(IteratorOperation, 0, 0)                              \
     F(GetMethod, 0, 0)                                      \
-    F(LoadRegexp, 1, 0)                                     \
+    F(LoadRegExp, 1, 0)                                     \
     F(WithOperation, 0, 0)                                  \
     F(ObjectDefineGetterSetter, 0, 0)                       \
     F(CallFunctionComplexCase, 0, 0)                        \
@@ -2231,10 +2231,10 @@ public:
 #endif
 };
 
-class LoadRegexp : public ByteCode {
+class LoadRegExp : public ByteCode {
 public:
-    LoadRegexp(const ByteCodeLOC& loc, const size_t registerIndex, String* body, String* opt)
-        : ByteCode(Opcode::LoadRegexpOpcode, loc)
+    LoadRegExp(const ByteCodeLOC& loc, const size_t registerIndex, String* body, String* opt)
+        : ByteCode(Opcode::LoadRegExpOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_body(body)
         , m_option(opt)

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -342,8 +342,8 @@ void ByteCodeGenerator::relocateByteCode(ByteCodeBlock* block)
             ASSIGN_STACKINDEX_IF_NEEDED(cd->m_registerIndex, stackBase, stackBaseWillBe, stackVariableSize);
             break;
         }
-        case LoadRegexpOpcode: {
-            LoadRegexp* cd = (LoadRegexp*)currentCode;
+        case LoadRegExpOpcode: {
+            LoadRegExp* cd = (LoadRegExp*)currentCode;
             ASSIGN_STACKINDEX_IF_NEEDED(cd->m_registerIndex, stackBase, stackBaseWillBe, stackVariableSize);
             break;
         }

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -1148,12 +1148,12 @@ Value ByteCodeInterpreter::interpret(ExecutionState* state, ByteCodeBlock* byteC
             NEXT_INSTRUCTION();
         }
 
-        DEFINE_OPCODE(LoadRegexp)
+        DEFINE_OPCODE(LoadRegExp)
             :
         {
-            LoadRegexp* code = (LoadRegexp*)programCounter;
+            LoadRegExp* code = (LoadRegExp*)programCounter;
             registerFile[code->m_registerIndex] = new RegExpObject(*state, code->m_body, code->m_option);
-            ADD_PROGRAM_COUNTER(LoadRegexp);
+            ADD_PROGRAM_COUNTER(LoadRegExp);
             NEXT_INSTRUCTION();
         }
 

--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -1721,7 +1721,7 @@ void Scanner::scanRegExp(Scanner::ScannerResult* token)
     result.body = body;
     result.flags = flags;
     token->setResult(Token::RegularExpressionToken, this->lineNumber, this->lineStart, start, this->index);
-    token->valueRegexp = result;
+    token->valueRegExp = result;
 }
 
 // ECMA-262 11.6.2.1 Keywords

--- a/src/parser/Lexer.h
+++ b/src/parser/Lexer.h
@@ -260,7 +260,7 @@ public:
             , lineStart(0)
             , start(0)
             , end(0)
-            , valueRegexp()
+            , valueRegExp()
         {
         }
 
@@ -286,7 +286,7 @@ public:
             ScannerSourceStringView valueStringLiteralData;
             double valueNumber;
             ScanTemplateResult* valueTemplate;
-            ScanRegExpResult valueRegexp;
+            ScanRegExpResult valueRegExp;
             KeywordKind valueKeywordKind;
         };
 

--- a/src/parser/ast/RegExpLiteralNode.h
+++ b/src/parser/ast/RegExpLiteralNode.h
@@ -41,7 +41,7 @@ public:
     {
         codeBlock->m_stringLiteralData.pushBack(m_body);
         codeBlock->m_stringLiteralData.pushBack(m_flag);
-        codeBlock->pushCode(LoadRegexp(ByteCodeLOC(m_loc.index), dstRegister, m_body, m_flag), context, this);
+        codeBlock->pushCode(LoadRegExp(ByteCodeLOC(m_loc.index), dstRegister, m_body, m_flag), context, this);
     }
 
 private:

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -1097,7 +1097,7 @@ public:
                 ALLOC_TOKEN(token);
                 this->nextRegexToken(token);
                 // raw = this->getTokenRaw(token);
-                return this->finalize(node, builder.createRegExpLiteralNode(token->valueRegexp.body, token->valueRegexp.flags));
+                return this->finalize(node, builder.createRegExpLiteralNode(token->valueRegExp.body, token->valueRegExp.flags));
             }
             default: {
                 ALLOC_TOKEN(token);

--- a/src/runtime/ErrorObject.h
+++ b/src/runtime/ErrorObject.h
@@ -109,6 +109,7 @@ public:
         static constexpr const char* GlobalObject_CalledOnIncompatibleReceiver = "%s: called on incompatible receiver";
         static constexpr const char* GlobalObject_IllegalFirstArgument = "%s: illegal first argument";
         static constexpr const char* String_InvalidStringLength = "Invalid string length";
+        static constexpr const char* CodeCache_Loaded_StaticError = "[CodeCache] Default Error Message of ThrowStaticError: %s";
     };
 
     enum Code {

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -93,7 +93,7 @@ ObjectRareData::ObjectRareData(Object* obj)
     m_isArrayObjectLengthWritable = true;
     m_isSpreadArrayObject = false;
     m_shouldUpdateEnumerateObject = false;
-    m_hasNonWritableLastIndexRegexpObject = false;
+    m_hasNonWritableLastIndexRegExpObject = false;
     m_arrayObjectFastModeBufferExpandCount = 0;
     m_extraData = nullptr;
     m_internalSlot = nullptr;

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -49,7 +49,7 @@ struct ObjectRareData : public PointerValue {
     bool m_isArrayObjectLengthWritable : 1;
     bool m_isSpreadArrayObject : 1;
     bool m_shouldUpdateEnumerateObject : 1; // used only for Array Object when ArrayObject::deleteOwnProperty called
-    bool m_hasNonWritableLastIndexRegexpObject : 1;
+    bool m_hasNonWritableLastIndexRegExpObject : 1;
     uint8_t m_arrayObjectFastModeBufferExpandCount : 8;
     void* m_extraData;
     Object* m_prototype;

--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -195,7 +195,7 @@ void RegExpObject::initWithOption(ExecutionState& state, String* source, Option 
 
 void RegExpObject::setLastIndex(ExecutionState& state, const Value& v)
 {
-    if (UNLIKELY(hasRareData() && rareData()->m_hasNonWritableLastIndexRegexpObject && (m_option & (Option::Sticky | Option::Global)))) {
+    if (UNLIKELY(hasRareData() && rareData()->m_hasNonWritableLastIndexRegExpObject && (m_option & (Option::Sticky | Option::Global)))) {
         Object::throwCannotWriteError(state, ObjectStructurePropertyName(state.context()->staticStrings().lastIndex));
     }
     m_lastIndex = v;
@@ -206,9 +206,9 @@ bool RegExpObject::defineOwnProperty(ExecutionState& state, const ObjectProperty
     bool returnValue = Object::defineOwnProperty(state, P, desc);
     if (!P.isUIntType() && returnValue && P.objectStructurePropertyName() == ObjectStructurePropertyName(state.context()->staticStrings().lastIndex)) {
         if (!structure()->readProperty((size_t)ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER).m_descriptor.isWritable()) {
-            ensureRareData()->m_hasNonWritableLastIndexRegexpObject = true;
+            ensureRareData()->m_hasNonWritableLastIndexRegExpObject = true;
         } else {
-            ensureRareData()->m_hasNonWritableLastIndexRegexpObject = false;
+            ensureRareData()->m_hasNonWritableLastIndexRegExpObject = false;
         }
     }
     return returnValue;


### PR DESCRIPTION
* handle ThrowStaticErrorOperation bytecode with default error message
* LoadRegexp bytecode could have empty string as its option string
* test on new-es benchmarks
* Unify regular expression notation as RegExp