### PR TITLE
Add conversion from ObjectGetResult to ObjectPropertyDescriptor

### DIFF
--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -413,23 +413,20 @@ static Value builtinObjectFromEntries(ExecutionState& state, Value thisValue, si
     return obj;
 }
 
+// https://262.ecma-international.org/#sec-object.getownpropertydescriptor
 static Value builtinObjectGetOwnPropertyDescriptor(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
-    // Object.getOwnPropertyDescriptor ( O, P )
-
     // Let obj be ToObject(O).
     Object* O = argv[0].toObject(state);
+    // Let key be ? ToPropertyKey(P).
+    Value key = argv[1].toPropertyKey(state);
 
-    // Let name be ToString(P).
-    Value name = argv[1];
-
-    // Let desc be the result of calling the [[GetOwnProperty]] internal method of O with argument name.
-    // Return the result of calling FromPropertyDescriptor(desc) (8.10.4).
-    return O->getOwnPropertyDescriptor(state, ObjectPropertyName(state, name));
+    // Let desc be ? obj.[[GetOwnProperty]](key).
+    // Return FromPropertyDescriptor(desc).
+    return O->getOwnPropertyDescriptor(state, ObjectPropertyName(state, key));
 }
 
-// 19.1.2.9Object.getOwnPropertyDescriptors ( O )
-// https://www.ecma-international.org/ecma-262/8.0/#sec-object.getownpropertydescriptors
+// https://262.ecma-international.org/#sec-object.getownpropertydescriptors
 static Value builtinObjectGetOwnPropertyDescriptors(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
     Object* obj = argv[0].toObject(state);

--- a/src/runtime/GlobalObjectBuiltinReflect.cpp
+++ b/src/runtime/GlobalObjectBuiltinReflect.cpp
@@ -153,7 +153,7 @@ static Value builtinReflectGetOwnPropertyDescriptor(ExecutionState& state, Value
     ObjectGetResult desc = target.asObject()->getOwnProperty(state, ObjectPropertyName(state, key));
 
     // 6. Return FromPropertyDescriptor(desc).
-    return desc.toPropertyDescriptor(state, target.asObject());
+    return desc.fromPropertyDescriptor(state, target.asObject());
 }
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-reflect.getprototypeof

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -128,7 +128,27 @@ Value ObjectGetResult::valueSlowCase(ExecutionState& state, const Value& receive
     return Value();
 }
 
-Value ObjectGetResult::toPropertyDescriptor(ExecutionState& state, const Value& receiver)
+ObjectPropertyDescriptor ObjectGetResult::convertToPropertyDescriptor(ExecutionState& state, const Value& receiver)
+{
+    ASSERT(hasValue());
+    ObjectPropertyDescriptor desc;
+
+    if (isDataProperty()) {
+        desc = ObjectPropertyDescriptor(this->value(state, receiver));
+        desc.setWritable(isWritable());
+    } else {
+        desc = ObjectPropertyDescriptor(*this->jsGetterSetter(), ObjectPropertyDescriptor::NotPresent);
+    }
+
+    desc.setEnumerable(isEnumerable());
+    desc.setConfigurable(isConfigurable());
+
+    ASSERT(desc.checkProperty());
+    return desc;
+}
+
+// https://262.ecma-international.org/#sec-frompropertydescriptor
+Value ObjectGetResult::fromPropertyDescriptor(ExecutionState& state, const Value& receiver)
 {
     // If Desc is undefined, then return undefined.
     if (!hasValue()) {
@@ -224,7 +244,7 @@ ObjectPropertyDescriptor::ObjectPropertyDescriptor(ExecutionState& state, Object
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "Invalid property descriptor. Cannot both specify accessors and a value or writable attribute");
     }
 
-    checkProperty();
+    ASSERT(checkProperty());
 }
 
 void ObjectPropertyDescriptor::setEnumerable(bool enumerable)
@@ -1170,9 +1190,10 @@ bool Object::setIntegrityLevel(ExecutionState& state, Object* O, bool isSealed)
             ObjectGetResult currentDesc = O->getOwnProperty(state, ObjectPropertyName(state, keys[i]));
             if (currentDesc.isConfigurable()) {
                 // Perform ? DefinePropertyOrThrow(O, k, PropertyDescriptor { [[Configurable]]: false }).
-                Object* newDesc = currentDesc.toPropertyDescriptor(state, O).asObject();
-                newDesc->setThrowsException(state, ObjectPropertyName(state, state.context()->staticStrings().configurable), Value(false), newDesc);
-                O->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, keys[i]), ObjectPropertyDescriptor(state, newDesc));
+                ObjectPropertyDescriptor newDesc = currentDesc.convertToPropertyDescriptor(state, O);
+                newDesc.setConfigurable(false);
+
+                O->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, keys[i]), newDesc);
             }
         }
     } else {
@@ -1184,18 +1205,14 @@ bool Object::setIntegrityLevel(ExecutionState& state, Object* O, bool isSealed)
             // If currentDesc is not undefined, then
             if (currentDesc.hasValue()) {
                 if (currentDesc.isConfigurable() || (currentDesc.isDataProperty() && currentDesc.isWritable())) {
-                    Object* newDesc = currentDesc.toPropertyDescriptor(state, O).asObject();
-                    if (currentDesc.isConfigurable()) {
-                        // Let desc be the PropertyDescriptor { [[Configurable]]: false }.
-                        newDesc->setThrowsException(state, ObjectPropertyName(state, state.context()->staticStrings().configurable), Value(false), newDesc);
+                    // Let desc be the PropertyDescriptor { [[Configurable]]: false, [[Writable]]: false }.
+                    ObjectPropertyDescriptor newDesc = currentDesc.convertToPropertyDescriptor(state, O);
+                    newDesc.setConfigurable(false);
+                    if (currentDesc.isDataProperty()) {
+                        newDesc.setWritable(false);
                     }
-                    if (currentDesc.isDataProperty() && currentDesc.isWritable()) {
-                        // Let desc be the PropertyDescriptor { [[Configurable]]: false, [[Writable]]: false }.
-                        newDesc->setThrowsException(state, ObjectPropertyName(state, state.context()->staticStrings().writable), Value(false), newDesc);
-                    }
-
                     // Perform ? DefinePropertyOrThrow(O, k, desc).
-                    O->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, keys[i]), ObjectPropertyDescriptor(state, newDesc));
+                    O->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, keys[i]), newDesc);
                 }
             }
         }


### PR DESCRIPTION
* update ObjectGetResult::convertToPropertyDescriptor
* directly convert ObjectGetResult to ObjectPropertyDescriptor instead of creating a new Object for descriptor

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>