### PR TITLE
Revise Jump bytecode and JumpFlowRecord for CodeCache

### DIFF
--- a/src/codecache/CodeCache.cpp
+++ b/src/codecache/CodeCache.cpp
@@ -92,6 +92,10 @@ void CodeCache::initialize(const char* baseCacheDir)
     m_cacheReader = new CodeCacheReader();
     m_enabled = true;
     m_status = Status::READY;
+
+#ifndef NDEBUG
+    ESCARGOT_LOG_INFO("[CodeCache] initialization done on cache directory: %s\n", m_cacheDirPath.data());
+#endif
 }
 
 bool CodeCache::tryInitCacheDir()
@@ -616,8 +620,12 @@ InterpretedCodeBlock* CodeCache::loadCodeBlockTree(Context* context, Script* scr
     // clear
     tempCodeBlockMap.clear();
     m_cacheReader->clearBuffer();
-
     ASSERT(topCodeBlock->isGlobalCodeBlock());
+
+#ifndef NDEBUG
+    ESCARGOT_LOG_INFO("[CodeCache] loading CodeBlock tree done\n");
+#endif
+
     // return topCodeBlock
     return topCodeBlock;
 }

--- a/src/codecache/CodeCacheReaderWriter.h
+++ b/src/codecache/CodeCacheReaderWriter.h
@@ -38,7 +38,6 @@ enum class ByteCodeRelocType : uint8_t {
     RELOC_STRING,
     RELOC_ATOMICSTRING,
     RELOC_CODEBLOCK,
-    RELOC_CONTROLFLOWRECORD,
     RELOC_BLOCKINFO,
 };
 

--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -108,6 +108,7 @@ ByteCodeBlock::ByteCodeBlock(InterpretedCodeBlock* codeBlock)
 
         self->m_code.clear();
         self->m_numeralLiteralData.clear();
+        self->m_jumpFlowRecordData.clear();
 
         if (!self->m_isOwnerMayFreed) {
             auto& v = self->m_codeBlock->context()->vmInstance()->compiledByteCodeBlocks();

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -87,9 +87,9 @@ void ByteCodeGenerateContext::morphJumpPositionIntoComplexCase(ByteCodeBlock* cb
 {
     auto iter = m_complexCaseStatementPositions.find(codePos);
     if (iter != m_complexCaseStatementPositions.end()) {
-        ControlFlowRecord* r = new ControlFlowRecord(ControlFlowRecord::ControlFlowReason::NeedsJump, (cb->peekCode<Jump>(codePos)->m_jumpPosition), iter->second, outerLimitCount);
-        m_byteCodeBlock->m_otherLiteralData.pushBack(r);
-        new (cb->m_code.data() + codePos) JumpComplexCase(r);
+        size_t index = m_byteCodeBlock->m_jumpFlowRecordData.size();
+        m_byteCodeBlock->m_jumpFlowRecordData.pushBack(JumpFlowRecord((cb->peekCode<Jump>(codePos)->m_jumpPosition), iter->second, outerLimitCount));
+        new (cb->m_code.data() + codePos) JumpComplexCase(index);
         m_complexCaseStatementPositions.erase(iter);
     }
 }

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -1115,7 +1115,7 @@ Value ByteCodeInterpreter::interpret(ExecutionState* state, ByteCodeBlock* byteC
             :
         {
             JumpComplexCase* code = (JumpComplexCase*)programCounter;
-            state->ensureRareData()->m_controlFlowRecord->back() = code->m_controlFlowRecord->clone();
+            state->ensureRareData()->m_controlFlowRecord->back() = byteCodeBlock->m_jumpFlowRecordData[code->m_recordIndex].createControlFlowRecord();
             return Value();
         }
 

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -268,9 +268,9 @@ ScriptParser::InitializeScriptResult ScriptParser::initializeScript(String* sour
                 ASSERT(!!topCodeBlock && !!topByteBlock);
                 script->m_topCodeBlock = topCodeBlock;
                 topCodeBlock->m_byteCodeBlock = topByteBlock;
-#ifndef NDEBUG
+
                 ESCARGOT_LOG_INFO("CODECACHE: Load CodeCache Done (%s)\n", srcName->toUTF8StringData().data());
-#endif
+
                 ScriptParser::InitializeScriptResult result;
                 result.script = script;
                 return result;
@@ -339,9 +339,8 @@ ScriptParser::InitializeScriptResult ScriptParser::initializeScript(String* sour
                 topCodeBlock->m_byteCodeBlock = ByteCodeGenerator::generateByteCode(m_context, topCodeBlock, programNode, inWith, true);
 
                 codeCache->postCacheWriting(srcHash);
-#ifndef NDEBUG
+
                 ESCARGOT_LOG_INFO("CODECACHE: Store CodeCache Done (%s)\n", srcName->toUTF8StringData().data());
-#endif
             } else {
                 topCodeBlock->m_byteCodeBlock = ByteCodeGenerator::generateByteCode(m_context, topCodeBlock, programNode, inWith, false);
             }

--- a/src/parser/ast/ForStatementNode.h
+++ b/src/parser/ast/ForStatementNode.h
@@ -203,7 +203,7 @@ public:
 
         size_t forEnd = codeBlock->currentCodeSize();
         if (m_test) {
-            codeBlock->peekCode<JumpByteCode>(testPos)->m_jumpPosition = forEnd;
+            codeBlock->peekCode<Jump>(testPos)->m_jumpPosition = forEnd;
         }
 
         if (m_iterationLexicalBlockIndex != LEXICAL_BLOCK_INDEX_MAX) {

--- a/src/parser/ast/IfStatementNode.h
+++ b/src/parser/ast/IfStatementNode.h
@@ -68,7 +68,7 @@ public:
             codeBlock->pushCode(Jump(ByteCodeLOC(m_loc.index)), context, this);
             jPos2 = codeBlock->lastCodePosition<Jump>();
         }
-        codeBlock->peekCode<JumpByteCode>(jPos)->m_jumpPosition = codeBlock->currentCodeSize();
+        codeBlock->peekCode<Jump>(jPos)->m_jumpPosition = codeBlock->currentCodeSize();
 
         if (m_alternate) {
             m_alternate->generateStatementByteCode(codeBlock, context);

--- a/src/parser/ast/WhileStatementNode.h
+++ b/src/parser/ast/WhileStatementNode.h
@@ -84,7 +84,7 @@ public:
         size_t whileEnd = codeBlock->currentCodeSize();
         newContext.consumeBreakPositions(codeBlock, whileEnd, context->tryCatchWithBlockStatementCount());
         if (testPos != SIZE_MAX)
-            codeBlock->peekCode<JumpByteCode>(testPos)->m_jumpPosition = whileEnd;
+            codeBlock->peekCode<Jump>(testPos)->m_jumpPosition = whileEnd;
         newContext.m_positionToContinue = context->m_positionToContinue;
         newContext.propagateInformationTo(*context);
     }

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -510,8 +510,9 @@ VMInstance::VMInstance(Platform* platform, const char* locale, const char* timez
     m_jobQueue = new JobQueue();
 
 #if defined(ENABLE_CODE_CACHE)
-    if (!baseCacheDir || strlen(baseCacheDir) == 0) {
-        baseCacheDir = getenv("HOME");
+    if (UNLIKELY(!baseCacheDir || strlen(baseCacheDir) == 0)) {
+        const char* homeDir = getenv("HOME");
+        baseCacheDir = (!homeDir || strlen(homeDir) == 0) ? "/tmp" : homeDir;
     }
     m_codeCache = new CodeCache(baseCacheDir);
 #endif


### PR DESCRIPTION
* remove JumpByteCode and add JumpFlowRecord which has no pointer value
* simplify JumpFlowRecord data caching
* fix coverity issue
* add log message for code cache

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>