### PR TITLE
Fix compile error on gcc version 5

### DIFF
--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -176,6 +176,21 @@
 #define NOMINMAX
 #endif
 
+/*
+we need to mark enum as unsigned if needs.
+because processing enum in msvc is little different
+
+ex) enum Type { A, B };
+struct Foo { Type type: 1; };
+Foo f; f.type = 1;
+if (f.type == Type::B) { puts("failed in msvc."); }
+*/
+#if defined(COMPILER_MSVC)
+#define ENSURE_ENUM_UNSIGNED : unsigned int
+#else
+#define ENSURE_ENUM_UNSIGNED
+#endif
+
 #if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
 #define HAVE_BUILTIN_ATOMIC_FUNCTIONS
 #endif

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -262,7 +262,7 @@ public:
 
 class MetaPropertyOperation : public ByteCode {
 public:
-    enum Type : unsigned {
+    enum Type ENSURE_ENUM_UNSIGNED {
         NewTarget,
         ImportMeta
     };
@@ -437,7 +437,7 @@ public:
 
 class InitializeClass : public ByteCode {
 public:
-    enum Stage : unsigned {
+    enum Stage ENSURE_ENUM_UNSIGNED {
         CreateClass,
         SetFieldSize,
         InitField,
@@ -708,7 +708,7 @@ BYTECODE_SIZE_CHECK_IN_32BIT(SuperReference, sizeof(size_t) * 2);
 
 class ComplexSetObjectOperation : public ByteCode {
 public:
-    enum Type : unsigned {
+    enum Type ENSURE_ENUM_UNSIGNED {
         Super,
         Private,
         PrivateWithoutOuterClass
@@ -757,7 +757,7 @@ public:
 
 class ComplexGetObjectOperation : public ByteCode {
 public:
-    enum Type : unsigned {
+    enum Type ENSURE_ENUM_UNSIGNED {
         Super,
         Private,
         PrivateWithoutOuterClass
@@ -1884,7 +1884,7 @@ public:
 
 class CallFunctionComplexCase : public ByteCode {
 public:
-    enum Kind : unsigned {
+    enum Kind ENSURE_ENUM_UNSIGNED {
         WithSpreadElement,
         MayBuiltinApply,
         MayBuiltinEval,
@@ -1980,7 +1980,7 @@ public:
 
 class ExecutionPause : public ByteCode {
 public:
-    enum Reason : unsigned {
+    enum Reason ENSURE_ENUM_UNSIGNED {
         Yield,
         Await,
         GeneratorsInitialize
@@ -2303,7 +2303,7 @@ public:
 
 class IteratorOperation : public ByteCode {
 public:
-    enum Operation : unsigned {
+    enum Operation ENSURE_ENUM_UNSIGNED {
         GetIterator,
         IteratorClose,
         IteratorBind,
@@ -2505,7 +2505,7 @@ public:
 
 class OpenLexicalEnvironment : public ByteCode {
 public:
-    enum Kind : unsigned {
+    enum Kind ENSURE_ENUM_UNSIGNED {
         WithStatement,
         ResumeExecution
     };
@@ -2617,7 +2617,7 @@ public:
 
 class TaggedTemplateOperation : public ByteCode {
 public:
-    enum Operation : unsigned {
+    enum Operation ENSURE_ENUM_UNSIGNED {
         TestCacheOperation,
         FillCacheOperation
     };

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -212,7 +212,7 @@ public:
         bool m_isStackAllocated : 1;
         bool m_isMutable : 1;
         bool m_isGlobalLexicalVariable : 1;
-        enum DeclarationType : unsigned {
+        enum DeclarationType ENSURE_ENUM_UNSIGNED {
             VarDeclared,
             LexicallyDeclared,
         };


### PR DESCRIPTION
gcc version 5 cannot decide how many bits are require for enum well
if there is enum has type. it generates warning but we don't need to set type into enum for gcc 5

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>