### PR TITLE
Update version of WASM engine

### DIFF
--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -56,7 +56,7 @@ namespace Escargot {
 
 #if defined(ENABLE_WASM)
 #ifndef ESCARGOT_WASM_GC_CHECK_INTERVAL
-#define ESCARGOT_WASM_GC_CHECK_INTERVAL 5000
+#define ESCARGOT_WASM_GC_CHECK_INTERVAL 10000
 #endif
 #endif
 

--- a/src/wasm/ExportedFunctionObject.cpp
+++ b/src/wasm/ExportedFunctionObject.cpp
@@ -95,10 +95,6 @@ static Value callExportedFunction(ExecutionState& state, Value thisValue, size_t
 
     // Let (store, ret) be the result of func_invoke(store, funcaddr, args).
     own wasm_trap_t* trap = wasm_func_call(funcaddr, args.data, ret.data);
-    // FIXME wabt allocates a Thread object for each function call
-    // Thread object is never explicitly reclaimed
-    // invoke collectHeap right after wasm_func_call
-    WASMOperations::collectHeap();
 
     // If ret is error, throw an exception. This exception should be a WebAssembly RuntimeError exception, unless otherwise indicated by the WebAssembly error mapping.
     if (trap) {

--- a/third_party/wasm/CMakeLists.txt
+++ b/third_party/wasm/CMakeLists.txt
@@ -149,7 +149,7 @@ set(WABT_SRC
 # disable -Wpointer-arith: this is a GCC extension, and doesn't work in MSVC.
 set(WASM_CXX_FLAGS_INTERNAL
     -Wall -Wextra -Werror -Wno-unused-parameter -Wpointer-arith
-    -Wuninitialized -fno-exceptions -fPIC -fdata-sections -ffunction-sections
+    -Wuninitialized -fPIC -fdata-sections -ffunction-sections
 )
 
 # set c++ flags

--- a/tools/test/wasm-js/wabt_patch
+++ b/tools/test/wasm-js/wabt_patch
@@ -1,17 +1,3 @@
-diff --git src/binary-reader.cc src/binary-reader.cc
-index e1a7a336..d373770d 100644
---- src/binary-reader.cc
-+++ src/binary-reader.cc
-@@ -2181,8 +2181,7 @@ Result BinaryReader::ReadTypeSection(Offset section_size) {
-     } else {
-       uint8_t type;
-       CHECK_RESULT(ReadU8(&type, "type form"));
--      ERROR_UNLESS(type == 0x60, "unexpected type form (got " PRItypecode ")",
--                   WABT_PRINTF_TYPE_CODE(type));
-+      ERROR_UNLESS(type == 0x60, "unexpected type form (got " "%#x" ")", type);
-       form = Type::Func;
-     }
- 
 diff --git src/interp/interp-wasm-c-api.cc src/interp/interp-wasm-c-api.cc
 index 4df66b89..2edc17d9 100644
 --- src/interp/interp-wasm-c-api.cc


### PR DESCRIPTION
* enable exception in wabt engine because Escargot function invoked from wasm function could trigger an exception
* fix compile warning
* fix Thread to be reclaimed after each wasm function call
* extend wasm gc interval

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>