### PR TITLE
Fix source name to always  have valid string value

### DIFF
--- a/src/parser/Script.h
+++ b/src/parser/Script.h
@@ -153,6 +153,8 @@ public:
         , m_topCodeBlock(nullptr)
         , m_moduleData(moduleData)
     {
+        // srcName and sourceCode should have valid string (empty string for no name)
+        ASSERT(!!srcName && !!sourceCode);
     }
 
     void* operator new(size_t size);

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -236,7 +236,7 @@ FunctionObject::FunctionSource FunctionObject::createFunctionScript(ExecutionSta
     String* srcName = sourceName;
 
     // find srcName through outer script except internal source
-    if (!isInternalSource && !srcName) {
+    if (!isInternalSource && !srcName->length()) {
         auto script = state.resolveOuterScript();
         if (script) {
             srcName = script->srcName();

--- a/src/runtime/FunctionObject.h
+++ b/src/runtime/FunctionObject.h
@@ -107,7 +107,7 @@ public:
         InterpretedCodeBlock* codeBlock;
         LexicalEnvironment* outerEnvironment;
     };
-    static FunctionSource createFunctionScript(ExecutionState& state, AtomicString functionName, size_t argCount, Value* argArray, Value bodyString, bool useStrict, bool isGenerator, bool isAsync, bool allowSuperCall, bool isInternalSource = false, String* sourceName = nullptr);
+    static FunctionSource createFunctionScript(ExecutionState& state, AtomicString functionName, size_t argCount, Value* argArray, Value bodyString, bool useStrict, bool isGenerator, bool isAsync, bool allowSuperCall, bool isInternalSource = false, String* sourceName = String::emptyString);
 
     bool setName(AtomicString name);
 

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -1059,7 +1059,7 @@ int main(int argc, char* argv[])
             return 3;
         }
         StringRef* str = Escargot::StringRef::createFromUTF8(buf, strlen(buf));
-        evalScript(context, str, StringRef::createFromASCII("from shell input"), true, false);
+        evalScript(context, str, StringRef::emptyString(), true, false);
     }
 
 #if defined(ESCARGOT_ENABLE_TEST)


### PR DESCRIPTION
* set empty string for no name case

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>