### PR TITLE
Add omitted source info in ExecutionStateRef::computeStackTraceData

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -2261,8 +2261,11 @@ GCManagedVector<Evaluator::StackTraceData> ExecutionStateRef::computeStackTraceD
                 locData = iterMap->second;
             }
 
+            InterpretedCodeBlock* codeBlock = byteCodeBlock->codeBlock();
             size_t byteCodePosition = stackTraceData[i].second.loc.byteCodePosition;
             stackTraceData[i].second.loc = byteCodeBlock->computeNodeLOCFromByteCode(state->context(), byteCodePosition, byteCodeBlock->m_codeBlock, locData);
+            stackTraceData[i].second.src = codeBlock->script()->srcName();
+            stackTraceData[i].second.sourceCode = codeBlock->script()->sourceCode();
         }
 
         Evaluator::StackTraceData t;


### PR DESCRIPTION
* add source name and source code info to Evaluator::StackTraceData

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>