### PR TITLE
Handle CodeCache file I/O errors

### DIFF
--- a/.github/workflows/es-actions.yml
+++ b/.github/workflows/es-actions.yml
@@ -43,8 +43,8 @@ jobs:
         ninja -Cout/debugger
     - name: Debugger Test
       run: |
-        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/debugger/escargot" debugger-server-source 
-        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/debugger/escargot" debugger-client-source 
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/debugger/escargot" debugger-server-source
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/debugger/escargot" debugger-client-source
 
   cctest:
     runs-on: ubuntu-latest
@@ -95,7 +95,7 @@ jobs:
         $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
         $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
         rm -rf $HOME/Escargot-cache/
-    - name: Run new-es 
+    - name: Run new-es
       run: |
         $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" new-es
         $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" new-es
@@ -103,6 +103,16 @@ jobs:
         $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" new-es
         $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" new-es
         rm -rf $HOME/Escargot-cache/
+    - name: Handle error cases
+      run: |
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
+        rm $HOME/Escargot-cache/3217641879501852439
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
+        ls -1q $HOME/Escargot-cache/ | wc -l
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
+        rm $HOME/Escargot-cache/cache_list
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
+
 
   coverity_scan:
     if: github.event_name == 'push'

--- a/src/codecache/CodeCacheReaderWriter.cpp
+++ b/src/codecache/CodeCacheReaderWriter.cpp
@@ -581,10 +581,15 @@ void CodeCacheReader::CacheBuffer::reset()
     m_index = 0;
 }
 
-void CodeCacheReader::loadData(FILE* file, size_t size)
+bool CodeCacheReader::loadData(FILE* file, size_t size)
 {
     m_buffer.resize(size);
-    fread((void*)bufferData(), sizeof(char), size, file);
+    if (UNLIKELY(fread((void*)bufferData(), sizeof(char), size, file) != size)) {
+        clearBuffer();
+        return false;
+    }
+
+    return true;
 }
 
 InterpretedCodeBlock* CodeCacheReader::loadInterpretedCodeBlock(Context* context, Script* script)
@@ -738,7 +743,6 @@ InterpretedCodeBlock* CodeCacheReader::loadInterpretedCodeBlock(Context* context
         for (size_t i = 0; i < mapSize; i++) {
             size_t stringIndex = m_buffer.get<size_t>();
             size_t index = m_buffer.get<size_t>();
-            m_stringTable->get(stringIndex);
             varMap->insert(std::make_pair(m_stringTable->get(stringIndex), index));
         }
         codeBlock->rareData()->m_identifierInfoMap = varMap;

--- a/src/codecache/CodeCacheReaderWriter.h
+++ b/src/codecache/CodeCacheReaderWriter.h
@@ -160,6 +160,7 @@ public:
 
     ~CodeCacheWriter()
     {
+        m_stringTable = nullptr;
         clearBuffer();
     }
 
@@ -269,6 +270,7 @@ public:
 
     ~CodeCacheReader()
     {
+        m_stringTable = nullptr;
         clearBuffer();
     }
 
@@ -286,7 +288,7 @@ public:
     char* bufferData() { return m_buffer.data(); }
     size_t bufferIndex() { return m_buffer.index(); }
     void clearBuffer() { m_buffer.reset(); }
-    void loadData(FILE*, size_t);
+    bool loadData(FILE*, size_t);
 
     InterpretedCodeBlock* loadInterpretedCodeBlock(Context* context, Script* script);
     ByteCodeBlock* loadByteCodeBlock(Context* context, InterpretedCodeBlock* topCodeBlock);


### PR DESCRIPTION
* first, try to lock cache directory to enable CodeCache
* if file I/O fails, stop caching and remove all cache files
* flush and sync files when writing cache
* add tests to check file error cases

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>