### PR TITLE
Add cache replacement policy for CodeCache

### DIFF
--- a/.github/workflows/es-actions.yml
+++ b/.github/workflows/es-actions.yml
@@ -87,21 +87,23 @@ jobs:
       run: |
         cmake -H. -Bout/codecache/x64 $BUILD_OPTIONS
         ninja -Cout/codecache/x64
-    - name: Run sunspider-js
+    - name: Run x86 test
       run: |
         $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" sunspider-js
         $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" sunspider-js
+        $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" new-es
+        $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" new-es
+        $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" octane-loading
+        $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" octane-loading
         rm -rf $HOME/Escargot-cache/
-        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
-        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
-        rm -rf $HOME/Escargot-cache/
-    - name: Run new-es
+    - name: Run x64 test
       run: |
-        $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" new-es
-        $RUNNER --arch=x86 --engine="$GITHUB_WORKSPACE/out/codecache/x86/escargot" new-es
-        rm -rf $HOME/Escargot-cache/
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" sunspider-js
         $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" new-es
         $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" new-es
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" octane-loading
+        $RUNNER --arch=x86_64 --engine="$GITHUB_WORKSPACE/out/codecache/x64/escargot" octane-loading
         rm -rf $HOME/Escargot-cache/
     - name: Handle error cases
       run: |

--- a/src/codecache/CodeCache.h
+++ b/src/codecache/CodeCache.h
@@ -75,19 +75,19 @@ struct CodeCacheMetaInfo {
 
 struct CodeCacheEntry {
     CodeCacheEntry()
-        : m_lastUsedTimeStamp(0)
+        : m_lastWrittenTimeStamp(0)
     {
     }
 
     void reset()
     {
-        m_lastUsedTimeStamp = 0;
+        m_lastWrittenTimeStamp = 0;
         for (size_t i = 0; i < (size_t)CodeCacheType::CACHE_TYPE_NUM; i++) {
             m_metaInfos[i].cacheType = CodeCacheType::CACHE_INVALID;
         }
     }
 
-    uint64_t m_lastUsedTimeStamp;
+    uint64_t m_lastWrittenTimeStamp;
     CodeCacheMetaInfo m_metaInfos[(size_t)CodeCacheType::CACHE_TYPE_NUM];
 };
 
@@ -177,7 +177,10 @@ private:
     void clearAll();
     void reset();
     void setCacheEntry(const CodeCacheEntryChunk& entryChunk);
-    void addCacheEntry(size_t hash, const CodeCacheEntry& entry);
+    bool addCacheEntry(size_t hash, const CodeCacheEntry& entry);
+
+    bool removeLRUCacheEntry();
+    bool removeCacheFile(size_t hash);
 
     void storeCodeBlockTreeNode(InterpretedCodeBlock* codeBlock, size_t& nodeCount);
     InterpretedCodeBlock* loadCodeBlockTreeNode(Script* script);

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -147,6 +147,16 @@ def run_octane(engine, arch):
     raise last_error
 
 
+@runner('octane-loading', default=True)
+def run_octane_loading(engine, arch):
+    OCTANE_OVERRIDE_DIR = join(PROJECT_SOURCE_DIR, 'tools', 'test', 'octane')
+    OCTANE_DIR = join(PROJECT_SOURCE_DIR, 'test', 'octane')
+    copy(join(OCTANE_OVERRIDE_DIR, 'runLoading.js'), join(OCTANE_DIR, 'runLoading.js'))
+
+    run([engine, 'runLoading.js'],
+         cwd=OCTANE_DIR)
+
+
 @runner('modifiedVendorTest', default=True)
 def run_internal_test(engine, arch):
     INTERNAL_OVERRIDE_DIR = join(PROJECT_SOURCE_DIR, 'tools', 'test', 'ModifiedVendorTest')

--- a/tools/test/octane/runLoading.js
+++ b/tools/test/octane/runLoading.js
@@ -1,0 +1,55 @@
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+var startTime = new Date();
+
+var base_dir = '';
+load(base_dir + 'base.js');
+load(base_dir + 'richards.js');
+load(base_dir + 'deltablue.js');
+load(base_dir + 'crypto.js');
+load(base_dir + 'raytrace.js');
+load(base_dir + 'earley-boyer.js');
+load(base_dir + 'regexp.js');
+load(base_dir + 'splay.js');
+load(base_dir + 'navier-stokes.js');
+load(base_dir + 'pdfjs.js');
+load(base_dir + 'mandreel.js');
+load(base_dir + 'gbemu-part1.js');
+load(base_dir + 'gbemu-part2.js');
+load(base_dir + 'code-load.js');
+load(base_dir + 'box2d.js');
+load(base_dir + 'zlib.js');
+load(base_dir + 'zlib-data.js');
+load(base_dir + 'typescript.js');
+load(base_dir + 'typescript-input.js');
+load(base_dir + 'typescript-compiler.js');
+
+var endTime = new Date();
+var elapsed = endTime - startTime;
+print("Loading Time: " + elapsed);


### PR DESCRIPTION
* to keep overall file operations as small as possible,
  remove only the least recently written cache file
* trigger cache replacement when the number of cache reaches the limit
* add octane loading TC for codecache test

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>