### PR TITLE
Add RegExpObjectRef::create() in public API

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -2714,6 +2714,11 @@ RegExpObjectRef* RegExpObjectRef::create(ExecutionStateRef* state, ValueRef* sou
     return toRef(new RegExpObject(*toImpl(state), toImpl(source).toString(*toImpl(state)), toImpl(option).toString(*toImpl(state))));
 }
 
+RegExpObjectRef* RegExpObjectRef::create(ExecutionStateRef* state, ValueRef* source, RegExpObjectOption option)
+{
+    return toRef(new RegExpObject(*toImpl(state), toImpl(source).toString(*toImpl(state)), option));
+}
+
 StringRef* RegExpObjectRef::source()
 {
     return toRef(toImpl(this)->source());

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -1418,6 +1418,8 @@ public:
     };
 
     static RegExpObjectRef* create(ExecutionStateRef* state, ValueRef* source, ValueRef* option);
+    static RegExpObjectRef* create(ExecutionStateRef* state, ValueRef* source, RegExpObjectOption option = None);
+
     StringRef* source();
     RegExpObjectOption option();
 };

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -94,7 +94,6 @@ public:
     RegExpObject(ExecutionState& state, Object* proto, String* source, unsigned int option);
 
     void init(ExecutionState& state, String* source, String* option = String::emptyString);
-    void initWithOption(ExecutionState& state, String* source, Option option);
 
     uint64_t computedLastIndex(ExecutionState& state)
     {
@@ -171,11 +170,11 @@ protected:
 
 private:
     void setOption(const Option& option);
-    void internalInit(ExecutionState& state, String* source, String* options = String::emptyString);
+    void internalInit(ExecutionState& state, String* source, Option option = None);
 
     static RegExpCacheEntry& getCacheEntryAndCompileIfNeeded(ExecutionState& state, String* source, const Option& option);
 
-    void parseOption(ExecutionState& state, String* optionString);
+    Option parseOption(ExecutionState& state, String* optionString);
 
     String* m_source;
     String* m_optionString;

--- a/test/cctest/testapi.cpp
+++ b/test/cctest/testapi.cpp
@@ -875,3 +875,45 @@ TEST(ObjectPropertyDescriptor, Basic1) {
         EXPECT_FALSE(desc.isWritable());
     }
 }
+
+TEST(RegExp, Basic1)
+{
+    Evaluator::execute(g_context.get(), [](ExecutionStateRef* state) -> ValueRef* {
+        auto re = RegExpObjectRef::create(state, StringRef::createFromASCII("foo"),
+                                          RegExpObjectRef::RegExpObjectOption::None);
+        EXPECT_TRUE(re->isRegExpObject());
+        EXPECT_TRUE(re->source()->equals(StringRef::createFromASCII("foo")));
+        EXPECT_TRUE(re->option() == RegExpObjectRef::RegExpObjectOption::None);
+
+        re = RegExpObjectRef::create(state, StringRef::createFromASCII("bar"),
+                                     (RegExpObjectRef::RegExpObjectOption)(RegExpObjectRef::RegExpObjectOption::IgnoreCase | RegExpObjectRef::RegExpObjectOption::Global));
+        EXPECT_TRUE(re->isRegExpObject());
+        EXPECT_TRUE(re->source()->equals(StringRef::createFromASCII("bar")));
+        EXPECT_TRUE(re->option() == (RegExpObjectRef::RegExpObjectOption)(RegExpObjectRef::RegExpObjectOption::IgnoreCase | RegExpObjectRef::RegExpObjectOption::Global));
+
+        re = RegExpObjectRef::create(state, StringRef::createFromASCII("baz"),
+                                     (RegExpObjectRef::RegExpObjectOption)(RegExpObjectRef::RegExpObjectOption::IgnoreCase | RegExpObjectRef::RegExpObjectOption::MultiLine));
+        EXPECT_TRUE(re->isRegExpObject());
+        EXPECT_TRUE(re->source()->equals(StringRef::createFromASCII("baz")));
+        EXPECT_TRUE(re->option() == (RegExpObjectRef::RegExpObjectOption)(RegExpObjectRef::RegExpObjectOption::IgnoreCase | RegExpObjectRef::RegExpObjectOption::MultiLine));
+
+        re = RegExpObjectRef::create(state, StringRef::createFromASCII("baz"),
+                                     (RegExpObjectRef::RegExpObjectOption)(RegExpObjectRef::RegExpObjectOption::Unicode | RegExpObjectRef::RegExpObjectOption::Sticky));
+        EXPECT_TRUE(re->isRegExpObject());
+        EXPECT_TRUE(re->source()->equals(StringRef::createFromASCII("baz")));
+        EXPECT_TRUE(re->option() == (RegExpObjectRef::RegExpObjectOption)(RegExpObjectRef::RegExpObjectOption::Unicode | RegExpObjectRef::RegExpObjectOption::Sticky));
+
+        re = RegExpObjectRef::create(state, StringRef::createFromASCII("foobar"), RegExpObjectRef::RegExpObjectOption::None);
+        EXPECT_TRUE(re->isRegExpObject());
+        EXPECT_TRUE(re->source()->equals(StringRef::createFromASCII("foobar")));
+        EXPECT_TRUE(re->option() == RegExpObjectRef::RegExpObjectOption::None);
+
+        re = RegExpObjectRef::create(state, StringRef::createFromASCII("foobarbaz"),
+                                     (RegExpObjectRef::RegExpObjectOption)(RegExpObjectRef::RegExpObjectOption::IgnoreCase | RegExpObjectRef::RegExpObjectOption::MultiLine));
+        EXPECT_TRUE(re->isRegExpObject());
+        EXPECT_TRUE(re->source()->equals(StringRef::createFromASCII("foobarbaz")));
+        EXPECT_TRUE(re->option() == (RegExpObjectRef::RegExpObjectOption)(RegExpObjectRef::RegExpObjectOption::IgnoreCase | RegExpObjectRef::RegExpObjectOption::MultiLine));
+
+        return ValueRef::createUndefined();
+    });
+}


### PR DESCRIPTION
* Make create() to accept options in enum

Signed-off-by: Ryan Choi <ryan.choi@samsung.com>