### PR TITLE
Revise BigInt not to hold VMInstance pointer

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -102,14 +102,25 @@ inline AtomicString toImpl(AtomicStringRef* v)
     return AtomicString::fromPayload(reinterpret_cast<void*>(v));
 }
 
+bool Globals::g_globalsInited = false;
 void Globals::initialize()
 {
+    // initialize global value or context
+    // this function should be invoked once at the start of the program
+    RELEASE_ASSERT(!g_globalsInited);
     Heap::initialize();
+    VMInstance::initialize();
+    g_globalsInited = true;
 }
 
 void Globals::finalize()
 {
+    // finalize global value or context
+    // this function should be invoked once at the end of the program
+    RELEASE_ASSERT(!!g_globalsInited);
     Heap::finalize();
+    VMInstance::finalize();
+    g_globalsInited = false;
 }
 
 void* Memory::gcMalloc(size_t siz)
@@ -529,19 +540,19 @@ StringRef* SymbolRef::symbolDescriptiveString()
     return toRef(toImpl(this)->symbolDescriptiveString());
 }
 
-BigIntRef* BigIntRef::create(VMInstanceRef* vmInstance, StringRef* desc)
+BigIntRef* BigIntRef::create(StringRef* desc)
 {
-    return toRef(new BigInt(toImpl(vmInstance), BigIntData(toImpl(vmInstance), toImpl(desc))));
+    return toRef(new BigInt(BigIntData(toImpl(desc))));
 }
 
-BigIntRef* BigIntRef::create(VMInstanceRef* vmInstance, int64_t num)
+BigIntRef* BigIntRef::create(int64_t num)
 {
-    return toRef(new BigInt(toImpl(vmInstance), num));
+    return toRef(new BigInt(num));
 }
 
-BigIntRef* BigIntRef::create(VMInstanceRef* vmInstance, uint64_t num)
+BigIntRef* BigIntRef::create(uint64_t num)
 {
-    return toRef(new BigInt(toImpl(vmInstance), num));
+    return toRef(new BigInt(num));
 }
 
 StringRef* BigIntRef::toString(int radix)

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -97,6 +97,8 @@ class ObjectTemplateRef;
 class FunctionTemplateRef;
 
 class ESCARGOT_EXPORT Globals {
+    static bool g_globalsInited;
+
 public:
     static void initialize();
     static void finalize();
@@ -952,9 +954,9 @@ public:
 
 class ESCARGOT_EXPORT BigIntRef : public PointerValueRef {
 public:
-    static BigIntRef* create(VMInstanceRef* context, StringRef* desc);
-    static BigIntRef* create(VMInstanceRef* vmInstance, int64_t num);
-    static BigIntRef* create(VMInstanceRef* vmInstance, uint64_t num);
+    static BigIntRef* create(StringRef* desc);
+    static BigIntRef* create(int64_t num);
+    static BigIntRef* create(uint64_t num);
 
     StringRef* toString(int radix = 10);
     double toNumber();

--- a/src/heap/Heap.cpp
+++ b/src/heap/Heap.cpp
@@ -26,17 +26,11 @@
 
 namespace Escargot {
 
-static bool g_isInited = false;
-
 void Heap::initialize()
 {
-    if (g_isInited)
-        return;
-
     RELEASE_ASSERT(GC_get_all_interior_pointers() == 0);
 
     GC_set_force_unmap_on_gcollect(1);
-    g_isInited = true;
     initializeCustomAllocators();
 
 #ifdef PROFILE_BDWGC

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -1915,7 +1915,7 @@ ALWAYS_INLINE bool abstractLeftIsLessThanRightNumeric(ExecutionState& state, con
     // If Type(px) is BigInt and Type(py) is String, then
     if (UNLIKELY(lvalIsBigInt && rvalIsString)) {
         // Let ny be StringToBigInt(py).
-        BigIntData ny(state.context()->vmInstance(), rval.asString());
+        BigIntData ny(rval.asString());
         // If ny is NaN, return undefined.
         if (ny.isNaN()) {
             return false;
@@ -1927,7 +1927,7 @@ ALWAYS_INLINE bool abstractLeftIsLessThanRightNumeric(ExecutionState& state, con
     // If Type(px) is String and Type(py) is BigInt, then
     if (UNLIKELY(lvalIsString && rvalIsBigInt)) {
         // Let nx be StringToBigInt(px).
-        BigIntData nx(state.context()->vmInstance(), lval.asString());
+        BigIntData nx(lval.asString());
         // If nx is NaN, return undefined.
         if (nx.isNaN()) {
             return false;
@@ -1952,11 +1952,11 @@ ALWAYS_INLINE bool abstractLeftIsLessThanRightNumeric(ExecutionState& state, con
         if (UNLIKELY(ny.second)) {
             return compBigIntBigInt(nx.first.asBigInt(), ny.first.asBigInt());
         } else {
-            return compBigIntBigIntData(nx.first.asBigInt(), BigIntData(state.context()->vmInstance(), ny.first.asNumber()));
+            return compBigIntBigIntData(nx.first.asBigInt(), BigIntData(ny.first.asNumber()));
         }
     } else {
         if (UNLIKELY(ny.second)) {
-            return compBigIntDataBigInt(BigIntData(state.context()->vmInstance(), nx.first.asNumber()), ny.first.asBigInt());
+            return compBigIntDataBigInt(BigIntData(nx.first.asNumber()), ny.first.asBigInt());
         } else {
             return compDoubleDouble(nx.first.asNumber(), ny.first.asNumber());
         }

--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -543,7 +543,7 @@ std::pair<Value, bool> Scanner::ScannerResult::valueNumberLiteral(Scanner* scann
 
         // bigint case
         if (UNLIKELY(buffer[length - 1] == 'n')) {
-            return std::make_pair(Value(BigInt::parseString(scannerInstance->escargotContext->vmInstance(), buffer, length - 1).value()), true);
+            return std::make_pair(Value(BigInt::parseString(buffer, length - 1).value()), true);
         }
 
         int lengthDummy;

--- a/src/runtime/BigInt.h
+++ b/src/runtime/BigInt.h
@@ -25,15 +25,14 @@
 namespace Escargot {
 
 class BigInt;
-class VMInstance;
 
 class BigIntData {
     friend class BigInt;
 
 public:
-    BigIntData(VMInstance* vmInstance, const double& d);
-    BigIntData(VMInstance* vmInstance, String* src);
-    BigIntData(VMInstance* vmInstance, const char* buf, size_t length, int radix = 10);
+    BigIntData(const double& d);
+    BigIntData(String* src);
+    BigIntData(const char* buf, size_t length, int radix = 10);
     BigIntData(BigIntData&& src);
     BigIntData(const BigIntData& src) = delete;
     BigIntData operator=(const BigIntData& src) = delete;
@@ -48,7 +47,7 @@ public:
     bool isInfinity();
 
 private:
-    void init(VMInstance* vmInstance, const char* buf, size_t length, int radix);
+    void init(const char* buf, size_t length, int radix);
     bf_t m_data;
 };
 
@@ -56,13 +55,13 @@ class BigInt : public PointerValue {
     friend class BigIntData;
 
 public:
-    BigInt(VMInstance* vmInstance, int64_t num);
-    BigInt(VMInstance* vmInstance, uint64_t num);
-    BigInt(VMInstance* vmInstance, BigIntData&& n);
-    BigInt(VMInstance* vmInstance, bf_t num);
+    BigInt(int64_t num);
+    BigInt(uint64_t num);
+    BigInt(BigIntData&& n);
+    BigInt(bf_t num);
 
-    static Optional<BigInt*> parseString(VMInstance* vmInstance, const char* buf, size_t length, int radix = 10);
-    static Optional<BigInt*> parseString(VMInstance* vmInstance, String* str, int radix = 10);
+    static Optional<BigInt*> parseString(const char* buf, size_t length, int radix = 10);
+    static Optional<BigInt*> parseString(String* str, int radix = 10);
 
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
@@ -116,12 +115,11 @@ public:
     }
 
 private:
-    BigInt(VMInstance* vmInstance);
+    BigInt();
 
     void initFinalizer();
 
     size_t m_tag;
-    VMInstance* m_vmInstance;
     bf_t m_bf;
 };
 } // namespace Escargot

--- a/src/runtime/GlobalObject.cpp
+++ b/src/runtime/GlobalObject.cpp
@@ -1166,7 +1166,7 @@ void GlobalObject::installOthers(ExecutionState& state)
     m_numberProxyObject = new NumberObject(state);
     m_booleanProxyObject = new BooleanObject(state);
     m_symbolProxyObject = new SymbolObject(state, state.context()->vmInstance()->globalSymbols().iterator);
-    m_bigIntProxyObject = new BigIntObject(state, new BigInt(state.context()->vmInstance(), UINT64_C(0)));
+    m_bigIntProxyObject = new BigIntObject(state, new BigInt(UINT64_C(0)));
 
     // 8.2.2 - 12
     // AddRestrictedFunctionProperties(funcProto, realmRec).

--- a/src/runtime/GlobalObjectBuiltinBigInt.cpp
+++ b/src/runtime/GlobalObjectBuiltinBigInt.cpp
@@ -46,7 +46,7 @@ static Value builtinBigIntConstructor(ExecutionState& state, Value thisValue, si
             ErrorObject::throwBuiltinError(state, ErrorObject::RangeError, "The value you input to BigInt constructor is not integer");
         }
         // Return the BigInt value that represents the mathematical value of number.
-        return new BigInt(state.context()->vmInstance(), (int64_t)prim.asNumber());
+        return new BigInt((int64_t)prim.asNumber());
     } else {
         // Otherwise, return ? ToBigInt(value).
         return argv[0].toBigInt(state);
@@ -64,15 +64,15 @@ static Value builtinBigIntAsUintN(ExecutionState& state, Value thisValue, size_t
     BigInt* bigint = argv[1].toBigInt(state);
     // Return a BigInt representing bigint modulo 2bits.
     bf_t mask, r;
-    bf_init(state.context()->vmInstance()->bfContext(), &mask);
-    bf_init(state.context()->vmInstance()->bfContext(), &r);
+    bf_init(VMInstance::bfContext(), &mask);
+    bf_init(VMInstance::bfContext(), &r);
     bf_set_ui(&mask, 1);
     bf_mul_2exp(&mask, bits, BF_PREC_INF, BF_RNDZ);
     bf_add_si(&mask, &mask, -1, BF_PREC_INF, BF_RNDZ);
     bf_logic_and(&r, bigint->bf(), &mask);
     bf_delete(&mask);
 
-    return new BigInt(state.context()->vmInstance(), r);
+    return new BigInt(r);
 }
 
 static Value builtinBigIntAsIntN(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
@@ -86,8 +86,8 @@ static Value builtinBigIntAsIntN(ExecutionState& state, Value thisValue, size_t 
     BigInt* bigint = argv[1].toBigInt(state);
     // Return a BigInt representing bigint modulo 2bits.
     bf_t mask, r;
-    bf_init(state.context()->vmInstance()->bfContext(), &mask);
-    bf_init(state.context()->vmInstance()->bfContext(), &r);
+    bf_init(VMInstance::bfContext(), &mask);
+    bf_init(VMInstance::bfContext(), &r);
     bf_set_ui(&mask, 1);
     bf_mul_2exp(&mask, bits, BF_PREC_INF, BF_RNDZ);
     bf_add_si(&mask, &mask, -1, BF_PREC_INF, BF_RNDZ);
@@ -103,7 +103,7 @@ static Value builtinBigIntAsIntN(ExecutionState& state, Value thisValue, size_t 
     }
     bf_delete(&mask);
 
-    return new BigInt(state.context()->vmInstance(), r);
+    return new BigInt(r);
 }
 
 // The abstract operation thisBigIntValue(value) performs the following steps:

--- a/src/runtime/TypedArrayInlines.h
+++ b/src/runtime/TypedArrayInlines.h
@@ -191,9 +191,9 @@ struct TypedArrayHelper {
         case TypedArrayType::Float64:
             return Value(*reinterpret_cast<Float64Adaptor::Type*>(rawBytes));
         case TypedArrayType::BigInt64:
-            return Value(new BigInt(state.context()->vmInstance(), *reinterpret_cast<BigInt64Adaptor::Type*>(rawBytes)));
+            return Value(new BigInt(*reinterpret_cast<BigInt64Adaptor::Type*>(rawBytes)));
         case TypedArrayType::BigUint64:
-            return Value(new BigInt(state.context()->vmInstance(), *reinterpret_cast<BigUint64Adaptor::Type*>(rawBytes)));
+            return Value(new BigInt(*reinterpret_cast<BigUint64Adaptor::Type*>(rawBytes)));
         default:
             RELEASE_ASSERT_NOT_REACHED();
             return Value();

--- a/src/runtime/TypedArrayObject.cpp
+++ b/src/runtime/TypedArrayObject.cpp
@@ -215,9 +215,9 @@ bool TypedArrayObject::integerIndexedElementSet(ExecutionState& state, double in
             }                                                                                                                                   \
         }                                                                                                                                       \
         if (std::is_same<int64_t, nativeType>::value) {                                                                                         \
-            return Value(new BigInt(state.context()->vmInstance(), (int64_t)res));                                                              \
+            return Value(new BigInt((int64_t)res));                                                                                             \
         } else if (std::is_same<uint64_t, nativeType>::value) {                                                                                 \
-            return Value(new BigInt(state.context()->vmInstance(), (uint64_t)res));                                                             \
+            return Value(new BigInt((uint64_t)res));                                                                                            \
         }                                                                                                                                       \
         return Value(res);                                                                                                                      \
     }                                                                                                                                           \

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -90,12 +90,19 @@ class VMInstance : public gc {
     friend class ScriptParser;
     friend class SandBox;
 
+    // global values which should be initialized once and shared during the runtime
+    static bf_context_t g_bfContext;
+
 public:
     VMInstance(Platform* platform, const char* locale = nullptr, const char* timezone = nullptr);
     ~VMInstance();
 
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
+
+    static void initialize();
+    static void finalize();
+    static bf_context_t* bfContext();
 
     void enterIdleMode();
     void clearCachesRelatedWithContext();
@@ -267,11 +274,6 @@ public:
     }
 #endif
 
-    bf_context_t* bfContext()
-    {
-        return &m_bfContext;
-    }
-
 private:
     StaticStrings m_staticStrings;
     AtomicStringMap m_atomicStringMap;
@@ -358,8 +360,6 @@ private:
 #if defined(ENABLE_WASM)
     GlobalWASMData m_wasmData;
 #endif
-
-    bf_context_t m_bfContext;
 };
 } // namespace Escargot
 

--- a/src/runtime/Value.cpp
+++ b/src/runtime/Value.cpp
@@ -150,14 +150,14 @@ BigInt* Value::toBigInt(ExecutionState& state) const
     if (prim.isBigInt()) {
         return prim.asBigInt();
     } else if (prim.isBoolean()) {
-        return new BigInt(state.context()->vmInstance(), prim.asBoolean() ? (uint64_t)1 : (uint64_t)0);
+        return new BigInt(prim.asBoolean() ? (uint64_t)1 : (uint64_t)0);
     } else if (prim.isString()) {
         // Let n be ! StringToBigInt(prim).
         // If n is NaN, throw a SyntaxError exception.
         // Return n.
-        auto b = BigInt::parseString(state.context()->vmInstance(), prim.asString()->trim());
+        auto b = BigInt::parseString(prim.asString()->trim());
         if (!b) {
-            b = BigInt::parseString(state.context()->vmInstance(), prim.asString()->trim());
+            b = BigInt::parseString(prim.asString()->trim());
             ErrorObject::throwBuiltinError(state, ErrorObject::Code::SyntaxError, "Cannot parse String as BigInt");
         }
         return b.value();
@@ -300,7 +300,7 @@ bool Value::abstractEqualsToSlowCase(ExecutionState& state, const Value& val) co
         } else if (UNLIKELY(selfIsBigInt && valIsString)) {
             // If Type(x) is BigInt and Type(y) is String, then
             // Let n be StringToBigInt(y).
-            BigIntData a(state.context()->vmInstance(), val.asString());
+            BigIntData a(val.asString());
             // If n is NaN, return false.
             if (a.isNaN()) {
                 return false;

--- a/src/wasm/WASMValueConverter.cpp
+++ b/src/wasm/WASMValueConverter.cpp
@@ -70,7 +70,7 @@ Value WASMValueConverter::wasmToJSValue(ExecutionState& state, const wasm_val_t&
         break;
     }
     case WASM_I64: {
-        result = new BigInt(state.context()->vmInstance(), value.of.i64);
+        result = new BigInt(value.of.i64);
         break;
     }
     default: {


### PR DESCRIPTION
* bf_context_t is now defined as a global variable and maintained during the runtime
* VMInstance::finalize is invoked at the end of program to guarantee the life time of bf_context_t

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>