### PR TITLE
Refactor GC allocation with bitmap info

### DIFF
--- a/src/runtime/ArgumentsObject.cpp
+++ b/src/runtime/ArgumentsObject.cpp
@@ -53,9 +53,7 @@ void* ArgumentsObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(ArgumentsObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArgumentsObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArgumentsObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArgumentsObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArgumentsObject, m_targetRecord));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArgumentsObject, m_sourceFunctionObject));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArgumentsObject, m_parameterMap));

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -611,9 +611,7 @@ void* ArrayIteratorObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(ArrayIteratorObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArrayIteratorObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArrayIteratorObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArrayIteratorObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArrayIteratorObject, m_array));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(ArrayIteratorObject));
         typeInited = true;

--- a/src/runtime/BigInt.cpp
+++ b/src/runtime/BigInt.cpp
@@ -140,14 +140,7 @@ bool BigIntData::isInfinity()
 
 void* BigInt::operator new(size_t size)
 {
-    static bool typeInited = false;
-    static GC_descr descr;
-    if (!typeInited) {
-        GC_word obj_bitmap[GC_BITMAP_SIZE(BigInt)] = { 0 };
-        descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(BigInt));
-        typeInited = true;
-    }
-    return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
+    return GC_MALLOC_ATOMIC(size);
 }
 
 void BigInt::initFinalizer()

--- a/src/runtime/BooleanObject.cpp
+++ b/src/runtime/BooleanObject.cpp
@@ -40,9 +40,7 @@ void* BooleanObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(BooleanObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(BooleanObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(BooleanObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(BooleanObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(BooleanObject));
         typeInited = true;
     }

--- a/src/runtime/DateObject.cpp
+++ b/src/runtime/DateObject.cpp
@@ -1418,7 +1418,7 @@ void* DateObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(DateObject)] = { 0 };
-        DateObject::fillGCDescriptor(obj_bitmap);
+        Object::fillGCDescriptor(obj_bitmap);
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(DateObject));
         typeInited = true;
     }

--- a/src/runtime/DateObject.h
+++ b/src/runtime/DateObject.h
@@ -123,11 +123,6 @@ public:
     void* operator new[](size_t size) = delete;
 
 protected:
-    static inline void fillGCDescriptor(GC_word* desc)
-    {
-        Object::fillGCDescriptor(desc);
-    }
-
     struct timeinfo {
         timeinfo()
             : year(0)

--- a/src/runtime/MapObject.cpp
+++ b/src/runtime/MapObject.cpp
@@ -40,9 +40,7 @@ void* MapObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(MapObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(MapObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(MapObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(MapObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(MapObject, m_storage));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(MapObject));
         typeInited = true;
@@ -163,9 +161,7 @@ void* MapIteratorObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(MapIteratorObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(MapIteratorObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(MapIteratorObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(MapIteratorObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(MapIteratorObject, m_map));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(MapIteratorObject));
         typeInited = true;

--- a/src/runtime/NumberObject.cpp
+++ b/src/runtime/NumberObject.cpp
@@ -43,9 +43,7 @@ void* NumberObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(NumberObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(NumberObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(NumberObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(NumberObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(NumberObject));
         typeInited = true;
     }

--- a/src/runtime/ObjectTemplate.cpp
+++ b/src/runtime/ObjectTemplate.cpp
@@ -35,7 +35,7 @@ void* ObjectTemplate::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word objBitmap[GC_BITMAP_SIZE(ObjectTemplate)] = { 0 };
-        ObjectTemplate::fillGCDescriptor(objBitmap);
+        Template::fillGCDescriptor(objBitmap);
         GC_set_bit(objBitmap, GC_WORD_OFFSET(ObjectTemplate, m_constructor));
         GC_set_bit(objBitmap, GC_WORD_OFFSET(ObjectTemplate, m_namedPropertyHandler));
         descr = GC_make_descriptor(objBitmap, GC_WORD_LEN(ObjectTemplate));

--- a/src/runtime/PromiseObject.cpp
+++ b/src/runtime/PromiseObject.cpp
@@ -52,7 +52,7 @@ void* PromiseObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word desc[GC_BITMAP_SIZE(PromiseObject)] = { 0 };
-        PromiseObject::fillGCDescriptor(desc);
+        fillGCDescriptor(desc);
         descr = GC_make_descriptor(desc, GC_WORD_LEN(PromiseObject));
         typeInited = true;
     }

--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -85,9 +85,7 @@ void* RegExpObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(RegExpObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(RegExpObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(RegExpObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(RegExpObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(RegExpObject, m_source));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(RegExpObject, m_optionString));
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(RegExpObject, m_yarrPattern));

--- a/src/runtime/SetObject.cpp
+++ b/src/runtime/SetObject.cpp
@@ -40,9 +40,7 @@ void* SetObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(SetObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SetObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SetObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SetObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SetObject, m_storage));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(SetObject));
         typeInited = true;
@@ -148,9 +146,7 @@ void* SetIteratorObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(SetIteratorObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SetIteratorObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SetIteratorObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SetIteratorObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SetIteratorObject, m_set));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(SetIteratorObject));
         typeInited = true;

--- a/src/runtime/StringObject.cpp
+++ b/src/runtime/StringObject.cpp
@@ -42,9 +42,7 @@ void* StringObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(StringObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringObject, m_primitiveValue));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(StringObject));
         typeInited = true;
@@ -141,9 +139,7 @@ void* StringIteratorObject::operator new(size_t size)
     static GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(StringIteratorObject)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringIteratorObject, m_structure));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringIteratorObject, m_prototype));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringIteratorObject, m_values));
+        Object::fillGCDescriptor(obj_bitmap);
         GC_set_bit(obj_bitmap, GC_WORD_OFFSET(StringIteratorObject, m_string));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(StringIteratorObject));
         typeInited = true;


### PR DESCRIPTION
* replace each Object's member marking with Object::fillGCDescriptor
* BigInt allocation is fixed to be handled by simple GC_MALLOC_ATOMIC call

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>