### PR TITLE
Refactoring index property handling

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -2492,14 +2492,24 @@ ValueRef::ValueIndex ValueRef::toIndex(ExecutionStateRef* state)
     return toImpl(this).toIndex(*toImpl(state));
 }
 
-uint32_t ValueRef::toArrayIndex(ExecutionStateRef* state)
+ValueRef::ValueIndex ValueRef::tryToUseAsIndex(ExecutionStateRef* state)
 {
-    return toImpl(this).toArrayIndex(*toImpl(state));
+    return toImpl(this).tryToUseAsIndex(*toImpl(state));
 }
 
-uint32_t ValueRef::tryToUseAsArrayIndex(ExecutionStateRef* state)
+uint32_t ValueRef::toIndex32(ExecutionStateRef* state)
 {
-    return toImpl(this).tryToUseAsArrayIndex(*toImpl(state));
+    return toImpl(this).toIndex32(*toImpl(state));
+}
+
+uint32_t ValueRef::tryToUseAsIndex32(ExecutionStateRef* state)
+{
+    return toImpl(this).tryToUseAsIndex32(*toImpl(state));
+}
+
+uint32_t ValueRef::tryToUseAsIndexProperty(ExecutionStateRef* state)
+{
+    return toImpl(this).tryToUseAsIndexProperty(*toImpl(state));
 }
 
 bool ValueRef::abstractEqualsTo(ExecutionStateRef* state, const ValueRef* other) const

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -763,10 +763,15 @@ public:
     enum : uint64_t { InvalidIndexValue = std::numeric_limits<uint64_t>::max() };
     typedef uint64_t ValueIndex;
     ValueIndex toIndex(ExecutionStateRef* state);
+    ValueIndex tryToUseAsIndex(ExecutionStateRef* state);
 
-    enum : uint32_t { InvalidArrayIndexValue = std::numeric_limits<uint32_t>::max() };
-    uint32_t toArrayIndex(ExecutionStateRef* state);
-    uint32_t tryToUseAsArrayIndex(ExecutionStateRef* state);
+    enum : uint32_t {
+        InvalidIndex32Value = std::numeric_limits<uint32_t>::max(),
+        InvalidIndexPropertyValue = InvalidIndex32Value
+    };
+    uint32_t toIndex32(ExecutionStateRef* state);
+    uint32_t tryToUseAsIndex32(ExecutionStateRef* state);
+    uint32_t tryToUseAsIndexProperty(ExecutionStateRef* state);
 
     bool abstractEqualsTo(ExecutionStateRef* state, const ValueRef* other) const; // ==
     bool equalsTo(ExecutionStateRef* state, const ValueRef* other) const; // ===

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -465,8 +465,8 @@ Value ByteCodeInterpreter::interpret(ExecutionState* state, ByteCodeBlock* byteC
             if (LIKELY(willBeObject.isObject() && (v = willBeObject.asPointerValue())->isArrayObject())) {
                 ArrayObject* arr = (ArrayObject*)v;
                 if (LIKELY(arr->isFastModeArray())) {
-                    uint32_t idx = property.tryToUseAsArrayIndex(*state);
-                    if (LIKELY(idx != Value::InvalidArrayIndexValue) && LIKELY(idx < arr->arrayLength(*state))) {
+                    uint32_t idx = property.tryToUseAsIndexProperty(*state);
+                    if (LIKELY(idx != Value::InvalidIndexPropertyValue) && LIKELY(idx < arr->arrayLength(*state))) {
                         const Value& v = arr->m_fastModeData[idx];
                         if (LIKELY(!v.isEmpty())) {
                             registerFile[code->m_storeRegisterIndex] = v;
@@ -487,9 +487,9 @@ Value ByteCodeInterpreter::interpret(ExecutionState* state, ByteCodeBlock* byteC
             const Value& property = registerFile[code->m_propertyRegisterIndex];
             if (LIKELY(willBeObject.isObject() && (willBeObject.asPointerValue())->isArrayObject())) {
                 ArrayObject* arr = willBeObject.asObject()->asArrayObject();
-                uint32_t idx = property.tryToUseAsArrayIndex(*state);
+                uint32_t idx = property.tryToUseAsIndexProperty(*state);
                 if (LIKELY(arr->isFastModeArray())) {
-                    if (LIKELY(idx != Value::InvalidArrayIndexValue)) {
+                    if (LIKELY(idx != Value::InvalidIndexPropertyValue)) {
                         uint32_t len = arr->arrayLength(*state);
                         if (UNLIKELY(len <= idx)) {
                             if (UNLIKELY(!arr->isExtensible(*state))) {

--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -98,12 +98,12 @@ private:
         return nullptr;
     }
 
-    Value getIndexedPropertyValueQuickly(ExecutionState& state, uint64_t index);
-    void setIndexedPropertyValueQuickly(ExecutionState& state, uint64_t index, const Value& value);
+    Value getIndexedPropertyValueQuickly(ExecutionState& state, size_t index);
+    void setIndexedPropertyValueQuickly(ExecutionState& state, size_t index, const Value& value);
 
-    bool isModifiedArgument(uint64_t index);
-    void setModifiedArgument(uint64_t index);
-    bool isMatchedArgument(uint64_t index);
+    bool isModifiedArgument(size_t index);
+    void setModifiedArgument(size_t index);
+    bool isMatchedArgument(size_t index);
 };
 } // namespace Escargot
 

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -162,9 +162,9 @@ bool ArrayObject::defineOwnProperty(ExecutionState& state, const ObjectPropertyN
         return true;
     }
 
-    uint64_t idx = P.tryToUseAsArrayIndex();
+    uint32_t idx = P.tryToUseAsIndexProperty();
     if (LIKELY(isFastModeArray())) {
-        if (LIKELY(idx != Value::InvalidArrayIndexValue)) {
+        if (LIKELY(idx != Value::InvalidIndexPropertyValue)) {
             uint32_t len = arrayLength(state);
             if (len > idx && !m_fastModeData[idx].isEmpty()) {
                 // Non-empty slot of fast-mode array always has {writable:true, enumerable:true, configurable:true}.
@@ -202,13 +202,13 @@ NonFastPath:
 
     uint32_t oldLen = arrayLength(state);
 
-    if (idx != Value::InvalidArrayIndexValue) {
+    if (idx != Value::InvalidIndexPropertyValue) {
         if ((idx >= oldLen) && !isLengthPropertyWritable())
             return false;
         bool succeeded = Object::defineOwnProperty(state, P, desc);
         if (!succeeded)
             return false;
-        if (idx >= oldLen && ((idx + 1) <= Value::InvalidArrayIndexValue)) {
+        if (idx >= oldLen && ((idx + 1) <= Value::InvalidIndexPropertyValue)) {
             return setArrayLength(state, idx + 1);
         }
         return true;
@@ -224,9 +224,9 @@ bool ArrayObject::deleteOwnProperty(ExecutionState& state, const ObjectPropertyN
     }
 
     if (LIKELY(isFastModeArray())) {
-        uint64_t idx = P.tryToUseAsArrayIndex();
-        if (LIKELY(idx != Value::InvalidArrayIndexValue)) {
-            uint64_t len = arrayLength(state);
+        uint32_t idx = P.tryToUseAsIndexProperty();
+        if (LIKELY(idx != Value::InvalidIndexPropertyValue)) {
+            uint32_t len = arrayLength(state);
             if (idx < len) {
                 if (!m_fastModeData[idx].isEmpty()) {
                     m_fastModeData[idx] = Value(Value::EmptyValue);
@@ -521,8 +521,8 @@ ObjectGetResult ArrayObject::getVirtualValue(ExecutionState& state, const Object
         return ObjectGetResult(Value(m_arrayLength), isLengthPropertyWritable(), false, false);
     }
     if (LIKELY(isFastModeArray())) {
-        uint64_t idx = P.tryToUseAsArrayIndex();
-        if (LIKELY(idx != Value::InvalidArrayIndexValue) && LIKELY(idx < arrayLength(state))) {
+        uint32_t idx = P.tryToUseAsIndexProperty();
+        if (LIKELY(idx != Value::InvalidIndexPropertyValue) && LIKELY(idx < arrayLength(state))) {
             Value v = m_fastModeData[idx];
             if (LIKELY(!v.isEmpty())) {
                 return ObjectGetResult(v, true, true, true);
@@ -536,8 +536,8 @@ ObjectGetResult ArrayObject::getVirtualValue(ExecutionState& state, const Object
 ObjectHasPropertyResult ArrayObject::hasIndexedProperty(ExecutionState& state, const Value& propertyName)
 {
     if (LIKELY(isFastModeArray())) {
-        uint32_t idx = propertyName.tryToUseAsArrayIndex(state);
-        if (LIKELY(idx != Value::InvalidArrayIndexValue) && LIKELY(idx < arrayLength(state))) {
+        uint32_t idx = propertyName.tryToUseAsIndexProperty(state);
+        if (LIKELY(idx != Value::InvalidIndexPropertyValue) && LIKELY(idx < arrayLength(state))) {
             Value v = m_fastModeData[idx];
             if (LIKELY(!v.isEmpty())) {
                 return ObjectHasPropertyResult(ObjectGetResult(v, true, true, true));
@@ -550,8 +550,8 @@ ObjectHasPropertyResult ArrayObject::hasIndexedProperty(ExecutionState& state, c
 ObjectGetResult ArrayObject::getIndexedProperty(ExecutionState& state, const Value& property, const Value& receiver)
 {
     if (LIKELY(isFastModeArray())) {
-        uint32_t idx = property.tryToUseAsArrayIndex(state);
-        if (LIKELY(idx != Value::InvalidArrayIndexValue) && LIKELY(idx < arrayLength(state))) {
+        uint32_t idx = property.tryToUseAsIndexProperty(state);
+        if (LIKELY(idx != Value::InvalidIndexPropertyValue) && LIKELY(idx < arrayLength(state))) {
             Value v = m_fastModeData[idx];
             if (LIKELY(!v.isEmpty())) {
                 return ObjectGetResult(v, true, true, true);
@@ -565,8 +565,8 @@ bool ArrayObject::setIndexedProperty(ExecutionState& state, const Value& propert
 {
     // checking isUint32 to prevent invoke toString on property more than once while calling setIndexedProperty
     if (LIKELY(isFastModeArray() && property.isUInt32())) {
-        uint32_t idx = property.tryToUseAsArrayIndex(state);
-        if (LIKELY(idx != Value::InvalidArrayIndexValue)) {
+        uint32_t idx = property.tryToUseAsIndexProperty(state);
+        if (LIKELY(idx != Value::InvalidIndexPropertyValue)) {
             uint32_t len = arrayLength(state);
             if (UNLIKELY(len <= idx)) {
                 if (UNLIKELY(!isExtensible(state))) {

--- a/src/runtime/ObjectStructurePropertyName.h
+++ b/src/runtime/ObjectStructurePropertyName.h
@@ -136,20 +136,13 @@ public:
         return n;
     }
 
-    uint64_t tryToUseAsIndex() const
+    uint32_t tryToUseAsIndexProperty() const
     {
+        // index property uses 32bit unsigned integer
         if (isPlainString()) {
-            return plainString()->tryToUseAsIndex();
+            return plainString()->tryToUseAsIndexProperty();
         }
-        return Value::InvalidIndexValue;
-    }
-
-    uint64_t tryToUseAsArrayIndex() const
-    {
-        if (isPlainString()) {
-            return plainString()->tryToUseAsArrayIndex();
-        }
-        return Value::InvalidArrayIndexValue;
+        return Value::InvalidIndexPropertyValue;
     }
 
     bool equals(String* s) const

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -469,7 +469,8 @@ public:
     static String* emptyString;
 
     uint64_t tryToUseAsIndex() const;
-    uint64_t tryToUseAsArrayIndex() const;
+    uint32_t tryToUseAsIndex32() const;
+    uint32_t tryToUseAsIndexProperty() const;
 
     bool is8Bit() const
     {

--- a/src/runtime/StringObject.cpp
+++ b/src/runtime/StringObject.cpp
@@ -52,8 +52,8 @@ void* StringObject::operator new(size_t size)
 
 ObjectHasPropertyResult StringObject::hasProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
-    Value::ValueIndex idx = P.tryToUseAsIndex();
-    if (idx != Value::InvalidIndexValue) {
+    size_t idx = P.tryToUseAsIndexProperty();
+    if (idx != Value::InvalidIndexPropertyValue) {
         size_t strLen = m_primitiveValue->length();
         if (LIKELY(idx < strLen)) {
             return ObjectHasPropertyResult(ObjectGetResult(Value(String::fromCharCode(m_primitiveValue->charAt(idx))), false, true, false));
@@ -65,8 +65,8 @@ ObjectHasPropertyResult StringObject::hasProperty(ExecutionState& state, const O
 
 ObjectGetResult StringObject::getOwnProperty(ExecutionState& state, const ObjectPropertyName& P)
 {
-    Value::ValueIndex idx = P.tryToUseAsIndex();
-    if (idx != Value::InvalidIndexValue) {
+    size_t idx = P.tryToUseAsIndexProperty();
+    if (idx != Value::InvalidIndexPropertyValue) {
         size_t strLen = m_primitiveValue->length();
         if (LIKELY(idx < strLen)) {
             return ObjectGetResult(Value(String::fromCharCode(m_primitiveValue->charAt(idx))), false, true, false);
@@ -104,8 +104,8 @@ void StringObject::enumeration(ExecutionState& state, bool (*callback)(Execution
 
 ObjectGetResult StringObject::getIndexedProperty(ExecutionState& state, const Value& property, const Value& receiver)
 {
-    Value::ValueIndex idx = property.tryToUseAsIndex(state);
-    if (idx != Value::InvalidIndexValue) {
+    size_t idx = property.tryToUseAsIndexProperty(state);
+    if (idx != Value::InvalidIndexPropertyValue) {
         size_t strLen = m_primitiveValue->length();
         if (LIKELY(idx < strLen)) {
             return ObjectGetResult(Value(String::fromCharCode(m_primitiveValue->charAt(idx))), false, true, false);
@@ -116,8 +116,8 @@ ObjectGetResult StringObject::getIndexedProperty(ExecutionState& state, const Va
 
 ObjectHasPropertyResult StringObject::hasIndexedProperty(ExecutionState& state, const Value& propertyName)
 {
-    Value::ValueIndex idx = propertyName.tryToUseAsIndex(state);
-    if (idx != Value::InvalidIndexValue) {
+    size_t idx = propertyName.tryToUseAsIndexProperty(state);
+    if (idx != Value::InvalidIndexPropertyValue) {
         size_t strLen = m_primitiveValue->length();
         if (LIKELY(idx < strLen)) {
             return ObjectHasPropertyResult(ObjectGetResult(Value(String::fromCharCode(m_primitiveValue->charAt(idx))), false, true, false));

--- a/src/runtime/Value.cpp
+++ b/src/runtime/Value.cpp
@@ -825,12 +825,12 @@ Value::ValueIndex Value::tryToUseAsIndexSlowCase(ExecutionState& ec) const
     return toString(ec)->tryToUseAsIndex();
 }
 
-uint32_t Value::tryToUseAsArrayIndexSlowCase(ExecutionState& ec) const
+uint32_t Value::tryToUseAsIndex32SlowCase(ExecutionState& ec) const
 {
     if (isSymbol()) {
-        return Value::InvalidArrayIndexValue;
+        return Value::InvalidIndex32Value;
     }
-    return toString(ec)->tryToUseAsArrayIndex();
+    return toString(ec)->tryToUseAsIndex32();
 }
 
 #if defined(ESCARGOT_ENABLE_TEST)

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -230,11 +230,15 @@ public:
     enum : uint64_t { InvalidIndexValue = std::numeric_limits<uint64_t>::max() };
     typedef uint64_t ValueIndex;
     ValueIndex toIndex(ExecutionState& ec) const;
-
     inline ValueIndex tryToUseAsIndex(ExecutionState& ec) const;
-    enum : uint32_t { InvalidArrayIndexValue = std::numeric_limits<uint32_t>::max() };
-    inline uint32_t toArrayIndex(ExecutionState& ec) const;
-    inline uint32_t tryToUseAsArrayIndex(ExecutionState& ec) const;
+
+    enum : uint32_t {
+        InvalidIndex32Value = std::numeric_limits<uint32_t>::max(),
+        InvalidIndexPropertyValue = InvalidIndex32Value
+    };
+    inline uint32_t toIndex32(ExecutionState& ec) const;
+    inline uint32_t tryToUseAsIndex32(ExecutionState& ec) const;
+    inline uint32_t tryToUseAsIndexProperty(ExecutionState& ec) const;
 
     inline bool abstractEqualsTo(ExecutionState& ec, const Value& val) const;
     bool abstractEqualsToSlowCase(ExecutionState& ec, const Value& val) const;
@@ -277,7 +281,7 @@ private:
     Value toPrimitiveSlowCase(ExecutionState& ec, PrimitiveTypeHint) const; // $7.1.1 ToPrimitive
     int32_t toInt32SlowCase(ExecutionState& ec) const; // $7.1.5 ToInt32
     ValueIndex tryToUseAsIndexSlowCase(ExecutionState& ec) const;
-    uint32_t tryToUseAsArrayIndexSlowCase(ExecutionState& ec) const;
+    uint32_t tryToUseAsIndex32SlowCase(ExecutionState& ec) const;
 #if defined(ESCARGOT_ENABLE_TEST)
     bool checkIfObjectWithIsHTMLDDA() const;
 #endif

--- a/src/runtime/ValueInlines.h
+++ b/src/runtime/ValueInlines.h
@@ -872,6 +872,20 @@ inline Value::ValueIndex Value::toIndex(ExecutionState& ec) const
     return index;
 }
 
+inline uint32_t Value::toIndex32(ExecutionState& state) const
+{
+    if (LIKELY(isUInt32())) {
+        return asUInt32();
+    } else {
+        uint32_t newLen = toUint32(state);
+        if (newLen != toNumber(state)) {
+            return Value::InvalidIndex32Value;
+        } else {
+            return newLen;
+        }
+    }
+}
+
 Value::ValueIndex Value::tryToUseAsIndex(ExecutionState& ec) const
 {
     if (LIKELY(isUInt32())) {
@@ -881,27 +895,18 @@ Value::ValueIndex Value::tryToUseAsIndex(ExecutionState& ec) const
     }
 }
 
-uint32_t Value::tryToUseAsArrayIndex(ExecutionState& ec) const
+uint32_t Value::tryToUseAsIndex32(ExecutionState& ec) const
 {
     if (LIKELY(isUInt32())) {
         return asUInt32();
     } else {
-        return tryToUseAsArrayIndexSlowCase(ec);
+        return tryToUseAsIndex32SlowCase(ec);
     }
 }
 
-inline uint32_t Value::toArrayIndex(ExecutionState& state) const
+uint32_t Value::tryToUseAsIndexProperty(ExecutionState& ec) const
 {
-    if (LIKELY(isUInt32())) {
-        return asUInt32();
-    } else {
-        uint32_t newLen = toUint32(state);
-        if (newLen != toNumber(state)) {
-            return Value::InvalidArrayIndexValue;
-        } else {
-            return newLen;
-        }
-    }
+    return tryToUseAsIndex32(ec);
 }
 
 inline double Value::toInteger(ExecutionState& state) const


### PR DESCRIPTION
* when trying to use index property, we use only 32bit for index value (uint32_t)
* rename ArrayIndex as to Index32 and IndexProperty
* add cctest to verify the new api

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>