### PR TITLE
Optimize enumeration of object without index property case

### DIFF
--- a/src/runtime/ArgumentsObject.h
+++ b/src/runtime/ArgumentsObject.h
@@ -52,6 +52,11 @@ public:
         return true;
     }
 
+    virtual bool hasOwnEnumeration() const override
+    {
+        return true;
+    }
+
     ScriptFunctionObject* sourceFunctionObject() const
     {
         return m_sourceFunctionObject;

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -56,6 +56,11 @@ public:
         return false;
     }
 
+    virtual bool hasOwnEnumeration() const override
+    {
+        return true;
+    }
+
     virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) override;

--- a/src/runtime/GlobalObjectProxyObject.h
+++ b/src/runtime/GlobalObjectProxyObject.h
@@ -67,6 +67,11 @@ public:
     virtual bool isExtensible(ExecutionState&) override;
     virtual bool preventExtensions(ExecutionState&) override;
 
+    virtual bool hasOwnEnumeration() const override
+    {
+        return true;
+    }
+
     virtual bool canUseOwnPropertyKeysFastPath() override
     {
         return false;

--- a/src/runtime/ModuleNamespaceObject.h
+++ b/src/runtime/ModuleNamespaceObject.h
@@ -41,6 +41,11 @@ public:
         return false;
     }
 
+    virtual bool hasOwnEnumeration() const override
+    {
+        return true;
+    }
+
     // http://www.ecma-international.org/ecma-262/6.0/#sec-module-namespace-exotic-objects-getprototypeof
     virtual Object* getPrototypeObject(ExecutionState&) override
     {

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -796,6 +796,12 @@ public:
         return hasRareData() ? rareData()->m_isExtensible : true;
     }
 
+    // represent that this Object has its own enumeration function other than Object::enumeration
+    virtual bool hasOwnEnumeration() const
+    {
+        return false;
+    }
+
     // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
     virtual bool preventExtensions(ExecutionState&)
     {

--- a/src/runtime/ProxyObject.h
+++ b/src/runtime/ProxyObject.h
@@ -56,6 +56,11 @@ public:
         return m_isConstructible;
     }
 
+    virtual bool hasOwnEnumeration() const override
+    {
+        return true;
+    }
+
     virtual Context* getFunctionRealm(ExecutionState& state) override;
 
     static ProxyObject* createProxy(ExecutionState& state, const Value& target, const Value& handler);

--- a/src/runtime/StringObject.h
+++ b/src/runtime/StringObject.h
@@ -40,6 +40,11 @@ public:
         return true;
     }
 
+    virtual bool hasOwnEnumeration() const override
+    {
+        return true;
+    }
+
     void setPrimitiveValue(ExecutionState& state, String* data)
     {
         m_primitiveValue = data;

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -72,6 +72,11 @@ public:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
+    virtual bool hasOwnEnumeration() const override
+    {
+        return true;
+    }
+
     virtual ObjectHasPropertyResult hasProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual ObjectGetResult getOwnProperty(ExecutionState& state, const ObjectPropertyName& P) override;
     virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc) override;


### PR DESCRIPTION
* directly insert property key when there is no index property name
* add hasOwnEnumeration function because some Objects(Array, Proxy...) possibly have index properties
but we cannot know this in advance with hasIndexPropertyName() function

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>