### PR TITLE
Handle tagged template literal in CodeCache

### DIFF
--- a/src/parser/ASTBuilder.h
+++ b/src/parser/ASTBuilder.h
@@ -851,7 +851,11 @@ public:
             Value value;
             if ((*templateLiteralNode->quasis())[i]->value) {
                 UTF16StringData& sd = (*templateLiteralNode->quasis())[i]->value.value();
-                value = new UTF16String(std::move(sd));
+                if (sd.size()) {
+                    value = new UTF16String(std::move(sd));
+                } else {
+                    value = String::emptyString;
+                }
             }
 
             elements.append(m_allocator, new (m_allocator) LiteralNode(value));
@@ -860,10 +864,15 @@ public:
         ArrayExpressionNode* arrayExpressionForRaw = nullptr;
         {
             NodeList elements;
+            Value value;
             for (size_t i = 0; i < templateLiteralNode->quasis()->size(); i++) {
                 UTF16StringData& sd = (*templateLiteralNode->quasis())[i]->valueRaw;
-                String* str = new UTF16String(std::move(sd));
-                elements.append(m_allocator, new (m_allocator) LiteralNode(Value(str)));
+                if (sd.size()) {
+                    value = new UTF16String(std::move(sd));
+                } else {
+                    value = String::emptyString;
+                }
+                elements.append(m_allocator, new (m_allocator) LiteralNode(value));
             }
             arrayExpressionForRaw = new (m_allocator) ArrayExpressionNode(elements);
         }

--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -1879,6 +1879,10 @@ String* Scanner::scanRegExpFlags()
         }
     }
 
+    if (!flags.length()) {
+        return String::emptyString;
+    }
+
     if (isAllASCII(flags.data(), flags.length())) {
         return new ASCIIString(flags.data(), flags.length());
     }

--- a/src/parser/ast/LiteralNode.h
+++ b/src/parser/ast/LiteralNode.h
@@ -42,7 +42,12 @@ public:
     {
         if (m_value.isPointerValue()) {
             if (LIKELY(m_value.asPointerValue()->isString())) {
-                codeBlock->m_stringLiteralData.pushBack(m_value.asPointerValue()->asString());
+                if (LIKELY(m_value.asPointerValue()->asString()->length())) {
+                    codeBlock->m_stringLiteralData.pushBack(m_value.asPointerValue()->asString());
+                } else {
+                    // change the value as empty string
+                    m_value = String::emptyString;
+                }
             } else {
                 ASSERT(m_value.asPointerValue()->isBigInt());
                 codeBlock->m_otherLiteralData.pushBack(m_value.asPointerValue()->asBigInt());

--- a/src/parser/ast/RegExpLiteralNode.h
+++ b/src/parser/ast/RegExpLiteralNode.h
@@ -39,8 +39,12 @@ public:
     String* flag() { return m_flag; }
     virtual void generateExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister) override
     {
+        // body string should not be empty string
+        ASSERT(m_body->length());
         codeBlock->m_stringLiteralData.pushBack(m_body);
-        codeBlock->m_stringLiteralData.pushBack(m_flag);
+        if (m_flag->length()) {
+            codeBlock->m_stringLiteralData.pushBack(m_flag);
+        }
         codeBlock->pushCode(LoadRegExp(ByteCodeLOC(m_loc.index), dstRegister, m_body, m_flag), context, this);
     }
 

--- a/src/parser/ast/TemplateLiteralNode.h
+++ b/src/parser/ast/TemplateLiteralNode.h
@@ -57,9 +57,14 @@ public:
         ASSERT(m_expressions.size() + 1 == m_quasis->size());
         Value value;
         if ((*m_quasis)[0]->value) {
-            String* str = new UTF16String(std::move((*m_quasis)[0]->value.value()));
-            codeBlock->m_stringLiteralData.push_back(str);
-            value = str;
+            UTF16StringData& sd = (*m_quasis)[0]->value.value();
+            if (sd.size()) {
+                String* str = new UTF16String(std::move((*m_quasis)[0]->value.value()));
+                codeBlock->m_stringLiteralData.push_back(str);
+                value = str;
+            } else {
+                value = String::emptyString;
+            }
         }
         codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), dstRegister, value), context, this);
 
@@ -71,8 +76,9 @@ public:
             context->giveUpRegister();
 
             if ((*m_quasis)[index + 1]->value) {
-                String* str = new UTF16String(std::move((*m_quasis)[index + 1]->value.value()));
-                if (str->length()) {
+                UTF16StringData& sd = (*m_quasis)[index + 1]->value.value();
+                if (sd.size()) {
+                    String* str = new UTF16String(std::move(sd));
                     codeBlock->m_stringLiteralData.push_back(str);
                     size_t reg = context->getRegister();
                     codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), reg, Value(str)), context, this);


### PR DESCRIPTION
* add relocation case for freeze function address
* remove empty strings from ByteCode and  ByteCodeBlock literal list

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>