### PR TITLE
Fix ByteCodeBlock nullify in gc callback

### DIFF
--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -260,7 +260,12 @@ void vmReclaimEndCallback(void* data)
             currentCodeSizeTotal = 0;
             auto& v = self->compiledByteCodeBlocks();
             for (size_t i = 0; i < v.size(); i++) {
-                v[i]->m_codeBlock->setByteCodeBlock(v[i]);
+                auto cb = v[i]->m_codeBlock;
+                if (UNLIKELY(!cb->isAsync() && !cb->isGenerator())) {
+                    v[i]->m_codeBlock->setByteCodeBlock(v[i]);
+                }
+                ASSERT(v[i]->m_codeBlock->byteCodeBlock() == v[i]);
+
                 currentCodeSizeTotal += v[i]->memoryAllocatedSize();
             }
         }


### PR DESCRIPTION
* we need to reset ByteCodeBlock only for normal functions
* add assertion to check invalid operation

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>