### PR TITLE
Implement setIndexedPropertyHandler for ObjectTemplate 

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -1383,7 +1383,7 @@ public:
 
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override
     {
-        Value PV = P.toPlainValue(state);
+        Value PV = P.toPlainValue();
         if (!PV.isSymbol()) {
             auto result = m_getOwnPropetyCallback(toRef(&state), toRef(this), toRef(PV));
             if (result.m_value.hasValue()) {
@@ -1396,7 +1396,7 @@ public:
     {
         // Only value type supported
         if (desc.isValuePresent()) {
-            Value PV = P.toPlainValue(state);
+            Value PV = P.toPlainValue();
             if (!PV.isSymbol() && m_defineOwnPropertyCallback(toRef(&state), toRef(this), toRef(PV), toRef(desc.value()))) {
                 return true;
             }
@@ -1405,11 +1405,11 @@ public:
     }
     virtual bool deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override
     {
-        Value PV = P.toPlainValue(state);
+        Value PV = P.toPlainValue();
         if (!PV.isSymbol()) {
-            auto result = m_getOwnPropetyCallback(toRef(&state), toRef(this), toRef(P.toPlainValue(state)));
+            auto result = m_getOwnPropetyCallback(toRef(&state), toRef(this), toRef(P.toPlainValue()));
             if (result.m_value.hasValue()) {
-                return m_deleteOwnPropertyCallback(toRef(&state), toRef(this), toRef(P.toPlainValue(state)));
+                return m_deleteOwnPropertyCallback(toRef(&state), toRef(this), toRef(P.toPlainValue()));
             }
         }
         return Object::deleteOwnProperty(state, P);
@@ -1723,7 +1723,7 @@ void ObjectRef::enumerateObjectOwnProperties(ExecutionStateRef* state, const std
     toImpl(this)->enumeration(*toImpl(state), [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
         const std::function<bool(ExecutionStateRef * state, ValueRef * propertyName, bool isWritable, bool isEnumerable, bool isConfigurable)>* cb
             = (const std::function<bool(ExecutionStateRef * state, ValueRef * propertyName, bool isWritable, bool isEnumerable, bool isConfigurable)>*)data;
-        return (*cb)(toRef(&state), toRef(name.toPlainValue(state)), desc.isWritable(), desc.isEnumerable(), desc.isConfigurable());
+        return (*cb)(toRef(&state), toRef(name.toPlainValue()), desc.isWritable(), desc.isEnumerable(), desc.isConfigurable());
     },
                               (void*)&cb, shouldSkipSymbolKey);
 }
@@ -3565,14 +3565,14 @@ ObjectTemplateRef* ObjectTemplateRef::create()
     return toRef(new ObjectTemplate());
 }
 
-void ObjectTemplateRef::setNamedPropertyHandler(const ObjectTemplateNamedPropertyHandlerData& data)
+void ObjectTemplateRef::setNamedPropertyHandler(const ObjectTemplatePropertyHandlerData& data)
 {
     toImpl(this)->setNamedPropertyHandler(data);
 }
 
-void ObjectTemplateRef::removeNamedPropertyHandler()
+void ObjectTemplateRef::removePropertyHandler()
 {
-    toImpl(this)->removeNamedPropertyHandler();
+    toImpl(this)->removePropertyHandler();
 }
 
 OptionalRef<FunctionTemplateRef> ObjectTemplateRef::constructor()

--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -3565,14 +3565,24 @@ ObjectTemplateRef* ObjectTemplateRef::create()
     return toRef(new ObjectTemplate());
 }
 
-void ObjectTemplateRef::setNamedPropertyHandler(const ObjectTemplatePropertyHandlerData& data)
+void ObjectTemplateRef::setNamedPropertyHandler(const ObjectTemplatePropertyHandlerConfiguration& data)
 {
     toImpl(this)->setNamedPropertyHandler(data);
 }
 
-void ObjectTemplateRef::removePropertyHandler()
+void ObjectTemplateRef::setIndexedPropertyHandler(const ObjectTemplatePropertyHandlerConfiguration& data)
 {
-    toImpl(this)->removePropertyHandler();
+    toImpl(this)->setIndexedPropertyHandler(data);
+}
+
+void ObjectTemplateRef::removeNamedPropertyHandler()
+{
+    toImpl(this)->removeNamedPropertyHandler();
+}
+
+void ObjectTemplateRef::removeIndexedPropertyHandler()
+{
+    toImpl(this)->removeIndexedPropertyHandler();
 }
 
 OptionalRef<FunctionTemplateRef> ObjectTemplateRef::constructor()

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -1036,7 +1036,7 @@ public:
     void operator delete[](void* obj) = delete;
 
 private:
-    friend class ObjectWithNamedPropertyHandler;
+    friend class ObjectWithPropertyHandler;
     ObjectPropertyDescriptorRef(void* src);
 
     void* m_privateData;
@@ -1728,10 +1728,10 @@ public:
     void* instanceExtraData();
 };
 
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerGetterCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
+typedef OptionalRef<ValueRef> (*TemplatePropertyHandlerGetterCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
 // if intercepted you may returns non-empty value.
 // the returned value will be use futuer operation(you can return true, or false)
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerSetterCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName, ValueRef* value);
+typedef OptionalRef<ValueRef> (*TemplatePropertyHandlerSetterCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName, ValueRef* value);
 enum TemplatePropertyAttribute {
     TemplatePropertyAttributeNotExist = 1 << 0,
     TemplatePropertyAttributeExist = 1 << 1,
@@ -1739,34 +1739,34 @@ enum TemplatePropertyAttribute {
     TemplatePropertyAttributeEnumerable = 1 << 3,
     TemplatePropertyAttributeConfigurable = 1 << 4,
 };
-typedef TemplatePropertyAttribute (*TemplateNamedPropertyHandlerQueryCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
+typedef TemplatePropertyAttribute (*TemplatePropertyHandlerQueryCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
 // if intercepted you may returns non-empty value.
 // the returned value will be use futuer operation(you can return true, or false)
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerDeleteCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
-typedef ValueVectorRef* (*TemplateNamedPropertyHandlerEnumerationCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data);
+typedef OptionalRef<ValueRef> (*TemplatePropertyHandlerDeleteCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
+typedef ValueVectorRef* (*TemplatePropertyHandlerEnumerationCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data);
 // if intercepted you may returns non-empty value.
 // the returned value will be use futuer operation(you can return true, or false)
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerDefineOwnPropertyCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName, const ObjectPropertyDescriptorRef& desc);
-typedef OptionalRef<ValueRef> (*TemplateNamedPropertyHandlerGetPropertyDescriptorCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
+typedef OptionalRef<ValueRef> (*TemplatePropertyHandlerDefineOwnPropertyCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName, const ObjectPropertyDescriptorRef& desc);
+typedef OptionalRef<ValueRef> (*TemplatePropertyHandlerGetPropertyDescriptorCallback)(ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName);
 
-struct ESCARGOT_EXPORT ObjectTemplateNamedPropertyHandlerData {
-    TemplateNamedPropertyHandlerGetterCallback getter;
-    TemplateNamedPropertyHandlerSetterCallback setter;
-    TemplateNamedPropertyHandlerQueryCallback query;
-    TemplateNamedPropertyHandlerDeleteCallback deleter;
-    TemplateNamedPropertyHandlerEnumerationCallback enumerator;
-    TemplateNamedPropertyHandlerDefineOwnPropertyCallback definer;
-    TemplateNamedPropertyHandlerGetPropertyDescriptorCallback descriptor;
+struct ESCARGOT_EXPORT ObjectTemplatePropertyHandlerData {
+    TemplatePropertyHandlerGetterCallback getter;
+    TemplatePropertyHandlerSetterCallback setter;
+    TemplatePropertyHandlerQueryCallback query;
+    TemplatePropertyHandlerDeleteCallback deleter;
+    TemplatePropertyHandlerEnumerationCallback enumerator;
+    TemplatePropertyHandlerDefineOwnPropertyCallback definer;
+    TemplatePropertyHandlerGetPropertyDescriptorCallback descriptor;
     void* data;
 
-    ObjectTemplateNamedPropertyHandlerData(
-        TemplateNamedPropertyHandlerGetterCallback getter = nullptr,
-        TemplateNamedPropertyHandlerSetterCallback setter = nullptr,
-        TemplateNamedPropertyHandlerQueryCallback query = nullptr,
-        TemplateNamedPropertyHandlerDeleteCallback deleter = nullptr,
-        TemplateNamedPropertyHandlerEnumerationCallback enumerator = nullptr,
-        TemplateNamedPropertyHandlerDefineOwnPropertyCallback definer = nullptr,
-        TemplateNamedPropertyHandlerGetPropertyDescriptorCallback descriptor = nullptr,
+    ObjectTemplatePropertyHandlerData(
+        TemplatePropertyHandlerGetterCallback getter = nullptr,
+        TemplatePropertyHandlerSetterCallback setter = nullptr,
+        TemplatePropertyHandlerQueryCallback query = nullptr,
+        TemplatePropertyHandlerDeleteCallback deleter = nullptr,
+        TemplatePropertyHandlerEnumerationCallback enumerator = nullptr,
+        TemplatePropertyHandlerDefineOwnPropertyCallback definer = nullptr,
+        TemplatePropertyHandlerGetPropertyDescriptorCallback descriptor = nullptr,
         void* data = nullptr)
         : getter(getter)
         , setter(setter)
@@ -1790,8 +1790,8 @@ public:
 class ESCARGOT_EXPORT ObjectTemplateRef : public TemplateRef {
 public:
     static ObjectTemplateRef* create();
-    void setNamedPropertyHandler(const ObjectTemplateNamedPropertyHandlerData& data);
-    void removeNamedPropertyHandler();
+    void setNamedPropertyHandler(const ObjectTemplatePropertyHandlerData& data);
+    void removePropertyHandler();
 
     // returns function template if object template is instance template of function template
     OptionalRef<FunctionTemplateRef> constructor();

--- a/src/builtins/BuiltinArray.cpp
+++ b/src/builtins/BuiltinArray.cpp
@@ -412,7 +412,7 @@ static Value builtinArrayJoin(ExecutionState& state, Value thisValue, size_t arg
                     int64_t index;
                     Data* e = (Data*)data;
                     int64_t* ret = &e->ret;
-                    Value key = name.toPlainValue(state);
+                    Value key = name.toPlainValue();
                     index = key.toNumber(state);
                     if ((uint64_t)index != Value::InvalidIndexValue) {
                         if (self->get(state, name).value(state, self).isUndefined()) {

--- a/src/builtins/BuiltinJSON.cpp
+++ b/src/builtins/BuiltinJSON.cpp
@@ -279,7 +279,7 @@ static Value builtinJSONParse(ExecutionState& state, Value thisValue, size_t arg
                     }
                 }
             }
-            Value arguments[] = { name.toPlainValue(state), val };
+            Value arguments[] = { name.toPlainValue(), val };
             return Object::call(state, reviver, holder, 2, arguments);
         };
         return Walk(root, ObjectPropertyName(state, String::emptyString));
@@ -643,7 +643,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
 
             std::vector<Value::ValueIndex> indexes;
             arrObject->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& P, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
-                Value::ValueIndex idx = P.toPlainValue(state).toNumber(state);
+                Value::ValueIndex idx = P.toPlainValue().toNumber(state);
                 if (idx != Value::InvalidIndexValue) {
                     std::vector<Value::ValueIndex>* indexes = (std::vector<Value::ValueIndex>*)data;
                     indexes->push_back(idx);

--- a/src/runtime/EnumerateObject.cpp
+++ b/src/runtime/EnumerateObject.cpp
@@ -128,7 +128,7 @@ void EnumerateObjectWithDestruction::executeEnumeration(ExecutionState& state, E
 
     m_object->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
         auto properties = (Properties*)data;
-        auto value = name.toPlainValue(state);
+        auto value = name.toPlainValue();
         if (desc.isEnumerable()) {
             Value::ValueIndex nameAsIndexValue;
             if (value.isSymbol()) {
@@ -229,7 +229,7 @@ void EnumerateObjectWithIteration::executeEnumeration(ExecutionState& state, Enc
             target.asObject()->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
                 EData* eData = (EData*)data;
                 if (desc.isEnumerable()) {
-                    String* key = name.toPlainValue(state).toString(state);
+                    String* key = name.toPlainValue().toString(state);
                     auto iter = eData->keyStringSet->find(key);
                     if (iter == eData->keyStringSet->end()) {
                         eData->keyStringSet->insert(key);
@@ -238,7 +238,7 @@ void EnumerateObjectWithIteration::executeEnumeration(ExecutionState& state, Enc
                 } else if (self == eData->obj) {
                     // 12.6.4 The values of [[Enumerable]] attributes are not considered
                     // when determining if a property of a prototype object is shadowed by a previous object on the prototype chain.
-                    String* key = name.toPlainValue(state).toString(state);
+                    String* key = name.toPlainValue().toString(state);
                     ASSERT(eData->keyStringSet->find(key) == eData->keyStringSet->end());
                     eData->keyStringSet->insert(key);
                 }
@@ -255,7 +255,7 @@ void EnumerateObjectWithIteration::executeEnumeration(ExecutionState& state, Enc
 
         m_object->enumeration(state, [](ExecutionState& state, Object* self, const ObjectPropertyName& name, const ObjectStructurePropertyDescriptor& desc, void* data) -> bool {
             auto properties = (Properties*)data;
-            auto value = name.toPlainValue(state);
+            auto value = name.toPlainValue();
             if (desc.isEnumerable()) {
                 Value::ValueIndex nameAsIndexValue;
                 if (name.isIndexString() && (nameAsIndexValue = value.toIndex(state)) != Value::InvalidIndexValue) {

--- a/src/runtime/GlobalObject.cpp
+++ b/src/runtime/GlobalObject.cpp
@@ -129,7 +129,7 @@ ObjectHasPropertyResult GlobalObject::hasProperty(ExecutionState& state, const O
             }
             target = target->getPrototypeObject(state);
         }
-        Value virtialIdResult = state.context()->virtualIdentifierCallback()(state, P.toPlainValue(state));
+        Value virtialIdResult = state.context()->virtualIdentifierCallback()(state, P.toPlainValue());
         if (!virtialIdResult.isEmpty()) {
             return ObjectHasPropertyResult(ObjectGetResult(virtialIdResult, true, true, true));
         }
@@ -150,7 +150,7 @@ ObjectGetResult GlobalObject::getOwnProperty(ExecutionState& state, const Object
             }
             target = target->getPrototypeObject(state);
         }
-        Value virtialIdResult = state.context()->virtualIdentifierCallback()(state, P.toPlainValue(state));
+        Value virtialIdResult = state.context()->virtualIdentifierCallback()(state, P.toPlainValue());
         if (!virtialIdResult.isEmpty())
             return ObjectGetResult(virtialIdResult, true, true, true);
     }

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -1564,7 +1564,7 @@ void Object::nextIndexForward(ExecutionState& state, Object* obj, const int64_t 
             int64_t index;
             Data* e = (Data*)data;
             int64_t* ret = e->ret;
-            Value key = name.toPlainValue(state);
+            Value key = name.toPlainValue();
             index = key.toNumber(state);
             if ((uint64_t)index != Value::InvalidIndexValue) {
                 if (index > *e->cur && *ret > index) {
@@ -1599,7 +1599,7 @@ void Object::nextIndexBackward(ExecutionState& state, Object* obj, const int64_t
             int64_t index;
             Data* e = (Data*)data;
             int64_t* ret = e->ret;
-            Value key = name.toPlainValue(state);
+            Value key = name.toPlainValue();
             index = key.toNumber(state);
             if ((uint64_t)index != Value::InvalidIndexValue) {
                 if (index < *e->cur) {

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -231,7 +231,7 @@ public:
         return objectStructurePropertyName().tryToUseAsIndexProperty();
     }
 
-    Value toPlainValue(ExecutionState&) const
+    Value toPlainValue() const
     {
         if (isUIntType()) {
             return Value(uintValue());

--- a/src/runtime/ObjectTemplate.h
+++ b/src/runtime/ObjectTemplate.h
@@ -25,7 +25,7 @@
 namespace Escargot {
 
 class FunctionTemplate;
-struct ObjectTemplateNamedPropertyHandlerData;
+struct ObjectTemplatePropertyHandlerData;
 
 class ObjectTemplate : public Template {
 public:
@@ -50,12 +50,12 @@ public:
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 
-    void setNamedPropertyHandler(const ObjectTemplateNamedPropertyHandlerData& data);
-    void removeNamedPropertyHandler();
+    void setNamedPropertyHandler(const ObjectTemplatePropertyHandlerData& data);
+    void removePropertyHandler();
 
-protected:
+private:
     Optional<FunctionTemplate*> m_constructor;
-    ObjectTemplateNamedPropertyHandlerData* m_namedPropertyHandler;
+    ObjectTemplatePropertyHandlerData* m_propertyHandler;
 };
 } // namespace Escargot
 

--- a/src/runtime/ObjectTemplate.h
+++ b/src/runtime/ObjectTemplate.h
@@ -25,7 +25,8 @@
 namespace Escargot {
 
 class FunctionTemplate;
-struct ObjectTemplatePropertyHandlerData;
+class ObjectTemplatePropertyHandlerData;
+struct ObjectTemplatePropertyHandlerConfiguration;
 
 class ObjectTemplate : public Template {
 public:
@@ -50,12 +51,15 @@ public:
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 
-    void setNamedPropertyHandler(const ObjectTemplatePropertyHandlerData& data);
-    void removePropertyHandler();
+    void setNamedPropertyHandler(const ObjectTemplatePropertyHandlerConfiguration& data);
+    void setIndexedPropertyHandler(const ObjectTemplatePropertyHandlerConfiguration& data);
+    void removeNamedPropertyHandler();
+    void removeIndexedPropertyHandler();
 
 private:
     Optional<FunctionTemplate*> m_constructor;
-    ObjectTemplatePropertyHandlerData* m_propertyHandler;
+    ObjectTemplatePropertyHandlerData* m_namedPropertyHandler;
+    ObjectTemplatePropertyHandlerData* m_indexedPropertyHandler;
 };
 } // namespace Escargot
 

--- a/test/cctest/testapi.cpp
+++ b/test/cctest/testapi.cpp
@@ -743,7 +743,7 @@ TEST(ObjectTemplate, Basic4)
 {
     ObjectTemplateRef* tpl = ObjectTemplateRef::create();
 
-    ObjectTemplateNamedPropertyHandlerData handler;
+    ObjectTemplatePropertyHandlerData handler;
     handler.getter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName) -> OptionalRef<ValueRef> {
         if (propertyName->isString() && propertyName->asString()->equalsWithASCIIString("aaa", 3)) {
             return (ValueRef*)self->extraData();
@@ -861,7 +861,7 @@ TEST(ObjectTemplate, Basic4)
 
 
     ObjectTemplateRef* tpl2 = ObjectTemplateRef::create();
-    ObjectTemplateNamedPropertyHandlerData handler2;
+    ObjectTemplatePropertyHandlerData handler2;
     handler2.getter = [](ExecutionStateRef* state, ObjectRef* self, ValueRef* receiver, void* data, ValueRef* propertyName) -> OptionalRef<ValueRef> {
         return OptionalRef<ValueRef>();
     };


### PR DESCRIPTION
* update to common PropertyHandler data and strucuture to represent IndexedProperty and NamedProperty both
* check property name in each ObjectWithPropertyHandler method
* rename data related to PropertyHandler
* refactoring ObjectWithPropertyHandler to handle NamedProperty and IndexedProperty

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>