### PR TITLE
Fix crash in debugger

### DIFF
--- a/tools/debugger/debugger_core.py
+++ b/tools/debugger/debugger_core.py
@@ -438,8 +438,8 @@ class Debugger(object):
                                  ESCARGOT_MESSAGE_EVAL_FAILED_16BIT,
                                  ESCARGOT_MESSAGE_EVAL_FAILED_16BIT_END]:
                 self.prompt = True
-                result = self._receive_string(ESCARGOT_MESSAGE_EVAL_RESULT_8BIT, data);
-                return DebuggerAction(DebuggerAction.TEXT, "%sException: %s%s" % (self.red, result, self.no_color));
+                result = self._receive_string(ESCARGOT_MESSAGE_EVAL_FAILED_8BIT, data);
+                return DebuggerAction(DebuggerAction.TEXT, "%sException: %s%s" % (self.red, result, self.nocolor));
 
             elif buffer_type in [ESCARGOT_MESSAGE_BACKTRACE,
                                  ESCARGOT_MESSAGE_EXCEPTION_BACKTRACE]:

--- a/tools/debugger/tests/do_eval.cmd
+++ b/tools/debugger/tests/do_eval.cmd
@@ -10,4 +10,6 @@ p b
 p c
 p d
 p e
+e k
+p k
 c

--- a/tools/debugger/tests/do_eval.expected
+++ b/tools/debugger/tests/do_eval.expected
@@ -15,6 +15,8 @@ function(){ return 1; }(escargot-debugger) e e
 Alma(escargot-debugger) p c
 undefined(escargot-debugger) p d
 function(){ return 1; }(escargot-debugger) p e
-[object Object](escargot-debugger) c
+[object Object](escargot-debugger) e k
+Exception: ReferenceError: k is not defined(escargot-debugger) p k
+Exception: ReferenceError: k is not defined(escargot-debugger) c
 Print: 42
 Connection closed.


### PR DESCRIPTION
There was a crash in debugger when a not existing variable was printed or evaluated.
This patch will fix this issue.

Signed-off-by: Gergo Csizi gergocs@inf.u-szeged.hu