### PR TITLE
Minor update to WebAssembly

### DIFF
--- a/src/runtime/StaticStrings.cpp
+++ b/src/runtime/StaticStrings.cpp
@@ -116,11 +116,14 @@ void StaticStrings::initStaticStrings()
     INIT_STATIC_STRING(symbolSplit, "[Symbol.split]");
 
 #if defined(ENABLE_WASM)
-    INIT_STATIC_STRING(WebAssemblyDotModule, "WebAssembly.Module");
+    INIT_STATIC_STRING(getExports, "get exports");
+    INIT_STATIC_STRING(getValue, "get value");
+    INIT_STATIC_STRING(setValue, "set value");
+    INIT_STATIC_STRING(WebAssemblyDotGlobal, "WebAssembly.Global");
     INIT_STATIC_STRING(WebAssemblyDotInstance, "WebAssembly.Instance");
     INIT_STATIC_STRING(WebAssemblyDotMemory, "WebAssembly.Memory");
+    INIT_STATIC_STRING(WebAssemblyDotModule, "WebAssembly.Module");
     INIT_STATIC_STRING(WebAssemblyDotTable, "WebAssembly.Table");
-    INIT_STATIC_STRING(WebAssemblyDotGlobal, "WebAssembly.Global");
 #endif
 #undef INIT_STATIC_STRING
 

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -837,11 +837,14 @@ public:
     AtomicString symbolSplit;
 
 #if defined(ENABLE_WASM)
-    AtomicString WebAssemblyDotModule;
+    AtomicString getExports;
+    AtomicString getValue;
+    AtomicString setValue;
+    AtomicString WebAssemblyDotGlobal;
     AtomicString WebAssemblyDotInstance;
     AtomicString WebAssemblyDotMemory;
+    AtomicString WebAssemblyDotModule;
     AtomicString WebAssemblyDotTable;
-    AtomicString WebAssemblyDotGlobal;
 #endif
 
 #define ESCARGOT_ASCII_TABLE_MAX 256

--- a/src/wasm/GlobalObjectBuiltinWASM.cpp
+++ b/src/wasm/GlobalObjectBuiltinWASM.cpp
@@ -815,7 +815,7 @@ void GlobalObject::installWASM(ExecutionState& state)
 
     {
         JSGetterSetter gs(
-            new NativeFunctionObject(state, NativeFunctionInfo(strings->exports, builtinWASMInstanceExportsGetter, 0, NativeFunctionInfo::Strict)), Value(Value::EmptyValue));
+            new NativeFunctionObject(state, NativeFunctionInfo(strings->getExports, builtinWASMInstanceExportsGetter, 0, NativeFunctionInfo::Strict)), Value(Value::EmptyValue));
         ObjectPropertyDescriptor exportsDesc(gs, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::EnumerablePresent | ObjectPropertyDescriptor::ConfigurablePresent));
         m_wasmInstancePrototype->defineOwnProperty(state, ObjectPropertyName(strings->exports), exportsDesc);
     }
@@ -871,7 +871,7 @@ void GlobalObject::installWASM(ExecutionState& state)
 
     {
         JSGetterSetter gs(
-            new NativeFunctionObject(state, NativeFunctionInfo(strings->length, builtinWASMTableLengthGetter, 0, NativeFunctionInfo::Strict)), Value(Value::EmptyValue));
+            new NativeFunctionObject(state, NativeFunctionInfo(strings->getLength, builtinWASMTableLengthGetter, 0, NativeFunctionInfo::Strict)), Value(Value::EmptyValue));
         ObjectPropertyDescriptor lengthDesc(gs, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::EnumerablePresent | ObjectPropertyDescriptor::ConfigurablePresent));
         m_wasmTablePrototype->defineOwnProperty(state, ObjectPropertyName(strings->length), lengthDesc);
     }
@@ -896,8 +896,8 @@ void GlobalObject::installWASM(ExecutionState& state)
 
     {
         JSGetterSetter gs(
-            new NativeFunctionObject(state, NativeFunctionInfo(strings->value, builtinWASMGlobalValueGetter, 0, NativeFunctionInfo::Strict)),
-            new NativeFunctionObject(state, NativeFunctionInfo(strings->value, builtinWASMGlobalValueSetter, 1, NativeFunctionInfo::Strict)));
+            new NativeFunctionObject(state, NativeFunctionInfo(strings->getValue, builtinWASMGlobalValueGetter, 0, NativeFunctionInfo::Strict)),
+            new NativeFunctionObject(state, NativeFunctionInfo(strings->setValue, builtinWASMGlobalValueSetter, 1, NativeFunctionInfo::Strict)));
         ObjectPropertyDescriptor valueDesc(gs, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::EnumerablePresent | ObjectPropertyDescriptor::ConfigurablePresent));
         m_wasmGlobalPrototype->defineOwnProperty(state, ObjectPropertyName(strings->value), valueDesc);
     }

--- a/src/wasm/GlobalObjectBuiltinWASM.cpp
+++ b/src/wasm/GlobalObjectBuiltinWASM.cpp
@@ -776,7 +776,7 @@ void GlobalObject::installWASM(ExecutionState& state)
 
     // WebAssembly.instantiate()
     wasm->defineOwnProperty(state, ObjectPropertyName(strings->instantiate),
-                            ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->instantiate, builtinWASMInstantiate, 2, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::AllPresent)));
+                            ObjectPropertyDescriptor(new NativeFunctionObject(state, NativeFunctionInfo(strings->instantiate, builtinWASMInstantiate, 1, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::AllPresent)));
 
 
     // WebAssembly.Module
@@ -785,6 +785,8 @@ void GlobalObject::installWASM(ExecutionState& state)
 
     m_wasmModulePrototype = new Object(state);
     m_wasmModulePrototype->setGlobalIntrinsicObject(state, true);
+
+    m_wasmModulePrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(wasmModule, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_wasmModulePrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                              ObjectPropertyDescriptor(state.context()->staticStrings().WebAssemblyDotModule.string(), ObjectPropertyDescriptor::ConfigurablePresent));
@@ -810,6 +812,8 @@ void GlobalObject::installWASM(ExecutionState& state)
     m_wasmInstancePrototype = new Object(state);
     m_wasmInstancePrototype->setGlobalIntrinsicObject(state, true);
 
+    m_wasmInstancePrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(wasmInstance, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
+
     m_wasmInstancePrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                                ObjectPropertyDescriptor(state.context()->staticStrings().WebAssemblyDotInstance.string(), ObjectPropertyDescriptor::ConfigurablePresent));
 
@@ -831,6 +835,8 @@ void GlobalObject::installWASM(ExecutionState& state)
 
     m_wasmMemoryPrototype = new Object(state);
     m_wasmMemoryPrototype->setGlobalIntrinsicObject(state, true);
+
+    m_wasmMemoryPrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(wasmMemory, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_wasmMemoryPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                              ObjectPropertyDescriptor(state.context()->staticStrings().WebAssemblyDotMemory.string(), ObjectPropertyDescriptor::ConfigurablePresent));
@@ -856,6 +862,8 @@ void GlobalObject::installWASM(ExecutionState& state)
 
     m_wasmTablePrototype = new Object(state);
     m_wasmTablePrototype->setGlobalIntrinsicObject(state, true);
+
+    m_wasmTablePrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(wasmTable, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_wasmTablePrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                             ObjectPropertyDescriptor(state.context()->staticStrings().WebAssemblyDotTable.string(), ObjectPropertyDescriptor::ConfigurablePresent));
@@ -887,6 +895,8 @@ void GlobalObject::installWASM(ExecutionState& state)
 
     m_wasmGlobalPrototype = new Object(state);
     m_wasmGlobalPrototype->setGlobalIntrinsicObject(state, true);
+
+    m_wasmGlobalPrototype->defineOwnProperty(state, ObjectPropertyName(strings->constructor), ObjectPropertyDescriptor(wasmGlobal, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_wasmGlobalPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->vmInstance()->globalSymbols().toStringTag),
                                              ObjectPropertyDescriptor(state.context()->staticStrings().WebAssemblyDotGlobal.string(), ObjectPropertyDescriptor::ConfigurablePresent));

--- a/tools/test/wasm-js/exclude_list.txt
+++ b/tools/test/wasm-js/exclude_list.txt
@@ -1,7 +1,6 @@
 constructor/instantiate-bad-imports.any.js
 constructor/instantiate.any.js
 constructor/multi-value.any.js
-instance/constructor-bad-imports.any.js
 instance/constructor-caching.any.js
 instance/constructor.any.js
 interface.any.js

--- a/tools/test/wasm-js/exclude_list.txt
+++ b/tools/test/wasm-js/exclude_list.txt
@@ -3,7 +3,6 @@ constructor/instantiate.any.js
 constructor/multi-value.any.js
 instance/constructor-caching.any.js
 instance/constructor.any.js
-interface.any.js
 limits.any.js
 memory/grow.any.js
 module/customSections.any.js


### PR DESCRIPTION
* Append missing constructor property for each WebAssembly constructor's prototype
* Fix error handling in WebAssembly.Instance constructor
* Fix the name of getter/setter methods in WebAssembly objects

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>