### PR TITLE
Add reference counter in CompressibleString and ReloadableString

### DIFF
--- a/src/runtime/CompressibleString.cpp
+++ b/src/runtime/CompressibleString.cpp
@@ -155,9 +155,9 @@ bool CompressibleString::compress()
 
     bool has8Bit = m_bufferData.has8BitContent;
     if (has8Bit) {
-        return compressWorker<LChar>(currentStackPointer());
+        return compressWorker<LChar>();
     } else {
-        return compressWorker<char16_t>(currentStackPointer());
+        return compressWorker<char16_t>();
     }
 }
 
@@ -178,18 +178,10 @@ constexpr static const size_t g_compressChunkSize = 1044465;
 static_assert(LZ4_COMPRESSBOUND(g_compressChunkSize) == 1024 * 1024, "");
 
 template <typename StringType>
-bool CompressibleString::compressWorker(void* callerSP)
+bool CompressibleString::compressWorker()
 {
     ASSERT(!m_isCompressed && !m_refCount);
     ASSERT(m_bufferData.length > 0);
-
-#if defined(STACK_GROWS_DOWN)
-    size_t* start = (size_t*)((size_t)callerSP & ~(sizeof(size_t) - 1));
-    size_t* end = (size_t*)m_vmInstance->stackStartAddress();
-#else
-    size_t* start = (size_t*)m_vmInstance->stackStartAddress();
-    size_t* end = (size_t*)((size_t)callerSP & ~(sizeof(size_t) - 1));
-#endif
 
     size_t originByteLength = m_bufferData.length * sizeof(StringType);
     int lastBoundLength = 0;

--- a/src/runtime/CompressibleString.h
+++ b/src/runtime/CompressibleString.h
@@ -67,12 +67,19 @@ public:
         if (isCompressed()) {
             decompress();
         }
-        return StringBufferAccessData(m_bufferData.has8BitContent, m_bufferData.length, const_cast<void*>(m_bufferData.buffer));
+
+        // add refCount pointer to count its usage in StringBufferAccessData
+        return StringBufferAccessData(m_bufferData.has8BitContent, m_bufferData.length, const_cast<void*>(m_bufferData.buffer), &m_refCount);
     }
 
     bool isCompressed()
     {
         return m_isCompressed;
+    }
+
+    size_t refCount() const
+    {
+        return m_refCount;
     }
 
     void* operator new(size_t);
@@ -106,6 +113,7 @@ private:
 
     bool m_isOwnerMayFreed;
     bool m_isCompressed;
+    size_t m_refCount; // reference count representing the usage of this CompressibleString
     VMInstance* m_vmInstance;
     uint64_t m_lastUsedTickcount;
     typedef std::vector<std::vector<char>> CompressedDataVector;

--- a/src/runtime/CompressibleString.h
+++ b/src/runtime/CompressibleString.h
@@ -107,7 +107,7 @@ private:
     }
 
     template <typename StringType>
-    NEVER_INLINE bool compressWorker(void* callerSP);
+    NEVER_INLINE bool compressWorker();
     template <typename StringType>
     NEVER_INLINE void decompressWorker();
 

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -144,18 +144,19 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
 
                 char* dest = reinterpret_cast<char*>(malloc((data->m_dest->length()) * (is8Bit ? 1 : 2)));
 
+                {
                 auto headAccessData = data->m_head->bufferAccessData();
                 auto bodyAccessData = data->m_body->bufferAccessData();
 
                 if (is8Bit) {
-                    ASSERT(headAccessData.has8BitContent && bodyAccessData.has8BitContent);
-                    char* ptr = dest;
-                    memcpy(ptr, headAccessData.bufferAs8Bit, headAccessData.length);
-                    ptr += headAccessData.length;
-                    memcpy(ptr, bodyAccessData.bufferAs8Bit, bodyAccessData.length);
-                    ptr += bodyAccessData.length;
-                    ptr[0] = '\n';
-                    ptr[1] = '}';
+                ASSERT(headAccessData.has8BitContent && bodyAccessData.has8BitContent);
+                char* ptr = dest;
+                memcpy(ptr, headAccessData.bufferAs8Bit, headAccessData.length);
+                ptr += headAccessData.length;
+                memcpy(ptr, bodyAccessData.bufferAs8Bit, bodyAccessData.length);
+                ptr += bodyAccessData.length;
+                ptr[0] = '\n';
+                ptr[1] = '}';
                 } else {
                     char16_t* ptr = reinterpret_cast<char16_t*>(dest);
                     if (headAccessData.has8BitContent) {
@@ -179,10 +180,9 @@ FunctionObject::FunctionSource FunctionObject::createFunctionSourceFromScriptSou
                     ptr[0] = '\n';
                     ptr[1] = '}';
                 }
+                }
 
                 // unload original body source immediately
-                // set nullptr to unload body string
-                bodyAccessData.buffer = nullptr;
                 data->m_body->unload();
                 return dest; }, [](void* memoryPtr, void* callbackData) { free(memoryPtr); });
 

--- a/src/runtime/ReloadableString.h
+++ b/src/runtime/ReloadableString.h
@@ -58,12 +58,19 @@ public:
         if (isUnloaded()) {
             load();
         }
-        return StringBufferAccessData(m_bufferData.has8BitContent, m_bufferData.length, const_cast<void*>(m_bufferData.buffer));
+
+        // add refCount pointer to count its usage in StringBufferAccessData
+        return StringBufferAccessData(m_bufferData.has8BitContent, m_bufferData.length, const_cast<void*>(m_bufferData.buffer), &m_refCount);
     }
 
     bool isUnloaded()
     {
         return m_isUnloaded;
+    }
+
+    size_t refCount() const
+    {
+        return m_refCount;
     }
 
     void* operator new(size_t);
@@ -75,7 +82,7 @@ public:
 
 private:
     void initBufferAccessData(void* data, size_t len, bool is8bit);
-    ATTRIBUTE_NO_SANITIZE_ADDRESS bool unloadWorker(void* callerSP);
+    ATTRIBUTE_NO_SANITIZE_ADDRESS bool unloadWorker();
 
     size_t unloadedBufferSize()
     {
@@ -88,6 +95,7 @@ private:
 
     bool m_isOwnerMayFreed;
     bool m_isUnloaded;
+    size_t m_refCount; // reference count representing the usage of this ReloadableString
     VMInstance* m_vmInstance;
     void* m_callbackData;
     void* (*m_stringLoadCallback)(void* callbackData);

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -106,9 +106,9 @@ struct StringBufferAccessData {
         , buffer(buffer)
         , extraData(extraDataToKeep)
     {
-#if defined(ENABLE_COMPRESSIBLE_STRING)
+#if defined(ENABLE_COMPRESSIBLE_STRING) || defined(ENABLE_RELOADABLE_STRING)
         if (extraData) {
-            // increase refCount in CompressibleString
+            // increase refCount in CompressibleString or ReloadableString
             (*reinterpret_cast<size_t*>(extraData))++;
         }
 #endif
@@ -116,9 +116,9 @@ struct StringBufferAccessData {
 
     ~StringBufferAccessData()
     {
-#if defined(ENABLE_COMPRESSIBLE_STRING)
+#if defined(ENABLE_COMPRESSIBLE_STRING) || defined(ENABLE_RELOADABLE_STRING)
         if (extraData) {
-            // decrease refCount in CompressibleString
+            // decrease refCount in CompressibleString or ReloadableString
             size_t& count = *reinterpret_cast<size_t*>(extraData);
             ASSERT(count > 0);
             count--;

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -100,12 +100,30 @@ struct StringBufferAccessData {
     };
     void* extraData;
 
-    StringBufferAccessData(bool has8Bit, size_t len, void* buffer, void* extraDataKeepInStack = nullptr)
+    StringBufferAccessData(bool has8Bit, size_t len, void* buffer, void* extraDataToKeep = nullptr)
         : has8BitContent(has8Bit)
         , length(len)
         , buffer(buffer)
-        , extraData(extraDataKeepInStack)
+        , extraData(extraDataToKeep)
     {
+#if defined(ENABLE_COMPRESSIBLE_STRING)
+        if (extraData) {
+            // increase refCount in CompressibleString
+            (*reinterpret_cast<size_t*>(extraData))++;
+        }
+#endif
+    }
+
+    ~StringBufferAccessData()
+    {
+#if defined(ENABLE_COMPRESSIBLE_STRING)
+        if (extraData) {
+            // decrease refCount in CompressibleString
+            size_t& count = *reinterpret_cast<size_t*>(extraData);
+            ASSERT(count > 0);
+            count--;
+        }
+#endif
     }
 
     char16_t uncheckedCharAtFor8Bit(size_t idx) const

--- a/src/runtime/StringView.h
+++ b/src/runtime/StringView.h
@@ -139,9 +139,6 @@ protected:
         ASSERT(m_bufferData.hasSpecialImpl);
 
         StringBufferAccessData r = m_bufferData.bufferAsString->bufferAccessData();
-        // keep original buffer pointer in stack
-        // without this, compressible string can free this pointer
-        r.extraData = const_cast<void*>(r.buffer);
         r.length = m_bufferData.length;
         if (r.has8BitContent) {
             r.bufferAs8Bit += m_start;


### PR DESCRIPTION
* remove stack searching for CompressibleString usage
* add reference counter and update it whenever each StringBufferAccessData is created and descturcted

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>