### PR TITLE
Store function name value correctly to access it in inner function scope

### DIFF
--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -189,34 +189,14 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* context, Interpreted
     ctx.m_breakpointContext = &breakpointContext;
 #endif /* ESCARGOT_DEBUGGER */
 
-    // generate common codes
-    {
-        AtomicString name = codeBlock->functionName();
-        if (name.string()->length()) {
-            if (UNLIKELY(codeBlock->isFunctionNameExplicitlyDeclared())) {
-                if (codeBlock->canUseIndexedVariableStorage()) {
-                    if (!codeBlock->isFunctionNameSaveOnHeap()) {
-                        auto r = ctx.getRegister();
-                        block->pushCode(LoadLiteral(ByteCodeLOC(0), r, Value()), &ctx, nullptr);
-                        block->pushCode(Move(ByteCodeLOC(0), r, REGULAR_REGISTER_LIMIT + 1), &ctx, nullptr);
-                        ctx.giveUpRegister();
-                    }
-                }
-            } else if (UNLIKELY(codeBlock->isFunctionNameSaveOnHeap() && !name.string()->equals("arguments"))) {
-                ctx.m_isVarDeclaredBindingInitialization = true;
-                IdentifierNode* id = new (alloca(sizeof(IdentifierNode))) IdentifierNode(codeBlock->functionName());
-                id->generateStoreByteCode(block, &ctx, REGULAR_REGISTER_LIMIT + 1, true);
-            }
-        }
-
-        ast->generateStatementByteCode(block, &ctx);
+    // generate bytecode
+    ast->generateStatementByteCode(block, &ctx);
 
 #ifdef ESCARGOT_DEBUGGER
-        if (context->debugger() && context->debugger()->enabled() && breakpointContext.m_parsingEnabled) {
-            context->debugger()->sendBreakpointLocations(breakpointContext.m_breakpointLocations);
-        }
-#endif /* ESCARGOT_DEBUGGER */
+    if (context->debugger() && context->debugger()->enabled() && breakpointContext.m_parsingEnabled) {
+        context->debugger()->sendBreakpointLocations(breakpointContext.m_breakpointLocations);
     }
+#endif /* ESCARGOT_DEBUGGER */
 
     if (ctx.m_keepNumberalLiteralsInRegisterFile) {
         block->m_numeralLiteralData.resizeWithUninitializedValues(nData->size());

--- a/src/parser/ast/IdentifierNode.h
+++ b/src/parser/ast/IdentifierNode.h
@@ -195,11 +195,16 @@ public:
                         }
                     } else {
                         if (isLexicallyDeclaredBindingInitialization || isVarDeclaredBindingInitialization) {
-                            ASSERT(info.m_upperIndex == 0);
-                            codeBlock->pushCode(InitializeByHeapIndex(ByteCodeLOC(m_loc.index), srcRegister, info.m_index), context, this);
-                        } else {
-                            codeBlock->pushCode(StoreByHeapIndex(ByteCodeLOC(m_loc.index), srcRegister, info.m_upperIndex, info.m_index), context, this);
+                            if (LIKELY(info.m_upperIndex == 0)) {
+                                codeBlock->pushCode(InitializeByHeapIndex(ByteCodeLOC(m_loc.index), srcRegister, info.m_index), context, this);
+                                return;
+                            }
+
+                            // it is for the case that function name of function expression should be initialized on the heap with other lexical variables
+                            ASSERT(m_name == codeBlock->codeBlock()->functionName() && codeBlock->codeBlock()->isFunctionExpression() && codeBlock->codeBlock()->isFunctionNameSaveOnHeap());
                         }
+
+                        codeBlock->pushCode(StoreByHeapIndex(ByteCodeLOC(m_loc.index), srcRegister, info.m_upperIndex, info.m_index), context, this);
                     }
                 }
             }


### PR DESCRIPTION
* handle exceptional case of function name which is that function name needs to be allocated on the heap with other lexical variables

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>