### PR TITLE
Fix YarrPattern to correctly reference GC memory

### DIFF
--- a/src/parser/ast/ASTContext.h
+++ b/src/parser/ast/ASTContext.h
@@ -171,8 +171,8 @@ struct ASTBlockContext {
 };
 
 typedef Vector<ASTBlockContext *, GCUtil::gc_malloc_atomic_allocator<ASTBlockContext *>, ComputeReservedCapacityFunctionWithLog2<>> ASTBlockContextVector;
-typedef std::unordered_map<AtomicString, StorePositiveIntergerAsOdd, std::hash<AtomicString>, std::equal_to<AtomicString>,
-                           GCUtil::gc_malloc_allocator<std::pair<AtomicString const, StorePositiveIntergerAsOdd>>>
+typedef std::unordered_map<AtomicString, StorePositiveNumberAsOddNumber, std::hash<AtomicString>, std::equal_to<AtomicString>,
+                           GCUtil::gc_malloc_allocator<std::pair<AtomicString const, StorePositiveNumberAsOddNumber>>>
     FunctionContextVarMap;
 
 

--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -66,7 +66,7 @@ private:
     TightVectorWithNoSize<std::pair<EncodedValue, AtomicString>, GCUtil::gc_malloc_allocator<std::pair<EncodedValue, AtomicString>>> m_parameterMap;
 
     struct ModifiedArguments : public gc {
-        StorePositiveIntergerAsOdd m_argc;
+        StorePositiveNumberAsOddNumber m_argc;
         bool* m_modified;
 
         ModifiedArguments(size_t s)

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -74,7 +74,7 @@ struct ObjectRareData : public PointerValue {
     Object* m_prototype;
     union {
         Object* m_internalSlot;
-        StorePositiveIntergerAsOdd m_arrayObjectFastModeBufferCapacity;
+        StorePositiveNumberAsOddNumber m_arrayObjectFastModeBufferCapacity;
     };
     explicit ObjectRareData(Object* obj);
 

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -61,9 +61,9 @@ inline void* currentStackPointer()
 #error
 #endif
 
-class StorePositiveIntergerAsOdd {
+class StorePositiveNumberAsOddNumber {
 public:
-    StorePositiveIntergerAsOdd(const size_t& src = 0)
+    StorePositiveNumberAsOddNumber(const size_t& src = 0)
     {
         ASSERT(src < std::numeric_limits<size_t>::max() / 2);
         m_data = (src << 1) | 0x1;

--- a/third_party/yarr/YarrPattern.cpp
+++ b/third_party/yarr/YarrPattern.cpp
@@ -700,7 +700,7 @@ public:
                 return;
             }
         }
-        m_pattern.m_namedForwardReferences.add(subpatternName);
+        m_pattern.m_namedForwardReferences.push_back(subpatternName);
         m_alternative->m_terms.append(PatternTerm::ForwardReference());
     }
 

--- a/third_party/yarr/YarrPattern.h
+++ b/third_party/yarr/YarrPattern.h
@@ -380,7 +380,8 @@ struct YarrPattern : public gc {
         m_disjunctions.clear();
         m_userCharacterClasses.clear();
         m_captureGroupNames.clear();
-        m_namedGroupToParenIndex.clear();
+        m_namedForwardReferences.clear();
+        HashMap<String, unsigned>().swap(m_namedGroupToParenIndex);
     }
 
     bool containsIllegalBackReference()
@@ -529,8 +530,8 @@ struct YarrPattern : public gc {
     Vector<std::unique_ptr<PatternDisjunction>, 4> m_disjunctions;
     Vector<std::unique_ptr<CharacterClass>> m_userCharacterClasses;
     ::Escargot::Vector<String, GCUtil::gc_malloc_allocator<String>> m_captureGroupNames;
-    HashMap<String, ::Escargot::StorePositiveIntergerAsOdd, GCUtil::gc_malloc_allocator<std::pair<String const, ::Escargot::StorePositiveIntergerAsOdd>>> m_namedGroupToParenIndex;
-    HashSet<String, GCUtil::gc_malloc_allocator<String>> m_namedForwardReferences;
+    ::Escargot::Vector<String, GCUtil::gc_malloc_allocator<String>> m_namedForwardReferences;
+    HashMap<String, unsigned> m_namedGroupToParenIndex;
 
 private:
     JS_EXPORT_PRIVATE YarrPattern(const String& pattern, RegExpFlags, ErrorCode&, void* stackLimit = nullptr);
@@ -541,7 +542,6 @@ private:
         if (!typeInited) {
             GC_word obj_bitmap[GC_BITMAP_SIZE(YarrPattern)] = { 0 };
             GC_set_bit(obj_bitmap, GC_WORD_OFFSET(YarrPattern, m_captureGroupNames));
-            GC_set_bit(obj_bitmap, GC_WORD_OFFSET(YarrPattern, m_namedGroupToParenIndex));
             GC_set_bit(obj_bitmap, GC_WORD_OFFSET(YarrPattern, m_namedForwardReferences));
             descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(YarrPattern));
             typeInited = true;


### PR DESCRIPTION
* String values in m_namedGroupToParenIndex are referenced by m_captureGroupNames (GC vector)
* m_namedForwardReferences only needs to be allocated as GC vector
* Change the name of StorePositiveIntergerAsOdd

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>