### PR TITLE
Add Global and ThreadLocal structure

### DIFF
--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -125,15 +125,15 @@ class ESCARGOT_EXPORT Globals {
     static thread_local bool g_globalsInited;
 
 public:
-    // Escargot has thread-isoloate Globals.
-    // Users should call initialize, finalize in the main thread
+    // Escargot has thread-independent Globals.
+    // Users should call initialize, finalize once in the main program
     static void initialize(PlatformRef* platform);
     static void finalize();
 
     // Globals also used for thread initialization
-    // Users need to call initializeThreadLocal, finalizeThreadLocal function for each thread
-    static void initializeThreadLocal();
-    static void finalizeThreadLocal();
+    // Users need to call initializeThread, finalizeThread function for each thread
+    static void initializeThread();
+    static void finalizeThread();
 
     static bool supportsThreading();
 
@@ -1874,6 +1874,22 @@ public:
         notifyHostImportModuleDynamicallyResult(relatedContext, referrer, src, promise, onLoadModule(relatedContext, referrer, src));
     }
     void notifyHostImportModuleDynamicallyResult(ContextRef* relatedContext, ScriptRef* referrer, StringRef* src, PromiseObjectRef* promise, LoadModuleResult loadModuleResult);
+
+    // ThreadLocal custom data
+    // PlatformRef should not have any member variables
+    // Instead, user could allocate thread-local values through following methods
+    virtual void* allocateThreadLocalCustomData()
+    {
+        // do nothing
+        return nullptr;
+    }
+
+    virtual void deallocateThreadLocalCustomData()
+    {
+        // do nothing
+    }
+
+    void* threadLocalCustomData();
 };
 
 #if defined(ENABLE_WASM)

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -126,9 +126,14 @@ class ESCARGOT_EXPORT Globals {
 
 public:
     // Escargot has thread-isoloate Globals.
-    // Users need to call initialize, finalize function for each thread
-    static void initialize();
+    // Users should call initialize, finalize in the main thread
+    static void initialize(PlatformRef* platform);
     static void finalize();
+
+    // Globals also used for thread initialization
+    // Users need to call initializeThreadLocal, finalizeThreadLocal function for each thread
+    static void initializeThreadLocal();
+    static void finalizeThreadLocal();
 
     static bool supportsThreading();
 
@@ -609,7 +614,7 @@ class ESCARGOT_EXPORT VMInstanceRef {
 public:
     // you can to provide timezone as TZ database name like "US/Pacific".
     // if you don't provide, we try to detect system timezone.
-    static PersistentRefHolder<VMInstanceRef> create(PlatformRef* platform, const char* locale = nullptr, const char* timezone = nullptr, const char* baseCacheDir = nullptr);
+    static PersistentRefHolder<VMInstanceRef> create(const char* locale = nullptr, const char* timezone = nullptr, const char* baseCacheDir = nullptr);
 
     typedef void (*OnVMInstanceDelete)(VMInstanceRef* instance);
     void setOnVMInstanceDelete(OnVMInstanceDelete cb);
@@ -635,8 +640,6 @@ public:
     // force clear every caches related with context
     // you can call this function if you don't want to use every alive contexts
     void clearCachesRelatedWithContext();
-
-    PlatformRef* platform();
 
     SymbolRef* toStringTagSymbol();
     SymbolRef* iteratorSymbol();
@@ -1469,7 +1472,7 @@ class ESCARGOT_EXPORT BackingStoreRef {
     friend class ArrayBufferObject;
 
 public:
-    static BackingStoreRef* create(VMInstanceRef* instance, size_t byteLength);
+    static BackingStoreRef* create(size_t byteLength);
     typedef void (*BackingStoreRefDeleterCallback)(void* data, size_t length,
                                                    void* deleterData);
     static BackingStoreRef* create(void* data, size_t byteLength, BackingStoreRefDeleterCallback callback, void* callbackData);
@@ -1478,7 +1481,7 @@ public:
     size_t byteLength();
     // Indicates whether the backing store is Shared Data Block (for SharedArrayBuffer)
     bool isShared();
-    void reallocate(VMInstanceRef* instance, size_t newByteLength);
+    void reallocate(size_t newByteLength);
 };
 
 class ESCARGOT_EXPORT ArrayBufferObjectRef : public ObjectRef {

--- a/src/codecache/CodeCacheReaderWriter.cpp
+++ b/src/codecache/CodeCacheReaderWriter.cpp
@@ -27,7 +27,7 @@
 #include "parser/CodeBlock.h"
 #include "interpreter/ByteCode.h"
 #include "runtime/Context.h"
-#include "runtime/VMInstance.h"
+#include "runtime/ThreadLocal.h"
 #include "runtime/ObjectStructurePropertyName.h"
 
 namespace Escargot {
@@ -867,7 +867,7 @@ ByteCodeBlock* CodeCacheReader::loadByteCodeBlock(Context* context, InterpretedC
     size = m_buffer.get<size_t>();
     bigIntData.resizeWithUninitializedValues(size);
     for (size_t i = 0; i < size; i++) {
-        bigIntData[i] = new BigInt(m_buffer.getBF(VMInstance::bfContext()));
+        bigIntData[i] = new BigInt(m_buffer.getBF(ThreadLocal::bfContext()));
     }
 
     // ByteCodeBlock::m_code bytecode stream

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -20,6 +20,8 @@
 #include "Escargot.h"
 #include "ByteCode.h"
 #include "ByteCodeInterpreter.h"
+#include "runtime/Global.h"
+#include "runtime/Platform.h"
 #include "runtime/Environment.h"
 #include "runtime/EnvironmentRecord.h"
 #include "runtime/FunctionObject.h"
@@ -3420,8 +3422,8 @@ NEVER_INLINE void ByteCodeInterpreter::callFunctionComplexCase(ExecutionState& s
         // Perform ! PerformPromiseThen(capability.[[Promise]], onFulfilled, onRejected).
         innerPromiseCapability.m_promise->asPromiseObject()->then(state, onFulfilled, onRejected);
 
-        state.context()->vmInstance()->platform()->hostImportModuleDynamically(byteCodeBlock->m_codeBlock->context(),
-                                                                               referencingScriptOrModule, specifierString, innerPromiseCapability.m_promise->asPromiseObject());
+        Global::platform()->hostImportModuleDynamically(byteCodeBlock->m_codeBlock->context(),
+                                                        referencingScriptOrModule, specifierString, innerPromiseCapability.m_promise->asPromiseObject());
 
         // Return promiseCapability.[[Promise]].
         registerFile[code->m_resultIndex] = promiseCapability.m_promise;

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -24,8 +24,10 @@
 #include "interpreter/ByteCodeInterpreter.h"
 #include "parser/ast/Node.h"
 #include "runtime/Context.h"
+#include "runtime/Global.h"
 #include "runtime/Environment.h"
 #include "runtime/EnvironmentRecord.h"
+#include "runtime/Platform.h"
 #include "runtime/ErrorObject.h"
 #include "runtime/ExtendedNativeFunctionObject.h"
 #include "runtime/SandBox.h"
@@ -80,12 +82,12 @@ Context* Script::context()
 
 Script* Script::loadModuleFromScript(ExecutionState& state, String* src)
 {
-    Platform::LoadModuleResult result = context()->vmInstance()->platform()->onLoadModule(context(), this, src);
+    Platform::LoadModuleResult result = Global::platform()->onLoadModule(context(), this, src);
     if (!result.script) {
         ErrorObject::throwBuiltinError(state, (ErrorObject::Code)result.errorCode, result.errorMessage->toNonGCUTF8StringData().data());
     }
     if (!result.script->moduleData()->m_didCallLoadedCallback) {
-        context()->vmInstance()->platform()->didLoadModule(context(), this, result.script.value());
+        Global::platform()->didLoadModule(context(), this, result.script.value());
         result.script->moduleData()->m_didCallLoadedCallback = true;
     }
     return result.script.value();
@@ -323,7 +325,7 @@ Value Script::execute(ExecutionState& state, bool isExecuteOnEvalFunction, bool 
 
     if (isModule()) {
         if (!moduleData()->m_didCallLoadedCallback) {
-            context()->vmInstance()->platform()->didLoadModule(context(), nullptr, this);
+            Global::platform()->didLoadModule(context(), nullptr, this);
             moduleData()->m_didCallLoadedCallback = true;
         }
 

--- a/src/runtime/ArrayBufferObject.cpp
+++ b/src/runtime/ArrayBufferObject.cpp
@@ -85,7 +85,7 @@ void ArrayBufferObject::allocateBuffer(ExecutionState& state, size_t byteLength)
         GC_invoke_finalizers();
     }
 
-    m_backingStore = new BackingStore(state.context()->vmInstance(), byteLength);
+    m_backingStore = new BackingStore(byteLength);
 }
 
 void ArrayBufferObject::attachBuffer(BackingStore* backingStore)

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -33,6 +33,7 @@ class ArrayIteratorObject;
 
 class ArrayObject : public Object {
     friend class VMInstance;
+    friend class Global;
     friend class ByteCodeInterpreter;
     friend class EnumerateObjectWithDestruction;
     friend class EnumerateObjectWithIteration;
@@ -97,7 +98,7 @@ protected:
 #endif
     {
         // dummy default constructor
-        // only called by VMInstance::initialize to set tag value
+        // only called by Global::initialize to set tag value
     }
 
 private:
@@ -141,7 +142,7 @@ private:
 };
 
 class ArrayPrototypeObject : public ArrayObject {
-    friend class VMInstance;
+    friend class Global;
 
 public:
     explicit ArrayPrototypeObject(ExecutionState& state);
@@ -151,7 +152,7 @@ private:
         : ArrayObject()
     {
         // dummy default constructor
-        // only called by VMInstance::initialize to set tag value
+        // only called by Global::initialize to set tag value
     }
 };
 

--- a/src/runtime/BackingStore.h
+++ b/src/runtime/BackingStore.h
@@ -22,8 +22,6 @@
 
 namespace Escargot {
 
-class VMInstance;
-
 using BackingStoreDeleterCallback = void (*)(void* data, size_t length,
                                              void* deleterData);
 
@@ -31,7 +29,7 @@ class BackingStore : public gc {
     friend class ArrayBufferObject;
 
 public:
-    BackingStore(VMInstance* instance, size_t byteLength);
+    BackingStore(size_t byteLength);
     BackingStore(void* data, size_t byteLength, BackingStoreDeleterCallback callback,
                  void* callbackData, bool isShared = false, bool isAllocatedByPlatformAllocator = false);
 
@@ -50,7 +48,7 @@ public:
         return m_isShared;
     }
 
-    void reallocate(VMInstance* instance, size_t newByteLength);
+    void reallocate(size_t newByteLength);
     void deallocate();
 
     void* operator new(size_t size);

--- a/src/runtime/BigInt.cpp
+++ b/src/runtime/BigInt.cpp
@@ -19,7 +19,7 @@
 
 #include "Escargot.h"
 #include "BigInt.h"
-#include "VMInstance.h"
+#include "ThreadLocal.h"
 #include "ErrorObject.h"
 
 namespace Escargot {
@@ -38,7 +38,7 @@ BigIntData::BigIntData(BigIntData&& src)
 
 BigIntData::BigIntData(const double& d)
 {
-    bf_init(VMInstance::bfContext(), &m_data);
+    bf_init(ThreadLocal::bfContext(), &m_data);
     bf_set_float64(&m_data, d);
 }
 
@@ -51,7 +51,7 @@ BigIntData::BigIntData(String* src)
         buffer = (char*)bd.bufferAs8Bit;
     } else {
         if (!isAllASCII(bd.bufferAs16Bit, bd.length)) {
-            bf_init(VMInstance::bfContext(), &m_data);
+            bf_init(ThreadLocal::bfContext(), &m_data);
             bf_set_nan(&m_data);
             return;
         }
@@ -72,7 +72,7 @@ BigIntData::BigIntData(const char* buf, size_t length, int radix)
 
 void BigIntData::init(const char* buf, size_t length, int radix)
 {
-    bf_init(VMInstance::bfContext(), &m_data);
+    bf_init(ThreadLocal::bfContext(), &m_data);
     if (!length) {
         bf_set_zero(&m_data, 0);
         return;
@@ -155,7 +155,7 @@ void BigInt::initFinalizer()
 BigInt::BigInt()
     : m_tag(POINTER_VALUE_BIGINT_TAG_IN_DATA)
 {
-    bf_init(VMInstance::bfContext(), &m_bf);
+    bf_init(ThreadLocal::bfContext(), &m_bf);
     initFinalizer();
 }
 
@@ -266,7 +266,7 @@ String* BigInt::toString(int radix)
         return String::emptyString;
     } else {
         String* ret = String::fromASCII(str, resultLen);
-        bf_free(VMInstance::bfContext(), str);
+        bf_free(ThreadLocal::bfContext(), str);
         return ret;
     }
 }
@@ -358,7 +358,7 @@ bool BigInt::greaterThanEqual(BigInt* b)
 BigInt* BigInt::addition(ExecutionState& state, BigInt* b)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_add(&r, &m_bf, &b->m_bf, BF_PREC_INF, BF_RNDZ);
     if (UNLIKELY(ret)) {
         bf_delete(&r);
@@ -370,7 +370,7 @@ BigInt* BigInt::addition(ExecutionState& state, BigInt* b)
 BigInt* BigInt::subtraction(ExecutionState& state, BigInt* b)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_sub(&r, &m_bf, &b->m_bf, BF_PREC_INF, BF_RNDZ);
     if (UNLIKELY(ret)) {
         bf_delete(&r);
@@ -382,7 +382,7 @@ BigInt* BigInt::subtraction(ExecutionState& state, BigInt* b)
 BigInt* BigInt::multiply(ExecutionState& state, BigInt* b)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_mul(&r, &m_bf, &b->m_bf, BF_PREC_INF, BF_RNDZ);
     if (UNLIKELY(ret)) {
         bf_delete(&r);
@@ -394,8 +394,8 @@ BigInt* BigInt::multiply(ExecutionState& state, BigInt* b)
 BigInt* BigInt::division(ExecutionState& state, BigInt* b)
 {
     bf_t r, rem;
-    bf_init(VMInstance::bfContext(), &r);
-    bf_init(VMInstance::bfContext(), &rem);
+    bf_init(ThreadLocal::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &rem);
     int ret = bf_divrem(&r, &rem, &m_bf, &b->m_bf, BF_PREC_INF, BF_RNDZ,
                         BF_RNDZ);
     bf_delete(&rem);
@@ -409,7 +409,7 @@ BigInt* BigInt::division(ExecutionState& state, BigInt* b)
 BigInt* BigInt::remainder(ExecutionState& state, BigInt* b)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_rem(&r, &m_bf, &b->m_bf, BF_PREC_INF, BF_RNDZ,
                      BF_RNDZ)
         & BF_ST_INVALID_OP;
@@ -423,7 +423,7 @@ BigInt* BigInt::remainder(ExecutionState& state, BigInt* b)
 BigInt* BigInt::pow(ExecutionState& state, BigInt* b)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_pow(&r, &m_bf, &b->m_bf, BF_PREC_INF, BF_RNDZ);
     if (UNLIKELY(ret)) {
         bf_delete(&r);
@@ -435,7 +435,7 @@ BigInt* BigInt::pow(ExecutionState& state, BigInt* b)
 BigInt* BigInt::bitwiseAnd(ExecutionState& state, BigInt* b)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_logic_and(&r, &m_bf, &b->m_bf);
     if (UNLIKELY(ret)) {
         bf_delete(&r);
@@ -447,7 +447,7 @@ BigInt* BigInt::bitwiseAnd(ExecutionState& state, BigInt* b)
 BigInt* BigInt::bitwiseOr(ExecutionState& state, BigInt* b)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_logic_or(&r, &m_bf, &b->m_bf);
     if (UNLIKELY(ret)) {
         bf_delete(&r);
@@ -459,7 +459,7 @@ BigInt* BigInt::bitwiseOr(ExecutionState& state, BigInt* b)
 BigInt* BigInt::bitwiseXor(ExecutionState& state, BigInt* b)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_logic_xor(&r, &m_bf, &b->m_bf);
     if (UNLIKELY(ret)) {
         bf_delete(&r);
@@ -471,7 +471,7 @@ BigInt* BigInt::bitwiseXor(ExecutionState& state, BigInt* b)
 BigInt* BigInt::leftShift(ExecutionState& state, BigInt* src)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
 
     slimb_t v2;
 #if defined(ESCARGOT_32)
@@ -501,7 +501,7 @@ BigInt* BigInt::leftShift(ExecutionState& state, BigInt* src)
 BigInt* BigInt::rightShift(ExecutionState& state, BigInt* src)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
 
     slimb_t v2;
 #if defined(ESCARGOT_32)
@@ -534,7 +534,7 @@ BigInt* BigInt::rightShift(ExecutionState& state, BigInt* src)
 BigInt* BigInt::increment(ExecutionState& state)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_add_si(&r, &m_bf, 1, BF_PREC_INF, BF_RNDZ);
     if (UNLIKELY(ret)) {
         bf_delete(&r);
@@ -546,7 +546,7 @@ BigInt* BigInt::increment(ExecutionState& state)
 BigInt* BigInt::decrement(ExecutionState& state)
 {
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_add_si(&r, &m_bf, -1, BF_PREC_INF, BF_RNDZ);
     if (UNLIKELY(ret)) {
         bf_delete(&r);
@@ -559,7 +559,7 @@ BigInt* BigInt::bitwiseNot(ExecutionState& state)
 {
     // The abstract operation BigInt::bitwiseNOT with an argument x of BigInt type returns the one's complement of x; that is, -x - 1.
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_add_si(&r, &m_bf, 1, BF_PREC_INF, BF_RNDZ);
     bf_neg(&r);
 
@@ -577,7 +577,7 @@ BigInt* BigInt::negativeValue(ExecutionState& state)
     }
 
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_set(&r, &m_bf);
     bf_neg(&r);
     if (UNLIKELY(ret)) {
@@ -596,7 +596,7 @@ BigInt* BigInt::negativeValue()
     }
 
     bf_t r;
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &r);
     int ret = bf_set(&r, &m_bf);
     bf_neg(&r);
     ASSERT(!ret);

--- a/src/runtime/Context.cpp
+++ b/src/runtime/Context.cpp
@@ -20,6 +20,7 @@
 #include "Escargot.h"
 #include "Context.h"
 #include "runtime/AtomicString.h"
+#include "runtime/ThreadLocal.h"
 #include "VMInstance.h"
 #include "GlobalObject.h"
 #include "StringObject.h"
@@ -119,7 +120,7 @@ void Context::setGlobalObjectProxy(Object* newGlobalObjectProxy)
 
 ASTAllocator& Context::astAllocator()
 {
-    return *VMInstance::astAllocator();
+    return *ThreadLocal::astAllocator();
 }
 
 #ifdef ESCARGOT_DEBUGGER

--- a/src/runtime/Global.cpp
+++ b/src/runtime/Global.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#include "Escargot.h"
+#include "runtime/Global.h"
+#include "runtime/Platform.h"
+
+namespace Escargot {
+
+bool Global::inited;
+std::thread::id Global::MAIN_THREAD_ID;
+Platform* Global::g_platform;
+
+void Global::initialize(Platform* platform)
+{
+    // initialize should be invoked only once in the main thread (must be thread-safe)
+    static bool called_once = true;
+    RELEASE_ASSERT(called_once && !inited);
+
+    MAIN_THREAD_ID = std::this_thread::get_id();
+
+    ASSERT(!g_platform);
+    g_platform = platform;
+
+    called_once = false;
+    inited = true;
+}
+
+void Global::finalize()
+{
+    // finalize should be invoked only once in the main thread (must be thread-safe)
+    static bool called_once = true;
+    RELEASE_ASSERT(called_once && inited);
+    ASSERT(MAIN_THREAD_ID == std::this_thread::get_id());
+
+    delete g_platform;
+    g_platform = nullptr;
+
+    called_once = false;
+    inited = false;
+}
+
+bool Global::inMainThread()
+{
+    ASSERT(inited);
+    return MAIN_THREAD_ID == std::this_thread::get_id();
+}
+
+Platform* Global::platform()
+{
+    ASSERT(inited && !!g_platform);
+    return g_platform;
+}
+
+} // namespace Escargot

--- a/src/runtime/Global.h
+++ b/src/runtime/Global.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#ifndef __EscargotGlobalRecord__
+#define __EscargotGlobalRecord__
+
+#include <mutex>
+#include <thread>
+
+namespace Escargot {
+
+class Platform;
+
+// Global is a global interface used by all threads
+class Global {
+    static bool inited;
+    static std::thread::id MAIN_THREAD_ID;
+    static Platform* g_platform;
+
+public:
+    static void initialize(Platform* platform);
+    static void finalize();
+
+    static bool inMainThread();
+
+    static Platform* platform();
+};
+
+} // namespace Escargot
+
+#endif

--- a/src/runtime/Global.h
+++ b/src/runtime/Global.h
@@ -17,11 +17,8 @@
  *  USA
  */
 
-#ifndef __EscargotGlobalRecord__
-#define __EscargotGlobalRecord__
-
-#include <mutex>
-#include <thread>
+#ifndef __EscargotGlobal__
+#define __EscargotGlobal__
 
 namespace Escargot {
 
@@ -30,14 +27,11 @@ class Platform;
 // Global is a global interface used by all threads
 class Global {
     static bool inited;
-    static std::thread::id MAIN_THREAD_ID;
     static Platform* g_platform;
 
 public:
     static void initialize(Platform* platform);
     static void finalize();
-
-    static bool inMainThread();
 
     static Platform* platform();
 };

--- a/src/runtime/GlobalObjectBuiltinBigInt.cpp
+++ b/src/runtime/GlobalObjectBuiltinBigInt.cpp
@@ -20,6 +20,7 @@
 #include "Escargot.h"
 #include "GlobalObject.h"
 #include "Context.h"
+#include "ThreadLocal.h"
 #include "VMInstance.h"
 #include "BigIntObject.h"
 #include "NativeFunctionObject.h"
@@ -49,7 +50,7 @@ static Value builtinBigIntConstructor(ExecutionState& state, Value thisValue, si
         if ((numValue > (double)std::numeric_limits<int64_t>::max()) || (numValue < (double)std::numeric_limits<int64_t>::min())) {
             // handle overflowed integer number
             bf_t r;
-            bf_init(VMInstance::bfContext(), &r);
+            bf_init(ThreadLocal::bfContext(), &r);
             int ret = bf_set_float64(&r, numValue);
             ASSERT(!ret);
             ASSERT(bf_is_finite(&r));
@@ -75,8 +76,8 @@ static Value builtinBigIntAsUintN(ExecutionState& state, Value thisValue, size_t
     BigInt* bigint = argv[1].toBigInt(state);
     // Return a BigInt representing bigint modulo 2bits.
     bf_t mask, r;
-    bf_init(VMInstance::bfContext(), &mask);
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &mask);
+    bf_init(ThreadLocal::bfContext(), &r);
     bf_set_ui(&mask, 1);
     bf_mul_2exp(&mask, bits, BF_PREC_INF, BF_RNDZ);
     bf_add_si(&mask, &mask, -1, BF_PREC_INF, BF_RNDZ);
@@ -97,8 +98,8 @@ static Value builtinBigIntAsIntN(ExecutionState& state, Value thisValue, size_t 
     BigInt* bigint = argv[1].toBigInt(state);
     // Return a BigInt representing bigint modulo 2bits.
     bf_t mask, r;
-    bf_init(VMInstance::bfContext(), &mask);
-    bf_init(VMInstance::bfContext(), &r);
+    bf_init(ThreadLocal::bfContext(), &mask);
+    bf_init(ThreadLocal::bfContext(), &r);
     bf_set_ui(&mask, 1);
     bf_mul_2exp(&mask, bits, BF_PREC_INF, BF_RNDZ);
     bf_add_si(&mask, &mask, -1, BF_PREC_INF, BF_RNDZ);

--- a/src/runtime/GlobalObjectBuiltinMath.cpp
+++ b/src/runtime/GlobalObjectBuiltinMath.cpp
@@ -21,6 +21,7 @@
 #include "GlobalObject.h"
 #include "Context.h"
 #include "VMInstance.h"
+#include "ThreadLocal.h"
 #include "StringObject.h"
 #include "NativeFunctionObject.h"
 
@@ -397,7 +398,7 @@ static Value builtinMathLog2(ExecutionState& state, Value thisValue, size_t argc
 static Value builtinMathRandom(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
     std::uniform_real_distribution<double> distribution;
-    return Value(distribution(VMInstance::randEngine()));
+    return Value(distribution(ThreadLocal::randEngine()));
 }
 
 static Value builtinMathExp(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)

--- a/src/runtime/Platform.h
+++ b/src/runtime/Platform.h
@@ -20,11 +20,11 @@
 #ifndef __EscargotPlatform__
 #define __EscargotPlatform__
 
-#include "runtime/SandBox.h"
-
 namespace Escargot {
 
 class Context;
+class Script;
+class String;
 class PromiseObject;
 
 class Platform {
@@ -47,6 +47,10 @@ public:
     virtual LoadModuleResult onLoadModule(Context* relatedContext, Script* whereRequestFrom, String* moduleSrc) = 0;
     virtual void didLoadModule(Context* relatedContext, Optional<Script*> whereRequestFrom, Script* loadedModule) = 0;
     virtual void hostImportModuleDynamically(Context* relatedContext, Script* referrer, String* src, PromiseObject* promise) = 0;
+
+    // ThreadLocal custom data (g_customData)
+    virtual void* allocateThreadLocalCustomData() = 0;
+    virtual void deallocateThreadLocalCustomData() = 0;
 };
 } // namespace Escargot
 

--- a/src/runtime/Platform.h
+++ b/src/runtime/Platform.h
@@ -24,12 +24,10 @@
 
 namespace Escargot {
 
-class ArrayBufferObject;
-class PromiseObject;
 class Context;
-class Job;
+class PromiseObject;
 
-class Platform : public gc {
+class Platform {
 public:
     virtual ~Platform() {}
     // ArrayBuffer

--- a/src/runtime/PointerValue.h
+++ b/src/runtime/PointerValue.h
@@ -107,7 +107,7 @@ class ExportedFunctionObject;
 class PointerValue : public gc {
     friend class Object;
     friend class Context;
-    friend class VMInstance;
+    friend class Global;
     friend class ByteCodeInterpreter;
 
     // tag values for fast type check

--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -18,10 +18,10 @@
  */
 
 #include "Escargot.h"
+#include "ThreadLocal.h"
 #include "RegExpObject.h"
 #include "Context.h"
 #include "ArrayObject.h"
-#include "VMInstance.h"
 
 #include "WTFBridge.h"
 #include "Yarr.h"
@@ -307,7 +307,7 @@ bool RegExpObject::match(ExecutionState& state, String* str, RegexMatchResult& m
         if (entry.m_bytecodePattern) {
             m_bytecodePattern = entry.m_bytecodePattern;
         } else {
-            WTF::BumpPointerAllocator* bumpAlloc = VMInstance::bumpPointerAllocator();
+            WTF::BumpPointerAllocator* bumpAlloc = ThreadLocal::bumpPointerAllocator();
             std::unique_ptr<JSC::Yarr::BytecodePattern> ownedBytecode = JSC::Yarr::byteCompile(*m_yarrPattern, bumpAlloc);
             m_bytecodePattern = ownedBytecode.release();
             entry.m_bytecodePattern = m_bytecodePattern;

--- a/src/runtime/SharedArrayBufferObject.cpp
+++ b/src/runtime/SharedArrayBufferObject.cpp
@@ -20,8 +20,9 @@
 #if defined(ENABLE_THREADING)
 
 #include "Escargot.h"
-#include "runtime/VMInstance.h"
 #include "runtime/Context.h"
+#include "runtime/Global.h"
+#include "runtime/Platform.h"
 #include "runtime/BackingStore.h"
 #include "runtime/ArrayBufferObject.h"
 #include "runtime/SharedArrayBufferObject.h"
@@ -46,13 +47,11 @@ SharedArrayBufferObject::SharedArrayBufferObject(ExecutionState& state, Object* 
         GC_invoke_finalizers();
     }
 
-    auto platform = state.context()->vmInstance()->platform();
-    void* buffer = platform->onMallocArrayBufferObjectDataBuffer(byteLength);
+    void* buffer = Global::platform()->onMallocArrayBufferObjectDataBuffer(byteLength);
     m_backingStore = new BackingStore(buffer, byteLength, [](void* data, size_t length, void* deleterData) {
-        Platform* platform = (Platform*)deleterData;
-        platform->onFreeArrayBufferObjectDataBuffer(data, length);
+        Global::platform()->onFreeArrayBufferObjectDataBuffer(data, length);
     },
-                                      platform, true);
+                                      nullptr, true);
 }
 
 SharedArrayBufferObject* SharedArrayBufferObject::allocateSharedArrayBuffer(ExecutionState& state, Object* constructor, uint64_t byteLength)

--- a/src/runtime/ThreadLocal.cpp
+++ b/src/runtime/ThreadLocal.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#include "Escargot.h"
+#include "runtime/ThreadLocal.h"
+#include "heap/Heap.h"
+#include "runtime/Global.h"
+#include "runtime/Platform.h"
+#include "parser/ASTAllocator.h"
+#include "BumpPointerAllocator.h"
+#if defined(ENABLE_WASM)
+#include "wasm.h"
+#endif
+
+namespace Escargot {
+
+MAY_THREAD_LOCAL bool ThreadLocal::inited;
+
+MAY_THREAD_LOCAL std::mt19937* ThreadLocal::g_randEngine;
+MAY_THREAD_LOCAL bf_context_t ThreadLocal::g_bfContext;
+#if defined(ENABLE_WASM)
+MAY_THREAD_LOCAL WASMContext ThreadLocal::g_wasmContext;
+#endif
+MAY_THREAD_LOCAL ASTAllocator* ThreadLocal::g_astAllocator;
+MAY_THREAD_LOCAL WTF::BumpPointerAllocator* ThreadLocal::g_bumpPointerAllocator;
+MAY_THREAD_LOCAL void* ThreadLocal::g_customData;
+
+void ThreadLocal::initialize()
+{
+    // initialize should be invoked only once in each thread
+    static MAY_THREAD_LOCAL bool called_once = true;
+    RELEASE_ASSERT(called_once && !inited);
+
+    // Heap is initialized for each thread
+    Heap::initialize();
+
+    // g_randEngine
+    g_randEngine = new std::mt19937((unsigned int)time(NULL));
+
+    // g_bfContext
+    bf_context_init(&g_bfContext, [](void* opaque, void* ptr, size_t size) -> void* {
+        return realloc(ptr, size);
+    },
+                    nullptr);
+
+#if defined(ENABLE_WASM)
+    // g_wasmContext
+    g_wasmContext.engine = wasm_engine_new();
+    g_wasmContext.store = wasm_store_new(g_wasmContext.engine);
+    g_wasmContext.lastGCCheckTime = 0;
+#endif
+
+    // g_astAllocator
+    g_astAllocator = new ASTAllocator();
+
+    // g_bumpPointerAllocator
+    g_bumpPointerAllocator = new WTF::BumpPointerAllocator();
+
+    // g_customData
+    g_customData = Global::platform()->allocateThreadLocalCustomData();
+
+    called_once = false;
+    inited = true;
+}
+
+void ThreadLocal::finalize()
+{
+    // finalize should be invoked only once in each thread
+    static MAY_THREAD_LOCAL bool called_once = true;
+    RELEASE_ASSERT(called_once && inited);
+
+    // g_customData
+    Global::platform()->deallocateThreadLocalCustomData();
+    g_customData = nullptr;
+
+    // full gc(Heap::finalize) should be invoked after g_customData deallocation
+    // because g_customData might contain GC-object
+    Heap::finalize();
+
+    // g_randEngine does not need finalization
+    delete g_randEngine;
+    g_randEngine = nullptr;
+
+    // g_bfContext
+    bf_context_end(&g_bfContext);
+
+#if defined(ENABLE_WASM)
+    // g_wasmContext
+    wasm_store_delete(g_wasmContext.store);
+    wasm_engine_delete(g_wasmContext.engine);
+    g_wasmContext.store = nullptr;
+    g_wasmContext.engine = nullptr;
+    g_wasmContext.lastGCCheckTime = 0;
+#endif
+
+    // g_astAllocator
+    delete g_astAllocator;
+    g_astAllocator = nullptr;
+
+    // g_bumpPointerAllocator
+    delete g_bumpPointerAllocator;
+    g_bumpPointerAllocator = nullptr;
+
+    called_once = false;
+    inited = false;
+}
+
+#if defined(ENABLE_WASM)
+void ThreadLocal::wasmGC(uint64_t lastCheckTime)
+{
+    ASSERT(inited && !!g_wasmContext.store);
+    wasm_store_gc(g_wasmContext.store);
+    g_wasmContext.lastGCCheckTime = lastCheckTime;
+}
+#endif
+
+} // namespace Escargot

--- a/src/runtime/ThreadLocal.h
+++ b/src/runtime/ThreadLocal.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#ifndef __EscargotThreadLocalRecord__
+#define __EscargotThreadLocalRecord__
+
+namespace WTF {
+class BumpPointerAllocator;
+}
+
+#if defined(ENABLE_WASM)
+struct wasm_engine_t;
+struct wasm_store_t;
+struct WASMContext {
+    wasm_engine_t* engine;
+    wasm_store_t* store;
+    uint64_t lastGCCheckTime;
+};
+#endif
+
+namespace Escargot {
+
+class ASTAllocator;
+
+// ThreadLocal has thread-local values
+// ThreadLocal should be created for each thread
+// ThreadLocal is a non-GC global object which means that users who want to customize it should manage memory by themselves
+class ThreadLocal {
+    static MAY_THREAD_LOCAL bool inited;
+
+    // Global data per thread
+    static MAY_THREAD_LOCAL std::mt19937* g_randEngine;
+    static MAY_THREAD_LOCAL bf_context_t g_bfContext;
+#if defined(ENABLE_WASM)
+    static MAY_THREAD_LOCAL WASMContext g_wasmContext;
+#endif
+    static MAY_THREAD_LOCAL ASTAllocator* g_astAllocator;
+    static MAY_THREAD_LOCAL WTF::BumpPointerAllocator* g_bumpPointerAllocator;
+    // custom data allocated by user through Platform::allocateThreadLocalCustomData
+    static MAY_THREAD_LOCAL void* g_customData;
+
+public:
+    static void initialize();
+    static void finalize();
+
+    // Global data getter
+    static std::mt19937& randEngine()
+    {
+        ASSERT(inited && !!g_randEngine);
+        return *g_randEngine;
+    }
+
+    static bf_context_t* bfContext()
+    {
+        ASSERT(inited && !!g_bfContext.realloc_func);
+        return &g_bfContext;
+    }
+
+#if defined(ENABLE_WASM)
+    static void wasmGC(uint64_t lastCheckTime);
+
+    static wasm_store_t* wasmStore()
+    {
+        ASSERT(inited && !!g_wasmContext.store);
+        return g_wasmContext.store;
+    }
+
+    static uint64_t wasmLastGCCheckTime()
+    {
+        ASSERT(inited && !!g_wasmContext.store);
+        return g_wasmContext.lastGCCheckTime;
+    }
+#endif
+
+    static ASTAllocator* astAllocator()
+    {
+        ASSERT(inited && !!g_astAllocator);
+        return g_astAllocator;
+    }
+
+    static WTF::BumpPointerAllocator* bumpPointerAllocator()
+    {
+        ASSERT(inited && !!g_bumpPointerAllocator);
+        return g_bumpPointerAllocator;
+    }
+
+    static void* customData()
+    {
+        ASSERT(inited && !!g_customData);
+        return g_customData;
+    }
+};
+
+} // namespace Escargot
+
+#endif

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -25,27 +25,12 @@
 #include "runtime/StaticStrings.h"
 #include "runtime/ToStringRecursionPreventer.h"
 
-#if defined(ENABLE_WASM)
-struct wasm_engine_t;
-struct wasm_store_t;
-struct WASMContext {
-    wasm_engine_t* engine;
-    wasm_store_t* store;
-    uint64_t lastGCCheckTime;
-};
-#endif
-
-namespace WTF {
-class BumpPointerAllocator;
-}
-
 namespace Escargot {
 
 class Context;
 class CodeBlock;
 class JobQueue;
 class Job;
-class ASTAllocator;
 class Symbol;
 class String;
 #if defined(ENABLE_COMPRESSIBLE_STRING)
@@ -92,53 +77,7 @@ class VMInstance : public gc {
     friend class ScriptParser;
     friend class SandBox;
 
-    /////////////////////////////////
-    // Global Data
-    // global values which should be initialized once and shared during the runtime
-    static MAY_THREAD_LOCAL std::mt19937* g_randEngine;
-    static MAY_THREAD_LOCAL bf_context_t g_bfContext;
-#if defined(ENABLE_WASM)
-    static MAY_THREAD_LOCAL WASMContext g_wasmContext;
-#endif
-
-    static MAY_THREAD_LOCAL ASTAllocator* g_astAllocator;
-    static MAY_THREAD_LOCAL WTF::BumpPointerAllocator* g_bumpPointerAllocator;
-    /////////////////////////////////
-
 public:
-    /////////////////////////////////
-    // Global Data Static Function
-    static void initialize();
-    static void finalize();
-    static std::mt19937& randEngine()
-    {
-        ASSERT(!!g_randEngine);
-        return *g_randEngine;
-    }
-    static bf_context_t* bfContext()
-    {
-        ASSERT(!!g_bfContext.realloc_func);
-        return &g_bfContext;
-    }
-#if defined(ENABLE_WASM)
-    static wasm_store_t* wasmStore()
-    {
-        ASSERT(!!g_wasmContext.store);
-        return g_wasmContext.store;
-    }
-#endif
-    static ASTAllocator* astAllocator()
-    {
-        ASSERT(!!g_astAllocator);
-        return g_astAllocator;
-    }
-    static WTF::BumpPointerAllocator* bumpPointerAllocator()
-    {
-        ASSERT(!!g_bumpPointerAllocator);
-        return g_bumpPointerAllocator;
-    }
-    /////////////////////////////////
-
     enum PromiseHookType {
         Init,
         Resolve,

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -20,7 +20,7 @@
 #ifndef __EscargotVMInstance__
 #define __EscargotVMInstance__
 
-#include "runtime/Platform.h"
+#include "runtime/SandBox.h"
 #include "runtime/AtomicString.h"
 #include "runtime/StaticStrings.h"
 #include "runtime/ToStringRecursionPreventer.h"
@@ -41,7 +41,6 @@ class BumpPointerAllocator;
 
 namespace Escargot {
 
-class SandBox;
 class Context;
 class CodeBlock;
 class JobQueue;
@@ -149,7 +148,7 @@ public:
 
     typedef void (*PromiseHook)(ExecutionState& state, PromiseHookType type, PromiseObject* promise, const Value& parent, void* hook);
 
-    VMInstance(Platform* platform, const char* locale = nullptr, const char* timezone = nullptr, const char* baseCacheDir = nullptr);
+    VMInstance(const char* locale = nullptr, const char* timezone = nullptr, const char* baseCacheDir = nullptr);
     ~VMInstance();
 
     void* operator new(size_t size);
@@ -259,11 +258,6 @@ public:
     }
 #endif
 
-    Platform* platform()
-    {
-        return m_platform;
-    }
-
     SandBox* currentSandBox()
     {
         return m_currentSandBox;
@@ -278,7 +272,6 @@ public:
     {
         return m_regexpOptionStringCache;
     }
-
 
     void setOnDestroyCallback(void (*onVMInstanceDestroy)(VMInstance* instance, void* data), void* data)
     {
@@ -398,8 +391,6 @@ private:
     std::string m_timezoneID;
 #endif
     DateObject* m_cachedUTC;
-
-    Platform* m_platform;
 
     // promise job queue
     JobQueue* m_jobQueue;

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -636,15 +636,11 @@ int main(int argc, char* argv[])
     mallopt(M_MMAP_MAX, 1024 * 1024);
 #endif
 
-    Globals::initialize();
+    Globals::initialize(new ShellPlatform());
 
     Memory::setGCFrequency(24);
 
-    ShellPlatform* platform = new ShellPlatform();
-    PersistentRefHolder<VMInstanceRef> instance = VMInstanceRef::create(platform);
-    instance->setOnVMInstanceDelete([](VMInstanceRef* instance) {
-        delete instance->platform();
-    });
+    PersistentRefHolder<VMInstanceRef> instance = VMInstanceRef::create();
     PersistentRefHolder<ContextRef> context = createEscargotContext(instance.get());
 
     if (getenv("GC_FREE_SPACE_DIVISOR") && strlen(getenv("GC_FREE_SPACE_DIVISOR"))) {

--- a/src/wasm/GlobalObjectBuiltinWASM.cpp
+++ b/src/wasm/GlobalObjectBuiltinWASM.cpp
@@ -23,6 +23,7 @@
 #include "wasm.h"
 #include "runtime/GlobalObject.h"
 #include "runtime/Context.h"
+#include "runtime/ThreadLocal.h"
 #include "runtime/VMInstance.h"
 #include "runtime/NativeFunctionObject.h"
 #include "runtime/ExtendedNativeFunctionObject.h"
@@ -124,7 +125,7 @@ static Value builtinWASMValidate(ExecutionState& state, Value thisValue, size_t 
     wasm_byte_vec_new_uninitialized(&binary, byteLength);
     memcpy(binary.data, srcBuffer->data(), byteLength);
 
-    bool result = wasm_module_validate(VMInstance::wasmStore(), &binary);
+    bool result = wasm_module_validate(ThreadLocal::wasmStore(), &binary);
     wasm_byte_vec_delete(&binary);
 
     return Value(result);
@@ -346,7 +347,7 @@ static Value builtinWASMInstanceConstructor(ExecutionState& state, Value thisVal
 
     // Instantiate the core of a WebAssembly module module with imports, and let instance be the result.
     own wasm_trap_t* trap = nullptr;
-    own wasm_instance_t* instance = wasm_instance_new(VMInstance::wasmStore(), module, imports.data, &trap);
+    own wasm_instance_t* instance = wasm_instance_new(ThreadLocal::wasmStore(), module, imports.data, &trap);
     wasm_extern_vec_delete(&imports);
 
     if (!instance) {
@@ -428,7 +429,7 @@ static Value builtinWASMMemoryConstructor(ExecutionState& state, Value thisValue
     own wasm_memorytype_t* memtype = wasm_memorytype_new(&limits);
 
     // Let (store, memaddr) be mem_alloc(store, memtype). If allocation fails, throw a RangeError exception.
-    own wasm_memory_t* memaddr = wasm_memory_new(VMInstance::wasmStore(), memtype);
+    own wasm_memory_t* memaddr = wasm_memory_new(ThreadLocal::wasmStore(), memtype);
     wasm_memorytype_delete(memtype);
 
     wasm_ref_t* memref = wasm_memory_as_ref(memaddr);
@@ -621,7 +622,7 @@ static Value builtinWASMTableConstructor(ExecutionState& state, Value thisValue,
     own wasm_tabletype_t* tabletype = wasm_tabletype_new(wasm_valtype_new(WASM_FUNCREF), &limits);
 
     // Let (store, tableaddr) be table_alloc(store, type).
-    own wasm_table_t* tableaddr = wasm_table_new(VMInstance::wasmStore(), tabletype, nullptr);
+    own wasm_table_t* tableaddr = wasm_table_new(ThreadLocal::wasmStore(), tabletype, nullptr);
     wasm_tabletype_delete(tabletype);
 
     wasm_ref_t* tableref = wasm_table_as_ref(tableaddr);
@@ -841,7 +842,7 @@ static Value builtinWASMGlobalConstructor(ExecutionState& state, Value thisValue
     own wasm_globaltype_t* globaltype = wasm_globaltype_new(wasm_valtype_new(valuetype), mut);
 
     // Let (store, globaladdr) be global_alloc(store, globaltype, value).
-    own wasm_global_t* globaladdr = wasm_global_new(VMInstance::wasmStore(), globaltype, &value);
+    own wasm_global_t* globaladdr = wasm_global_new(ThreadLocal::wasmStore(), globaltype, &value);
     wasm_globaltype_delete(globaltype);
 
     wasm_ref_t* globalref = wasm_global_as_ref(globaladdr);


### PR DESCRIPTION
* Platform is also managed in Global object
* Global has life time same to program
* ThreadLocal manage global values allocated for each thread
* Update PlatformRef to allow users to add thread-local custom data

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>