### PR TITLE
Replace TemplatePropertyName with existing ObjectStructurePropertyName

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -3450,25 +3450,25 @@ FinalizationRegistryObjectRef* FinalizationRegistryObjectRef::create(ExecutionSt
     return toRef(new FinalizationRegistryObject(*toImpl(state), toImpl(cleanupCallback), toImpl(realm)));
 }
 
-void TemplateRef::set(const TemplatePropertyNameRef& name, ValueRef* data, bool isWritable, bool isEnumerable, bool isConfigurable)
+void TemplateRef::set(ValueRef* propertyName, ValueRef* data, bool isWritable, bool isEnumerable, bool isConfigurable)
 {
-    toImpl(this)->set(TemplatePropertyName(toImpl(name.value())), toImpl(data), isWritable, isEnumerable, isConfigurable);
+    toImpl(this)->set(toImpl(propertyName), toImpl(data), isWritable, isEnumerable, isConfigurable);
 }
 
-void TemplateRef::set(const TemplatePropertyNameRef& name, TemplateRef* data, bool isWritable, bool isEnumerable, bool isConfigurable)
+void TemplateRef::set(ValueRef* propertyName, TemplateRef* data, bool isWritable, bool isEnumerable, bool isConfigurable)
 {
-    toImpl(this)->set(TemplatePropertyName(toImpl(name.value())), toImpl(data), isWritable, isEnumerable, isConfigurable);
+    toImpl(this)->set(toImpl(propertyName), toImpl(data), isWritable, isEnumerable, isConfigurable);
 }
 
-void TemplateRef::setAccessorProperty(const TemplatePropertyNameRef& name, OptionalRef<FunctionTemplateRef> getter, OptionalRef<FunctionTemplateRef> setter, bool isEnumerable, bool isConfigurable)
+void TemplateRef::setAccessorProperty(ValueRef* propertyName, OptionalRef<FunctionTemplateRef> getter, OptionalRef<FunctionTemplateRef> setter, bool isEnumerable, bool isConfigurable)
 {
     Optional<FunctionTemplate*> getterImpl(toImpl(getter.get()));
     Optional<FunctionTemplate*> setterImpl(toImpl(setter.get()));
 
-    toImpl(this)->setAccessorProperty(TemplatePropertyName(toImpl(name.value())), getterImpl, setterImpl, isEnumerable, isConfigurable);
+    toImpl(this)->setAccessorProperty(toImpl(propertyName), getterImpl, setterImpl, isEnumerable, isConfigurable);
 }
 
-void TemplateRef::setNativeDataAccessorProperty(const TemplatePropertyNameRef& name, ObjectRef::NativeDataAccessorPropertyGetter getter, ObjectRef::NativeDataAccessorPropertySetter setter,
+void TemplateRef::setNativeDataAccessorProperty(ValueRef* propertyName, ObjectRef::NativeDataAccessorPropertyGetter getter, ObjectRef::NativeDataAccessorPropertySetter setter,
                                                 bool isWritable, bool isEnumerable, bool isConfigurable, bool actsLikeJSGetterSetter)
 {
     ObjectRef::NativeDataAccessorPropertyData* publicData = new ObjectRef::NativeDataAccessorPropertyData(isWritable, isEnumerable, isConfigurable, getter, setter);
@@ -3492,10 +3492,10 @@ void TemplateRef::setNativeDataAccessorProperty(const TemplatePropertyNameRef& n
         };
     }
 
-    toImpl(this)->setNativeDataAccessorProperty(TemplatePropertyName(toImpl(name.value())), innerData, publicData);
+    toImpl(this)->setNativeDataAccessorProperty(toImpl(propertyName), innerData, publicData);
 }
 
-void TemplateRef::setNativeDataAccessorProperty(const TemplatePropertyNameRef& name, ObjectRef::NativeDataAccessorPropertyData* publicData, bool actsLikeJSGetterSetter)
+void TemplateRef::setNativeDataAccessorProperty(ValueRef* propertyName, ObjectRef::NativeDataAccessorPropertyData* publicData, bool actsLikeJSGetterSetter)
 {
     ObjectPropertyNativeGetterSetterData* innerData = new ObjectPropertyNativeGetterSetterData(publicData->m_isWritable, publicData->m_isEnumerable, publicData->m_isConfigurable,
                                                                                                [](ExecutionState& state, Object* self, const Value& receiver, const EncodedValue& privateDataFromObjectPrivateArea) -> Value {
@@ -3517,17 +3517,17 @@ void TemplateRef::setNativeDataAccessorProperty(const TemplatePropertyNameRef& n
         };
     }
 
-    toImpl(this)->setNativeDataAccessorProperty(TemplatePropertyName(toImpl(name.value())), innerData, publicData);
+    toImpl(this)->setNativeDataAccessorProperty(toImpl(propertyName), innerData, publicData);
 }
 
-bool TemplateRef::has(const TemplatePropertyNameRef& name)
+bool TemplateRef::has(ValueRef* propertyName)
 {
-    return toImpl(this)->has(TemplatePropertyName(toImpl(name.value())));
+    return toImpl(this)->has(toImpl(propertyName));
 }
 
-bool TemplateRef::remove(const TemplatePropertyNameRef& name)
+bool TemplateRef::remove(ValueRef* propertyName)
 {
-    return toImpl(this)->remove(TemplatePropertyName(toImpl(name.value())));
+    return toImpl(this)->remove(toImpl(propertyName));
 }
 
 ObjectRef* TemplateRef::instantiate(ContextRef* ctx)

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -1701,40 +1701,22 @@ public:
     static FinalizationRegistryObjectRef* create(ExecutionStateRef* state, ObjectRef* cleanupCallback, ContextRef* realm);
 };
 
-class ESCARGOT_EXPORT TemplatePropertyNameRef {
-public:
-    TemplatePropertyNameRef(StringRef* name = StringRef::emptyString())
-        : m_ptr(name)
-    {
-    }
-    TemplatePropertyNameRef(SymbolRef* name)
-        : m_ptr(name)
-    {
-    }
-
-    PointerValueRef* value() const
-    {
-        return m_ptr;
-    }
-
-private:
-    PointerValueRef* m_ptr;
-};
-
 // don't modify template after instantiate object
 // it is not intented operation
+// Note) only String or Symbol type is allowed for `propertyName`
+// because TemplateRef is set without ExecutionStateRef, so property name conversion is impossible.
 class ESCARGOT_EXPORT TemplateRef {
 public:
-    void set(const TemplatePropertyNameRef& name, ValueRef* data, bool isWritable, bool isEnumerable, bool isConfigurable);
-    void set(const TemplatePropertyNameRef& name, TemplateRef* data, bool isWritable, bool isEnumerable, bool isConfigurable);
-    void setAccessorProperty(const TemplatePropertyNameRef& name, OptionalRef<FunctionTemplateRef> getter, OptionalRef<FunctionTemplateRef> setter, bool isEnumerable, bool isConfigurable);
-    void setNativeDataAccessorProperty(const TemplatePropertyNameRef& name, ObjectRef::NativeDataAccessorPropertyGetter getter, ObjectRef::NativeDataAccessorPropertySetter setter,
+    void set(ValueRef* propertyName, ValueRef* data, bool isWritable, bool isEnumerable, bool isConfigurable);
+    void set(ValueRef* propertyName, TemplateRef* data, bool isWritable, bool isEnumerable, bool isConfigurable);
+    void setAccessorProperty(ValueRef* propertyName, OptionalRef<FunctionTemplateRef> getter, OptionalRef<FunctionTemplateRef> setter, bool isEnumerable, bool isConfigurable);
+    void setNativeDataAccessorProperty(ValueRef* propertyName, ObjectRef::NativeDataAccessorPropertyGetter getter, ObjectRef::NativeDataAccessorPropertySetter setter,
                                        bool isWritable, bool isEnumerable, bool isConfigurable, bool actsLikeJSGetterSetter = false);
-    void setNativeDataAccessorProperty(const TemplatePropertyNameRef& name, ObjectRef::NativeDataAccessorPropertyData* data, bool actsLikeJSGetterSetter = false);
+    void setNativeDataAccessorProperty(ValueRef* propertyName, ObjectRef::NativeDataAccessorPropertyData* data, bool actsLikeJSGetterSetter = false);
 
-    bool has(const TemplatePropertyNameRef& name);
+    bool has(ValueRef* propertyName);
     // return true if removed
-    bool remove(const TemplatePropertyNameRef& name);
+    bool remove(ValueRef* propertyName);
 
     ObjectRef* instantiate(ContextRef* ctx);
     bool didInstantiate();
@@ -1746,10 +1728,10 @@ public:
     void* instanceExtraData();
 };
 
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerGetterCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName);
+typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerGetterCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
 // if intercepted you may returns non-empty value.
 // the returned value will be use futuer operation(you can return true, or false)
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerSetterCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName, ValueRef* value);
+typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerSetterCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName, ValueRef* value);
 enum TemplatePropertyAttribute {
     TemplatePropertyAttributeNotExist = 1 << 0,
     TemplatePropertyAttributeExist = 1 << 1,
@@ -1757,16 +1739,15 @@ enum TemplatePropertyAttribute {
     TemplatePropertyAttributeEnumerable = 1 << 3,
     TemplatePropertyAttributeConfigurable = 1 << 4,
 };
-typedef TemplatePropertyAttribute (*TemplateNamedPropertyHandlerQueryCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName);
+typedef TemplatePropertyAttribute (*TemplateNamedPropertyHandlerQueryCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
 // if intercepted you may returns non-empty value.
 // the returned value will be use futuer operation(you can return true, or false)
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerDeleteCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName);
-typedef GCManagedVector<TemplatePropertyNameRef> TemplateNamedPropertyHandlerEnumerationCallbackResultVector;
-typedef TemplateNamedPropertyHandlerEnumerationCallbackResultVector (*TemplateNamedPropertyHandlerEnumerationCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data);
+typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerDeleteCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
+typedef ValueVectorRef* (*TemplateNamedPropertyHandlerEnumerationCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data);
 // if intercepted you may returns non-empty value.
 // the returned value will be use futuer operation(you can return true, or false)
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerDefineOwnPropertyCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName, const ObjectPropertyDescriptorRef& desc);
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerGetPropertyDescriptorCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName);
+typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerDefineOwnPropertyCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName, const ObjectPropertyDescriptorRef& desc);
+typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerGetPropertyDescriptorCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
 
 struct ESCARGOT_EXPORT ObjectTemplateNamedPropertyHandlerData {
     TemplateNamedPropertyHandlerGetterCallback getter;

--- a/src/runtime/FunctionTemplate.cpp
+++ b/src/runtime/FunctionTemplate.cpp
@@ -180,8 +180,8 @@ Object* FunctionTemplate::instantiate(Context* ctx)
     Object* functionPrototype = nullptr;
     if (m_isConstructor) {
         // [prototype, name, length]
-        if (!m_prototypeTemplate->has(ctx->staticStrings().constructor)) {
-            m_prototypeTemplate->set(ctx->staticStrings().constructor, Value(), true, false, true);
+        if (!m_prototypeTemplate->has(ctx->staticStrings().constructor.string())) {
+            m_prototypeTemplate->set(ctx->staticStrings().constructor.string(), Value(), true, false, true);
         }
 
         ObjectPropertyValue baseValues[3];

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -38,6 +38,22 @@ namespace Escargot {
 COMPILE_ASSERT(OBJECT_PROPERTY_NAME_UINT32_VIAS == (OBJECT_PROPERTY_NAME_ATOMIC_STRING_VIAS << 1), "");
 COMPILE_ASSERT(OBJECT_PROPERTY_NAME_UINT32_VIAS <= (1 << 3), "");
 
+ObjectStructurePropertyName::ObjectStructurePropertyName()
+    : m_data(((size_t)AtomicString().string()) | OBJECT_PROPERTY_NAME_ATOMIC_STRING_VIAS)
+{
+}
+
+ObjectStructurePropertyName::ObjectStructurePropertyName(const Value& value)
+{
+    // accept string or symbol value only
+    ASSERT(value.isString() || value.isSymbol());
+    if (value.isString()) {
+        m_data = reinterpret_cast<size_t>(value.asString());
+    } else {
+        m_data = reinterpret_cast<size_t>(value.asSymbol());
+    }
+}
+
 ObjectStructurePropertyName::ObjectStructurePropertyName(ExecutionState& state, const Value& valueIn)
 {
     Value value = valueIn.toPrimitive(state, Value::PreferString);

--- a/src/runtime/ObjectStructurePropertyName.h
+++ b/src/runtime/ObjectStructurePropertyName.h
@@ -25,13 +25,17 @@
 
 namespace Escargot {
 
+class Template;
+
 #define OBJECT_PROPERTY_NAME_ATOMIC_STRING_VIAS 1
 
 class ObjectStructurePropertyName {
+    friend Template;
+
 public:
     ObjectStructurePropertyName(const AtomicString& atomicString)
     {
-        m_data = ((size_t)atomicString.string() + OBJECT_PROPERTY_NAME_ATOMIC_STRING_VIAS);
+        m_data = ((size_t)atomicString.string()) | OBJECT_PROPERTY_NAME_ATOMIC_STRING_VIAS;
         ASSERT(m_data);
     }
 
@@ -40,7 +44,10 @@ public:
         m_data = (size_t)symbol;
     }
 
+    ObjectStructurePropertyName();
+    // same as `ToPropertyKey` https://262.ecma-international.org/#sec-topropertykey
     ObjectStructurePropertyName(ExecutionState& state, const Value& value);
+
     size_t hashValue() const
     {
         if (LIKELY(hasAtomicString())) {
@@ -169,6 +176,9 @@ public:
 
 private:
     size_t m_data;
+
+    // used only for Template case
+    ObjectStructurePropertyName(const Value& value);
 
 protected:
     ALWAYS_INLINE bool hasSymbol() const

--- a/test/cctest/testapi.cpp
+++ b/test/cctest/testapi.cpp
@@ -744,23 +744,23 @@ TEST(ObjectTemplate, Basic4)
     ObjectTemplateRef* tpl = ObjectTemplateRef::create();
 
     ObjectTemplateNamedPropertyHandlerData handler;
-    handler.getter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName) -> OptionalRef<ValueRef> {
-        if (propertyName.value()->isString() && propertyName.value()->asString()->equalsWithASCIIString("aaa", 3)) {
+    handler.getter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName) -> OptionalRef<ValueRef> {
+        if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("aaa", 3)) {
             return (ValueRef*)self->extraData();
         }
-        if (propertyName.value()->isString() && propertyName.value()->asString()->equalsWithASCIIString("ccc", 3)) {
+        if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("ccc", 3)) {
             return ValueRef::create(555.555);
         }
         return OptionalRef<ValueRef>();
     };
 
-    handler.setter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName, ValueRef* value) -> OptionalRef<ValueRef> {
-        if (propertyName.value()->isString() && propertyName.value()->asString()->equalsWithASCIIString("aaa", 3)) {
+    handler.setter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName, ValueRef* value) -> OptionalRef<ValueRef> {
+        if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("aaa", 3)) {
             self->setExtraData(value);
             return OptionalRef<ValueRef>(ValueRef::create(true));
         }
 
-        if (propertyName.value()->isString() && propertyName.value()->asString()->equalsWithASCIIString("ccc", 3)) {
+        if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("ccc", 3)) {
             self->setExtraData(ValueRef::create(123));
             return OptionalRef<ValueRef>(ValueRef::create(true));
         }
@@ -768,33 +768,33 @@ TEST(ObjectTemplate, Basic4)
         return OptionalRef<ValueRef>();
     };
 
-    handler.query = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName) -> TemplatePropertyAttribute {
-        if (propertyName.value()->isString() && propertyName.value()->asString()->equalsWithASCIIString("aaa", 3)) {
+    handler.query = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName) -> TemplatePropertyAttribute {
+        if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("aaa", 3)) {
             return (TemplatePropertyAttribute)(TemplatePropertyAttribute::TemplatePropertyAttributeWritable | TemplatePropertyAttribute::TemplatePropertyAttributeEnumerable | TemplatePropertyAttribute::TemplatePropertyAttributeConfigurable);
         }
-        if (propertyName.value()->isString() && propertyName.value()->asString()->equalsWithASCIIString("ccc", 3)) {
+        if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("ccc", 3)) {
             return (TemplatePropertyAttribute)(TemplatePropertyAttribute::TemplatePropertyAttributeWritable);
         }
         return TemplatePropertyAttribute::TemplatePropertyAttributeNotExist;
     };
 
-    handler.enumerator = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data) -> TemplateNamedPropertyHandlerEnumerationCallbackResultVector {
-        TemplateNamedPropertyHandlerEnumerationCallbackResultVector v(2);
-        v[0] = StringRef::createFromASCII("aaa");
-        v[1] = StringRef::createFromASCII("ccc");
+    handler.enumerator = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data) -> ValueVectorRef* {
+        ValueVectorRef* v = ValueVectorRef::create(2);
+        v->set(0, StringRef::createFromASCII("aaa"));
+        v->set(1, StringRef::createFromASCII("ccc"));
         return v;
     };
 
-    handler.deleter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName) -> OptionalRef<ValueRef> {
-        if (propertyName.value()->isString() && propertyName.value()->asString()->equalsWithASCIIString("ddd", 3)) {
+    handler.deleter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName) -> OptionalRef<ValueRef> {
+        if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("ddd", 3)) {
             return OptionalRef<ValueRef>(ValueRef::create(false));
         }
 
         return OptionalRef<ValueRef>();
     };
 
-    handler.descriptor = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName) -> OptionalRef<ValueRef> {
-        if (propertyName.value()->isString() && propertyName.value()->asString()->equalsWithASCIIString("eee", 3)) {
+    handler.descriptor = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName) -> OptionalRef<ValueRef> {
+        if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("eee", 3)) {
             ObjectRef* desc = ObjectRef::create(state);
             desc->set(state, StringRef::createFromASCII("value"), ValueRef::createNull());
             return desc;
@@ -862,11 +862,11 @@ TEST(ObjectTemplate, Basic4)
 
     ObjectTemplateRef* tpl2 = ObjectTemplateRef::create();
     ObjectTemplateNamedPropertyHandlerData handler2;
-    handler2.getter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName) -> OptionalRef<ValueRef> {
+    handler2.getter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName) -> OptionalRef<ValueRef> {
         return OptionalRef<ValueRef>();
     };
-    handler2.definer = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, const TemplatePropertyNameRef& propertyName, const ObjectPropertyDescriptorRef& desc) -> OptionalRef<ValueRef> {
-        if (propertyName.value()->isString() && propertyName.value()->asString()->equalsWithASCIIString("ttt", 3)) {
+    handler2.definer = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName, const ObjectPropertyDescriptorRef& desc) -> OptionalRef<ValueRef> {
+        if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("ttt", 3)) {
             return OptionalRef<ValueRef>(ValueRef::create(false));
         }
         return OptionalRef<ValueRef>();


### PR DESCRIPTION
* usually property name is delivered as Value format
* replace `TemplatePropertyName` with `ObjectStructurePropertyName` to handle Value format nicely

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>