### PR TITLE
Fix CodeCache clear to be invoked immediately

### DIFF
--- a/src/codecache/CodeCache.cpp
+++ b/src/codecache/CodeCache.cpp
@@ -43,8 +43,10 @@ void CodeCache::CodeCacheContext::reset()
     m_cacheFilePath.clear();
     m_cacheEntry.reset();
 
-    delete m_cacheStringTable;
-    m_cacheStringTable = nullptr;
+    if (m_cacheStringTable) {
+        delete m_cacheStringTable;
+        m_cacheStringTable = nullptr;
+    }
     m_cacheDataOffset = 0;
 }
 
@@ -121,7 +123,7 @@ bool CodeCache::tryInitCacheDir()
     // lock cache directory
     ASSERT(m_cacheDirFD != -1);
     if (flock(m_cacheDirFD, LOCK_EX | LOCK_NB) == -1) {
-        ESCARGOT_LOG_INFO("[CodeCache] cache directory (%s) lock failed\n", m_cacheDirPath.data());
+        ESCARGOT_LOG_ERROR("[CodeCache] cache directory (%s) lock failed\n", m_cacheDirPath.data());
         close(m_cacheDirFD);
         m_cacheDirFD = -1;
         return false;
@@ -244,10 +246,14 @@ void CodeCache::clear()
     m_cacheDirPath.clear();
     m_cacheList.clear();
 
-    delete m_cacheWriter;
-    delete m_cacheReader;
-    m_cacheWriter = nullptr;
-    m_cacheReader = nullptr;
+    if (m_cacheWriter) {
+        delete m_cacheWriter;
+        m_cacheWriter = nullptr;
+    }
+    if (m_cacheReader) {
+        delete m_cacheReader;
+        m_cacheReader = nullptr;
+    }
 
     // disable code cache
     m_enabled = false;

--- a/src/codecache/CodeCache.h
+++ b/src/codecache/CodeCache.h
@@ -151,6 +151,8 @@ public:
     InterpretedCodeBlock* loadCodeBlockTree(Context* context, Script* script);
     ByteCodeBlock* loadByteCodeBlock(Context* context, InterpretedCodeBlock* topCodeBlock);
 
+    void clear();
+
 private:
     std::string m_cacheDirPath;
 
@@ -173,7 +175,6 @@ private:
     void unLockAndCloseCacheDir();
     void clearCacheDir();
 
-    void clear();
     void clearAll();
     void reset();
     void setCacheEntry(const CodeCacheEntryChunk& entryChunk);

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -485,6 +485,11 @@ void VMInstance::clearCachesRelatedWithContext()
     m_regexpCache->clear();
     m_cachedUTC = nullptr;
     globalSymbolRegistry().clear();
+#if defined(ENABLE_CODE_CACHE)
+    // CodeCache should be cleared here because CodeCache holds a lock of cache directory
+    // this lock should be released immediately (destructor may be called later)
+    m_codeCache->clear();
+#endif
 }
 
 void VMInstance::enterIdleMode()


### PR DESCRIPTION
* CodeCache holds a lock of cache directory that should be released immediately when it is no longer necessary
* since GC may reclaim VMInstance and its CodeCache member lazily, so destructor of CodeCache could be called later too
* invoke CodeCache clear() in clearCachesRelatedWithContext method to resolve this issue

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>