### PR TITLE
Fix WebAssembly object caching based on wasm_ref_t comparison

### DIFF
--- a/src/wasm/ExportedFunctionObject.cpp
+++ b/src/wasm/ExportedFunctionObject.cpp
@@ -128,12 +128,16 @@ ExportedFunctionObject* ExportedFunctionObject::createExportedFunction(Execution
 {
     ASSERT(!!funcaddr);
 
+    wasm_ref_t* funcref = wasm_func_as_ref(funcaddr);
+
     // Let map be the surrounding agent's associated Exported Function cache.
     // If map[funcaddr] exists, Return map[funcaddr].
     WASMFunctionMap& map = state.context()->wasmCache()->functionMap;
-    auto mapIter = map.find(funcaddr);
-    if (mapIter != map.end()) {
-        return mapIter->second;
+    for (auto iter = map.begin(); iter != map.end(); iter++) {
+        wasm_ref_t* ref = iter->first;
+        if (wasm_ref_same(funcref, ref)) {
+            return iter->second;
+        }
     }
 
     // Let steps be "call the Exported Function funcaddr with arguments."
@@ -158,7 +162,7 @@ ExportedFunctionObject* ExportedFunctionObject::createExportedFunction(Execution
     // Perform ! SetFunctionName(function, name).
 
     // Set map[funcaddr] to function.
-    map.insert(std::make_pair(funcaddr, function));
+    map.pushBack(std::make_pair(funcref, function));
 
     // Return function.
     return function;

--- a/src/wasm/WASMBuiltinOperations.h
+++ b/src/wasm/WASMBuiltinOperations.h
@@ -500,6 +500,8 @@ static Object* wasmCreateExportsObject(ExecutionState& state, wasm_module_t* mod
     // Perform ! SetIntegrityLevel(exportsObject, "frozen").
     Object::setIntegrityLevel(state, exportsObject, false);
 
+    wasm_exporttype_vec_delete(&export_types);
+
     // Return exportsObject.
     return exportsObject;
 }

--- a/src/wasm/WASMObject.cpp
+++ b/src/wasm/WASMObject.cpp
@@ -155,11 +155,15 @@ WASMMemoryObject* WASMMemoryObject::createMemoryObject(ExecutionState& state, wa
 {
     ASSERT(!!memory);
 
+    wasm_ref_t* memref = wasm_memory_as_ref(memory);
+
     // Let map be the surrounding agent's associated Memory object cache.
     WASMMemoryMap& map = state.context()->wasmCache()->memoryMap;
-    auto mapIter = map.find(memory);
-    if (mapIter != map.end()) {
-        return mapIter->second;
+    for (auto iter = map.begin(); iter != map.end(); iter++) {
+        wasm_ref_t* ref = iter->first;
+        if (wasm_ref_same(memref, ref)) {
+            return iter->second;
+        }
     }
 
     // Let memory be a new Memory.
@@ -176,7 +180,7 @@ WASMMemoryObject* WASMMemoryObject::createMemoryObject(ExecutionState& state, wa
     WASMMemoryObject* memoryObj = new WASMMemoryObject(state, memory, buffer);
 
     // Set map[memory] to memory.
-    map.insert(std::make_pair(memory, memoryObj));
+    map.pushBack(std::make_pair(memref, memoryObj));
 
     //  Return memory.
     return memoryObj;
@@ -229,13 +233,16 @@ WASMTableObject* WASMTableObject::createTableObject(ExecutionState& state, wasm_
 {
     ASSERT(!!tableaddr);
 
+    wasm_ref_t* tableref = wasm_table_as_ref(tableaddr);
+
     // Let map be the surrounding agent's associated Table object cache.
     // If map[tableaddr] exists,
     WASMTableMap& map = state.context()->wasmCache()->tableMap;
-    auto mapIter = map.find(tableaddr);
-    if (mapIter != map.end()) {
-        // Return map[tableaddr].
-        return mapIter->second;
+    for (auto iter = map.begin(); iter != map.end(); iter++) {
+        wasm_ref_t* ref = iter->first;
+        if (wasm_ref_same(tableref, ref)) {
+            return iter->second;
+        }
     }
 
     // Let table be a new Table.
@@ -243,7 +250,7 @@ WASMTableObject* WASMTableObject::createTableObject(ExecutionState& state, wasm_
 
     // Initialize table from tableaddr.
     // Set map[tableaddr] to table.
-    map.insert(std::make_pair(tableaddr, table));
+    map.pushBack(std::make_pair(tableref, table));
 
     // Return table.
     return table;
@@ -284,13 +291,17 @@ WASMGlobalObject* WASMGlobalObject::createGlobalObject(ExecutionState& state, wa
 {
     ASSERT(!!globaladdr);
 
+    wasm_ref_t* globalref = wasm_global_as_ref(globaladdr);
+
     // Let map be the current agent's associated Global object cache.
     // If map[globaladdr] exists,
     WASMGlobalMap& map = state.context()->wasmCache()->globalMap;
-    auto mapIter = map.find(globaladdr);
-    if (mapIter != map.end()) {
-        // Return map[globaladdr].
-        return mapIter->second;
+    for (auto iter = map.begin(); iter != map.end(); iter++) {
+        wasm_ref_t* ref = iter->first;
+        if (wasm_ref_same(globalref, ref)) {
+            // Return map[globaladdr].
+            return iter->second;
+        }
     }
 
     // Let global be a new Global.
@@ -298,7 +309,7 @@ WASMGlobalObject* WASMGlobalObject::createGlobalObject(ExecutionState& state, wa
 
     // Initialize global from globaladdr.
     // Set map[globaladdr] to global.
-    map.insert(std::make_pair(globaladdr, global));
+    map.pushBack(std::make_pair(globalref, global));
 
     // Return global.
     return global;

--- a/src/wasm/WASMObject.h
+++ b/src/wasm/WASMObject.h
@@ -107,7 +107,7 @@ public:
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 
-    static WASMMemoryObject* createMemoryObject(ExecutionState& state, wasm_memory_t* memory);
+    static WASMMemoryObject* createMemoryObject(ExecutionState& state, wasm_memory_t* memaddr);
 
     wasm_memory_t* memory() const
     {
@@ -175,12 +175,13 @@ private:
     wasm_global_t* m_global;
 };
 
-typedef std::unordered_map<void*, WASMMemoryObject*, std::hash<void*>, std::equal_to<void*>, GCUtil::gc_malloc_allocator<std::pair<void* const, WASMMemoryObject*>>> WASMMemoryMap;
-typedef std::unordered_map<void*, WASMTableObject*, std::hash<void*>, std::equal_to<void*>, GCUtil::gc_malloc_allocator<std::pair<void* const, WASMTableObject*>>> WASMTableMap;
-typedef std::unordered_map<void*, WASMGlobalObject*, std::hash<void*>, std::equal_to<void*>, GCUtil::gc_malloc_allocator<std::pair<void* const, WASMGlobalObject*>>> WASMGlobalMap;
+// FIXME change vector structure to hash map (it requires hash value for each wasm_ref_t pointer)
+typedef Vector<std::pair<wasm_ref_t*, WASMMemoryObject*>, GCUtil::gc_malloc_allocator<std::pair<wasm_ref_t*, WASMMemoryObject*>>> WASMMemoryMap;
+typedef Vector<std::pair<wasm_ref_t*, WASMTableObject*>, GCUtil::gc_malloc_allocator<std::pair<wasm_ref_t*, WASMTableObject*>>> WASMTableMap;
+typedef Vector<std::pair<wasm_ref_t*, WASMGlobalObject*>, GCUtil::gc_malloc_allocator<std::pair<wasm_ref_t*, WASMGlobalObject*>>> WASMGlobalMap;
 
 class ExportedFunctionObject;
-typedef std::unordered_map<void*, ExportedFunctionObject*, std::hash<void*>, std::equal_to<void*>, GCUtil::gc_malloc_allocator<std::pair<void* const, ExportedFunctionObject*>>> WASMFunctionMap;
+typedef Vector<std::pair<wasm_ref_t*, ExportedFunctionObject*>, GCUtil::gc_malloc_allocator<std::pair<wasm_ref_t*, ExportedFunctionObject*>>> WASMFunctionMap;
 
 struct WASMCacheMap : public gc {
     WASMMemoryMap memoryMap;

--- a/tools/test/wasm-js/exclude_list.txt
+++ b/tools/test/wasm-js/exclude_list.txt
@@ -1,9 +1,7 @@
 constructor/instantiate-bad-imports.any.js
 constructor/instantiate.any.js
 constructor/multi-value.any.js
-instance/constructor-caching.any.js
 instance/constructor.any.js
 limits.any.js
 memory/grow.any.js
 module/customSections.any.js
-table/get-set.any.js


### PR DESCRIPTION
* each extern pointer(wasm_ref_t*) should be compared by wasm_ref_same
* Vector structure is used instead of HashMap since we cannot calculate hashvalue of wasm_ref_t

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>