### PR TITLE
Add InlineStorage for FunctionEnvironmentRecordOnHeap

### DIFF
--- a/src/runtime/ScriptFunctionObject.cpp
+++ b/src/runtime/ScriptFunctionObject.cpp
@@ -161,7 +161,7 @@ void ScriptFunctionObject::generateArgumentsObject(ExecutionState& state, size_t
                 if (v[i].m_needToAllocateOnStack) {
                     stackStorage[v[i].m_indexForIndexedStorage] = newArgumentsObject;
                 } else {
-                    environmentRecordWillArgumentsObjectBeLocatedIn->heapStorage()[v[i].m_indexForIndexedStorage] = newArgumentsObject;
+                    environmentRecordWillArgumentsObjectBeLocatedIn->setHeapValueByIndex(state, v[i].m_indexForIndexedStorage, newArgumentsObject);
                 }
                 break;
             }


### PR DESCRIPTION
for runnung octane, we should make 1.05M copies of FunctionEnvironmentRecordOnHeap.
but almost copies(0.84M) of FunctionEnvironmentRecordOnHeap use under 5 heapStorage.
If we inline heapStorage, we can reduce count of GC_MALLOC.

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>