### PR TITLE
Fix crash in the debugger

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -2583,7 +2583,7 @@ bool ContextRef::isDebuggerRunning()
 bool ContextRef::isWaitBeforeExit()
 {
 #ifdef ESCARGOT_DEBUGGER
-    return toImpl(this)->debugger()->getWaitBeforeExitClient();
+    return isDebuggerRunning() && toImpl(this)->debugger()->getWaitBeforeExitClient();
 #else /* !ESCARGOT_DEBUGGER */
     return false;
 #endif /* ESCARGOT_DEBUGGER */

--- a/test/cctest/testapi.cpp
+++ b/test/cctest/testapi.cpp
@@ -2437,6 +2437,7 @@ TEST(Debugger, RemoteOption)
     // 100ms
     EXPECT_FALSE(context->initDebuggerRemote("--accept-timeout=100"));
     EXPECT_FALSE(context->isDebuggerRunning());
+    EXPECT_FALSE(context->isWaitBeforeExit());
 
     context.release();
     instance.release();


### PR DESCRIPTION
If Escargot is compiled with debugger but run without the debug server
then the Escargot will crash. This patch will fix this problem.

Signed-off-by: Gergo Csizi gergocs@inf.u-szeged.hu