### PR TITLE
Enable created function's format check only for non-reloadable string…

### DIFF
--- a/src/parser/ParserStringView.h
+++ b/src/parser/ParserStringView.h
@@ -159,8 +159,6 @@ protected:
             m_bufferData.buffer = ((char16_t*)srcData.buffer) + start;
         }
     }
-
-private:
 };
 
 } // namespace Escargot

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -88,6 +88,9 @@ public:
 };
 
 struct StringBufferAccessData {
+    // should be allocated on the stack
+    MAKE_STACK_ALLOCATED();
+
     bool has8BitContent;
     size_t length;
     union {
@@ -657,10 +660,6 @@ public:
     void* operator new(size_t size, GCPlacement p)
     {
         return gc::operator new(size, p);
-    }
-    void* operator new(size_t, void* ptr)
-    {
-        return ptr;
     }
     void* operator new[](size_t size) = delete;
 };

--- a/test/cctest/testapi.cpp
+++ b/test/cctest/testapi.cpp
@@ -1718,6 +1718,8 @@ TEST(ReloadableString, Basic)
         free(memoryPtr); });
 
     EXPECT_FALSE(d.flag);
+    EXPECT_TRUE(string->has8BitContent());
+    EXPECT_FALSE(d.flag);
     string->length();
     EXPECT_FALSE(d.flag);
     string->charAt(0);
@@ -1733,6 +1735,8 @@ TEST(ReloadableString, Basic)
         // body string(string) is unloaded right after function creation because body string is no longer necessary when function creation finished
         EXPECT_FALSE(d->flag);
         EXPECT_TRUE(fn->toString(state)->toStdUTF8String() == "function test(asdf\n) {\nlet x = 'test String'\n}");
+        EXPECT_FALSE(d->flag);
+        EXPECT_TRUE(fn->toString(state)->has8BitContent());
         EXPECT_FALSE(d->flag);
         string->charAt(0);
         EXPECT_TRUE(d->flag);


### PR DESCRIPTION
… in test mode

* format check requires double-parsing for the same source string
* format check is necessary to filter out a few format cases only
* in general mode, format check is limited to speed up the function creation process

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>