### PR TITLE
Add IsHTMLDDA feature

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -1355,6 +1355,13 @@ void ObjectRef::setExtraData(void* e)
     toImpl(this)->setExtraData(e);
 }
 
+#if defined(ESCARGOT_ENABLE_TEST)
+void ObjectRef::setIsHTMLDDA()
+{
+    toImpl(this)->setIsHTMLDDA();
+}
+#endif
+
 void ObjectRef::removeFromHiddenClassChain()
 {
     toImpl(this)->markThisObjectDontNeedStructureTransitionTable();

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -1099,6 +1099,9 @@ public:
 
     void* extraData();
     void setExtraData(void* e);
+#if defined(ESCARGOT_ENABLE_TEST)
+    void setIsHTMLDDA();
+#endif
 
     void removeFromHiddenClassChain();
 

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -3584,14 +3584,21 @@ NEVER_INLINE void ByteCodeInterpreter::unaryTypeof(ExecutionState& state, UnaryT
     } else {
         ASSERT(val.isPointerValue());
         PointerValue* p = val.asPointerValue();
-        if (p->isCallable()) {
-            val = state.context()->staticStrings().function.string();
-        } else if (p->isSymbol()) {
+        if (p->isSymbol()) {
             val = state.context()->staticStrings().symbol.string();
         } else if (p->isBigInt()) {
             val = state.context()->staticStrings().bigint.string();
         } else {
-            val = state.context()->staticStrings().object.string();
+            ASSERT(p->isObject());
+            if (!p->isCallable()) {
+                val = state.context()->staticStrings().object.string();
+#if defined(ESCARGOT_ENABLE_TEST)
+            } else if (UNLIKELY(p->asObject()->isHTMLDDA())) {
+                val = state.context()->staticStrings().undefined.string();
+#endif
+            } else {
+                val = state.context()->staticStrings().function.string();
+            }
         }
     }
 

--- a/src/runtime/GlobalObjectBuiltinArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinArray.cpp
@@ -594,14 +594,9 @@ static Value builtinArraySplice(ExecutionState& state, Value thisValue, size_t a
             ObjectPropertyName from(state, Value(actualStart + k));
             A->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, k),
                                                 ObjectPropertyDescriptor(fromValue.value(state, from, O), ObjectPropertyDescriptor::AllPresent));
-            // Increment k by 1.
-            k++;
-        } else {
-            int64_t result;
-            Object::nextIndexForward(state, O, actualStart + k, len, result);
-            k = result - actualStart;
-            A->setThrowsException(state, ObjectPropertyName(state.context()->staticStrings().length), Value(k), A);
         }
+        // Increment k by 1.
+        k++;
     }
     // Let setStatus be Set(A, "length", actualDeleteCount, true).
     A->setThrowsException(state, ObjectPropertyName(state.context()->staticStrings().length), Value(actualDeleteCount), A);
@@ -622,9 +617,9 @@ static Value builtinArraySplice(ExecutionState& state, Value thisValue, size_t a
         // move [actualStart + deleteCnt, len) to [actualStart + insertCnt, len - deleteCnt + insertCnt)
         while (k < len - actualDeleteCount) {
             // Let from be ToString(k+actualDeleteCount).
-            uint32_t from = k + actualDeleteCount;
+            int64_t from = k + actualDeleteCount;
             // Let to be ToString(k+itemCount).
-            uint32_t to = k + itemCount;
+            int64_t to = k + itemCount;
             // Let fromPresent be the result of calling the [[HasProperty]] internal method of O with argument from.
             ObjectHasPropertyResult fromValue = O->hasIndexedProperty(state, Value(from));
             // If fromPresent is true, then

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -83,21 +83,21 @@ ObjectStructurePropertyName ObjectPropertyName::toObjectStructurePropertyNameUin
 }
 
 ObjectRareData::ObjectRareData(Object* obj)
+    : m_isExtensible(true)
+    , m_isEverSetAsPrototypeObject(false)
+    , m_isFastModeArrayObject(true)
+    , m_isArrayObjectLengthWritable(true)
+    , m_isSpreadArrayObject(false)
+    , m_shouldUpdateEnumerateObject(false)
+    , m_hasNonWritableLastIndexRegExpObject(false)
+#if defined(ESCARGOT_ENABLE_TEST)
+    , m_isHTMLDDA(false)
+#endif
+    , m_arrayObjectFastModeBufferExpandCount(0)
+    , m_extraData(nullptr)
+    , m_prototype(obj ? obj->m_prototype : nullptr)
+    , m_internalSlot(nullptr)
 {
-    if (obj)
-        m_prototype = obj->m_prototype;
-    else
-        m_prototype = nullptr;
-    m_isExtensible = true;
-    m_isEverSetAsPrototypeObject = false;
-    m_isFastModeArrayObject = true;
-    m_isArrayObjectLengthWritable = true;
-    m_isSpreadArrayObject = false;
-    m_shouldUpdateEnumerateObject = false;
-    m_hasNonWritableLastIndexRegExpObject = false;
-    m_arrayObjectFastModeBufferExpandCount = 0;
-    m_extraData = nullptr;
-    m_internalSlot = nullptr;
 }
 
 void* ObjectRareData::operator new(size_t size)

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -50,6 +50,9 @@ struct ObjectRareData : public PointerValue {
     bool m_isSpreadArrayObject : 1;
     bool m_shouldUpdateEnumerateObject : 1; // used only for Array Object when ArrayObject::deleteOwnProperty called
     bool m_hasNonWritableLastIndexRegExpObject : 1;
+#if defined(ESCARGOT_ENABLE_TEST)
+    bool m_isHTMLDDA : 1;
+#endif
     uint8_t m_arrayObjectFastModeBufferExpandCount : 8;
     void* m_extraData;
     Object* m_prototype;
@@ -976,6 +979,18 @@ public:
     {
         ensureRareData()->m_extraData = e;
     }
+
+#if defined(ESCARGOT_ENABLE_TEST)
+    bool isHTMLDDA()
+    {
+        return hasRareData() ? rareData()->m_isHTMLDDA : false;
+    }
+
+    void setIsHTMLDDA()
+    {
+        ensureRareData()->m_isHTMLDDA = true;
+    }
+#endif
 
     Object* ensureInternalSlot(ExecutionState& state)
     {

--- a/src/runtime/Value.cpp
+++ b/src/runtime/Value.cpp
@@ -370,6 +370,15 @@ bool Value::abstractEqualsToSlowCase(ExecutionState& state, const Value& val) co
                 return o->asString()->equals(comp->asString());
             return equalsTo(state, val);
         }
+
+#if defined(ESCARGOT_ENABLE_TEST)
+        if (UNLIKELY(selfIsUndefinedOrNull && valIsPointerValue && val.asPointerValue()->isObject() && val.asObject()->isHTMLDDA())) {
+            return true;
+        }
+        if (UNLIKELY(valIsUndefinedOrNull && selfIsPointerValue && asPointerValue()->isObject() && asObject()->isHTMLDDA())) {
+            return true;
+        }
+#endif
     }
     return false;
 }
@@ -824,4 +833,11 @@ uint32_t Value::tryToUseAsArrayIndexSlowCase(ExecutionState& ec) const
     }
     return toString(ec)->tryToUseAsArrayIndex();
 }
+
+#if defined(ESCARGOT_ENABLE_TEST)
+bool Value::checkIfObjectWithIsHTMLDDA() const
+{
+    return isObject() && asObject()->isHTMLDDA();
+}
+#endif
 }

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -274,6 +274,9 @@ private:
     int32_t toInt32SlowCase(ExecutionState& ec) const; // $7.1.5 ToInt32
     ValueIndex tryToUseAsIndexSlowCase(ExecutionState& ec) const;
     uint32_t tryToUseAsArrayIndexSlowCase(ExecutionState& ec) const;
+#if defined(ESCARGOT_ENABLE_TEST)
+    bool checkIfObjectWithIsHTMLDDA() const;
+#endif
 };
 
 typedef Vector<Value, CustomAllocator<Value>> ValueVector;

--- a/src/runtime/ValueInlines.h
+++ b/src/runtime/ValueInlines.h
@@ -825,6 +825,11 @@ inline bool Value::toBoolean(ExecutionState& ec) const // $7.1.2 ToBoolean
         return !asBigInt()->isZero();
     }
 
+#if defined(ESCARGOT_ENABLE_TEST)
+    if (UNLIKELY(checkIfObjectWithIsHTMLDDA())) {
+        return false;
+    }
+#endif
     // Symbol, Objects..
     return true;
 }

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -322,6 +322,11 @@ static ValueRef* builtin262EvalScript(ExecutionStateRef* state, ValueRef* thisVa
     auto script = state->context()->scriptParser()->initializeScript(src, StringRef::createFromASCII("$262.evalScript input"), false).fetchScriptThrowsExceptionIfParseError(state);
     return script->execute(state);
 }
+
+static ValueRef* builtin262IsHTMLDDA(ExecutionStateRef* state, ValueRef* thisValue, size_t argc, ValueRef** argv, bool isConstructCall)
+{
+    return ValueRef::createNull();
+}
 #endif
 
 
@@ -430,7 +435,10 @@ PersistentRefHolder<ContextRef> createEscargotContext(VMInstanceRef* instance)
             }
 
             {
-                dollor262Object->defineDataProperty(state, StringRef::createFromASCII("IsHTMLDDA"), ValueRef::create(false), true, true, true);
+                FunctionObjectRef::NativeFunctionInfo nativeFunctionInfo(AtomicStringRef::create(context, "IsHTMLDDA"), builtin262IsHTMLDDA, 0, true, false);
+                FunctionObjectRef* buildFunctionObjectRef = FunctionObjectRef::create(state, nativeFunctionInfo);
+                buildFunctionObjectRef->setIsHTMLDDA();
+                dollor262Object->defineDataProperty(state, StringRef::createFromASCII("IsHTMLDDA"), buildFunctionObjectRef, true, true, true);
             }
 
             context->globalObject()->defineDataProperty(state, StringRef::createFromASCII("$262"), dollor262Object, true, false, true);

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -35,17 +35,10 @@
     <test id="annexB/built-ins/RegExp/match-indices/indices-groups-object"><reason>TODO</reason></test>
     <test id="annexB/built-ins/RegExp/named-groups/non-unicode-malformed"><reason>TODO</reason></test>
     <test id="annexB/built-ins/RegExp/named-groups/non-unicode-malformed-lookbehind"><reason>TODO</reason></test>
-    <test id="annexB/built-ins/String/prototype/match/custom-matcher-emulates-undefined"><reason>TODO</reason></test>
-    <test id="annexB/built-ins/String/prototype/matchAll/custom-matcher-emulates-undefined"><reason>TODO</reason></test>
-    <test id="annexB/built-ins/String/prototype/replace/custom-replacer-emulates-undefined"><reason>TODO</reason></test>
     <test id="annexB/built-ins/String/prototype/replaceAll/custom-replacer-emulates-undefined"><reason>TODO</reason></test>
-    <test id="annexB/built-ins/String/prototype/search/custom-searcher-emulates-undefined"><reason>TODO</reason></test>
-    <test id="annexB/built-ins/String/prototype/split/custom-splitter-emulates-undefined"><reason>TODO</reason></test>
     <test id="annexB/language/comments/multi-line-html-close"><reason>TODO</reason></test>
     <test id="annexB/language/function-code/block-decl-func-skip-arguments"><reason>TODO</reason></test>
     <test id="annexB/language/literals/regexp/legacy-octal-escape"><reason>TODO</reason></test>
-    <test id="built-ins/Array/prototype/splice/create-species-length-exceeding-integer-limit"><reason>TODO</reason></test>
-    <test id="built-ins/Array/prototype/splice/length-exceeding-integer-limit-shrink-array"><reason>TODO</reason></test>
     <test id="built-ins/ArrayBuffer/prototype/byteLength/this-is-sharedarraybuffer"><reason>TODO</reason></test>
     <test id="built-ins/ArrayBuffer/prototype/slice/this-is-sharedarraybuffer"><reason>TODO</reason></test>
     <test id="built-ins/AsyncFromSyncIteratorPrototype/next/absent-value-not-passed"><reason>TODO</reason></test>


### PR DESCRIPTION
* https://www.ecma-international.org/ecma-262/#sec-IsHTMLDDA-internal-slot
* IsHTMLDDA internal slot is an ECMAScript feature for Web Browsers
* IsHTMLDDA is currently enabled only for test mode (we can enable it later if it is really used by third party app)
* some related operations are optionally fixed
* Minor fix in Array.prototype.splice