### PR TITLE
Simplify the parsing API of the debugger.

### DIFF
--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -141,7 +141,7 @@ void ByteCodeGenerateContext::insertBreakpoint(size_t index, Node* node)
 void ByteCodeGenerateContext::insertBreakpointAt(size_t line, Node* node)
 {
     if (m_breakpointContext->m_parsingEnabled) {
-        m_breakpointContext->m_breakpointLocations.push_back(Debugger::BreakpointLocation(line, (uint32_t)m_byteCodeBlock->currentCodeSize()));
+        m_breakpointContext->m_breakpointLocations->push_back(Debugger::BreakpointLocation(line, (uint32_t)m_byteCodeBlock->currentCodeSize()));
         m_byteCodeBlock->pushCode(BreakpointDisabled(ByteCodeLOC(node->loc().index)), this, node);
     }
 }
@@ -198,8 +198,8 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* context, Interpreted
     ast->generateStatementByteCode(block, &ctx);
 
 #ifdef ESCARGOT_DEBUGGER
-    if (breakpointContext.m_parsingEnabled) {
-        context->debugger()->storeBreakpointLocations(breakpointContext.m_breakpointLocations);
+    if (breakpointContext.m_parsingEnabled && context->debugger() != nullptr) {
+        context->debugger()->appendBreakpointLocations(codeBlock, breakpointContext.m_breakpointLocations);
     }
 #endif /* ESCARGOT_DEBUGGER */
 

--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -57,12 +57,13 @@ struct ByteCodeBreakpointContext {
     bool m_parsingEnabled;
     size_t m_lastBreakpointLineOffset;
     size_t m_lastBreakpointIndexOffset;
-    std::vector<Debugger::BreakpointLocation> m_breakpointLocations;
+    Debugger::BreakpointLocationVector* m_breakpointLocations;
 
     ByteCodeBreakpointContext(bool parsingEnabled)
         : m_parsingEnabled(parsingEnabled)
         , m_lastBreakpointLineOffset(0)
         , m_lastBreakpointIndexOffset(0)
+        , m_breakpointLocations(new Debugger::BreakpointLocationVector())
     {
     }
 };

--- a/src/parser/ast/ProgramNode.h
+++ b/src/parser/ast/ProgramNode.h
@@ -53,7 +53,7 @@ public:
         codeBlock->finalizeLexicalBlock(context, blockContext);
 
 #ifdef ESCARGOT_DEBUGGER
-        if (context->m_breakpointContext->m_breakpointLocations.size() == 0) {
+        if (context->m_breakpointContext->m_breakpointLocations->size() == 0) {
             if (context->m_isEvalCode) {
                 context->insertBreakpointAt(1, this);
             } else {

--- a/src/parser/ast/ReturnStatementNode.h
+++ b/src/parser/ast/ReturnStatementNode.h
@@ -36,9 +36,9 @@ public:
     virtual void generateStatementByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context) override
     {
 #ifdef ESCARGOT_DEBUGGER
-        if (context->m_breakpointContext->m_breakpointLocations.size() == 0 && context->m_breakpointContext->m_parsingEnabled) {
+        if (context->m_breakpointContext->m_breakpointLocations->size() == 0 && context->m_breakpointContext->m_parsingEnabled) {
             ASSERT(context->m_breakpointContext->m_lastBreakpointLineOffset == 0);
-            ASSERT(context->m_breakpointContext->m_breakpointLocations.size() == 0);
+            ASSERT(context->m_breakpointContext->m_breakpointLocations->size() == 0);
 
             InterpretedCodeBlock* interpretedCodeBlock = context->m_codeBlock;
 


### PR DESCRIPTION
The new method uses only a single virtual function. Should be much better for a C++ API.