### PR TITLE
Update ObjectRef::enumerateObjectOwnProperties api

### DIFF
--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -737,7 +737,7 @@ public:
     bool asBoolean();
     double asNumber();
     int32_t asInt32();
-    uint32_t asUint32();
+    uint32_t asUInt32();
     PointerValueRef* asPointerValue();
 
 #define DEFINE_VALUEREF_IS_AS(Name) \
@@ -765,6 +765,7 @@ public:
 
     enum : uint32_t { InvalidArrayIndexValue = std::numeric_limits<uint32_t>::max() };
     uint32_t toArrayIndex(ExecutionStateRef* state);
+    uint32_t tryToUseAsArrayIndex(ExecutionStateRef* state);
 
     bool abstractEqualsTo(ExecutionStateRef* state, const ValueRef* other) const; // ==
     bool equalsTo(ExecutionStateRef* state, const ValueRef* other) const; // ===
@@ -1141,7 +1142,7 @@ public:
 
     ValueVectorRef* ownPropertyKeys(ExecutionStateRef* state);
 
-    void enumerateObjectOwnProperies(ExecutionStateRef* state, const std::function<bool(ExecutionStateRef* state, ValueRef* propertyName, bool isWritable, bool isEnumerable, bool isConfigurable)>& cb);
+    void enumerateObjectOwnProperties(ExecutionStateRef* state, const std::function<bool(ExecutionStateRef* state, ValueRef* propertyName, bool isWritable, bool isEnumerable, bool isConfigurable)>& cb, bool shouldSkipSymbolKey = true);
 
     // get `length` property like ToLength(Get(obj, "length"))
     // it returns 0 for exceptional cases (e.g. undefined, nan)

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -97,7 +97,7 @@ ArrayObject* ArrayObject::createSpreadArray(ExecutionState& state)
     return spreadArray;
 }
 
-ObjectHasPropertyResult ArrayObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+ObjectHasPropertyResult ArrayObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     ObjectGetResult v = getVirtualValue(state, P);
     if (LIKELY(v.hasValue())) {
@@ -108,7 +108,7 @@ ObjectHasPropertyResult ArrayObject::hasProperty(ExecutionState& state, const Ob
 }
 
 
-ObjectGetResult ArrayObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+ObjectGetResult ArrayObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     ObjectGetResult v = getVirtualValue(state, P);
     if (LIKELY(v.hasValue())) {
@@ -118,7 +118,7 @@ ObjectGetResult ArrayObject::getOwnProperty(ExecutionState& state, const ObjectP
     }
 }
 
-bool ArrayObject::defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+bool ArrayObject::defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc)
 {
     if (!P.isUIntType() && P.objectStructurePropertyName() == state.context()->staticStrings().length) {
         // Let newLen be ToUint32(Desc.[[Value]]).
@@ -217,7 +217,7 @@ NonFastPath:
     return Object::defineOwnProperty(state, P, desc);
 }
 
-bool ArrayObject::deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+bool ArrayObject::deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     if (!P.isUIntType() && P.toObjectStructurePropertyName(state) == state.context()->staticStrings().length) {
         return false;
@@ -240,7 +240,7 @@ bool ArrayObject::deleteOwnProperty(ExecutionState& state, const ObjectPropertyN
     return Object::deleteOwnProperty(state, P);
 }
 
-void ArrayObject::enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+void ArrayObject::enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey)
 {
     if (LIKELY(isFastModeArray())) {
         size_t len = arrayLength(state);

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -55,17 +55,17 @@ public:
         return false;
     }
 
-    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
-    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
-    virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) override;
+    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
+    virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) override;
     void defineOwnPropertyThrowsException(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc)
     {
         if (!ArrayObject::defineOwnProperty(state, P, desc)) {
             throwCannotDefineError(state, P.toObjectStructurePropertyName(state));
         }
     }
-    virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
-    virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
+    virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
+    virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) override;
     virtual void sort(ExecutionState& state, int64_t length, const std::function<bool(const Value& a, const Value& b)>& comp) override;
     virtual ObjectGetResult getIndexedProperty(ExecutionState& state, const Value& property, const Value& receiver) override;
     virtual ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override;

--- a/src/runtime/EncodedValue.h
+++ b/src/runtime/EncodedValue.h
@@ -237,6 +237,8 @@ public:
 
     bool isUInt32()
     {
+        // Note. use only 31 bits to represent unsigned integer value.
+        // Its because we just store signed integer value.
         return isInt32() && asInt32() >= 0;
     }
 

--- a/src/runtime/EncodedValue.h
+++ b/src/runtime/EncodedValue.h
@@ -235,21 +235,25 @@ public:
         return HAS_SMI_TAG(m_data.payload);
     }
 
-    uint32_t asInt32()
+    bool isUInt32()
+    {
+        return isInt32() && asInt32() >= 0;
+    }
+
+    int32_t asInt32()
+    {
+        ASSERT(HAS_SMI_TAG(m_data.payload));
+        return EncodedValueImpl::PlatformSmiTagging::SmiToInt(m_data.payload);
+    }
+
+    uint32_t asUInt32()
     {
         ASSERT(HAS_SMI_TAG(m_data.payload));
         int32_t value = EncodedValueImpl::PlatformSmiTagging::SmiToInt(m_data.payload);
         return (uint32_t)value;
     }
 
-    uint32_t asUint32()
-    {
-        ASSERT(HAS_SMI_TAG(m_data.payload));
-        int32_t value = EncodedValueImpl::PlatformSmiTagging::SmiToInt(m_data.payload);
-        return (uint32_t)value;
-    }
-
-    uint32_t toUint32(ExecutionState& state)
+    uint32_t toUInt32(ExecutionState& state)
     {
         if (LIKELY(HAS_SMI_TAG(m_data.payload))) {
             int32_t value = EncodedValueImpl::PlatformSmiTagging::SmiToInt(m_data.payload);

--- a/src/runtime/GlobalObject.cpp
+++ b/src/runtime/GlobalObject.cpp
@@ -146,7 +146,7 @@ static Value builtinEval(ExecutionState& state, Value thisValue, size_t argc, Va
     return realm->globalObject()->eval(state, argv[0]);
 }
 
-ObjectHasPropertyResult GlobalObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+ObjectHasPropertyResult GlobalObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     ObjectHasPropertyResult hasResult = Object::hasProperty(state, P);
     if (!hasResult.hasProperty() && UNLIKELY((bool)state.context()->virtualIdentifierCallback())) {
@@ -167,7 +167,7 @@ ObjectHasPropertyResult GlobalObject::hasProperty(ExecutionState& state, const O
     return hasResult;
 }
 
-ObjectGetResult GlobalObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+ObjectGetResult GlobalObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     ObjectGetResult r = Object::getOwnProperty(state, P);
     if (!r.hasValue() && UNLIKELY((bool)state.context()->virtualIdentifierCallback())) {

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -297,8 +297,8 @@ public:
         return false;
     }
 
-    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) override ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
-    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) override;
+    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
 
     void* operator new(size_t size)
     {

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -613,7 +613,7 @@ void Object::markAsPrototypeObject(ExecutionState& state)
     }
 }
 
-ObjectGetResult Object::getOwnProperty(ExecutionState& state, const ObjectPropertyName& propertyName) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+ObjectGetResult Object::getOwnProperty(ExecutionState& state, const ObjectPropertyName& propertyName)
 {
     if (propertyName.isUIntType() && !m_structure->hasIndexPropertyName()) {
         return ObjectGetResult();
@@ -640,7 +640,7 @@ ObjectGetResult Object::getOwnProperty(ExecutionState& state, const ObjectProper
     return ObjectGetResult();
 }
 
-bool Object::defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+bool Object::defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc)
 {
     if (UNLIKELY(isEverSetAsPrototypeObject() && !state.context()->vmInstance()->didSomePrototypeObjectDefineIndexedProperty() && P.isIndexString())) {
         state.context()->vmInstance()->somePrototypeObjectDefineIndexedProperty(state);
@@ -820,7 +820,7 @@ bool Object::defineOwnProperty(ExecutionState& state, const ObjectPropertyName& 
     }
 }
 
-bool Object::deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+bool Object::deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     auto result = getOwnProperty(state, P);
     if (result.hasValue() && result.isConfigurable()) {
@@ -832,7 +832,7 @@ bool Object::deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& 
     return true;
 }
 
-void Object::enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+void Object::enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey)
 {
     const ObjectStructureItem* propertiesVector;
     propertiesVector = m_structure->properties();

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -767,7 +767,6 @@ private:
 };
 
 #define ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER 0
-#define ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
 
 enum class EnumerableOwnPropertiesType {
     Key,
@@ -876,11 +875,11 @@ public:
     // internal [[prototype]]
     virtual bool setPrototype(ExecutionState& state, const Value& proto);
 
-    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
-    virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
-    virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
+    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P);
+    virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc);
+    virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P);
     // callback function should skip un-Enumerable property if needs
-    virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE;
+    virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true);
     // ToLength(Get(obj, "length"))
     uint64_t length(ExecutionState& state);
 

--- a/src/runtime/StringObject.cpp
+++ b/src/runtime/StringObject.cpp
@@ -50,7 +50,7 @@ void* StringObject::operator new(size_t size)
     return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
 }
 
-ObjectHasPropertyResult StringObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+ObjectHasPropertyResult StringObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     Value::ValueIndex idx = P.tryToUseAsIndex();
     if (idx != Value::InvalidIndexValue) {
@@ -63,7 +63,7 @@ ObjectHasPropertyResult StringObject::hasProperty(ExecutionState& state, const O
 }
 
 
-ObjectGetResult StringObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+ObjectGetResult StringObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     Value::ValueIndex idx = P.tryToUseAsIndex();
     if (idx != Value::InvalidIndexValue) {
@@ -75,7 +75,7 @@ ObjectGetResult StringObject::getOwnProperty(ExecutionState& state, const Object
     return Object::getOwnProperty(state, P);
 }
 
-bool StringObject::defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+bool StringObject::defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc)
 {
     auto r = getOwnProperty(state, P);
     if (r.hasValue() && !r.isConfigurable())
@@ -83,7 +83,7 @@ bool StringObject::defineOwnProperty(ExecutionState& state, const ObjectProperty
     return Object::defineOwnProperty(state, P, desc);
 }
 
-bool StringObject::deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+bool StringObject::deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
     auto r = getOwnProperty(state, P);
     if (r.hasValue() && !r.isConfigurable())
@@ -91,7 +91,7 @@ bool StringObject::deleteOwnProperty(ExecutionState& state, const ObjectProperty
     return Object::deleteOwnProperty(state, P);
 }
 
-void StringObject::enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
+void StringObject::enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey)
 {
     size_t len = m_primitiveValue->length();
     for (size_t i = 0; i < len; i++) {

--- a/src/runtime/StringObject.h
+++ b/src/runtime/StringObject.h
@@ -45,11 +45,11 @@ public:
         m_primitiveValue = data;
     }
 
-    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
-    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
-    virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
-    virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
-    virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE override;
+    virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) override;
+    virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
+    virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) override;
+    virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
+    virtual void enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey = true) override;
     virtual ObjectGetResult getIndexedProperty(ExecutionState& state, const Value& property, const Value& receiver) override;
     virtual ObjectHasPropertyResult hasIndexedProperty(ExecutionState& state, const Value& propertyName) override;
 

--- a/src/runtime/ValueInlines.h
+++ b/src/runtime/ValueInlines.h
@@ -892,9 +892,8 @@ uint32_t Value::tryToUseAsArrayIndex(ExecutionState& ec) const
 
 inline uint64_t Value::toArrayIndex(ExecutionState& state) const
 {
-    int32_t i;
-    if (LIKELY(isInt32()) && LIKELY((i = asInt32()) >= 0)) {
-        return i;
+    if (LIKELY(isUInt32())) {
+        return asUInt32();
     } else {
         uint32_t newLen = toUint32(state);
         if (newLen != toNumber(state)) {


### PR DESCRIPTION
* add tryToUseAsArrayIndex api for enumeration
* remove ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE macro
* fix UInt-naming

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>