### PR TITLE
Update PromiseRejectCallback

### DIFF
--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -647,11 +647,22 @@ public:
         After
     };
 
+    enum PromiseRejectEvent {
+        PromiseRejectWithNoHandler = 0,
+        PromiseHandlerAddedAfterReject = 1,
+        PromiseRejectAfterResolved = 2,
+        PromiseResolveAfterResolved = 3,
+    };
+
     typedef void (*PromiseHook)(ExecutionStateRef* state, PromiseHookType type, PromiseObjectRef* promise, ValueRef* parent);
+    typedef void (*PromiseRejectCallback)(ExecutionStateRef* state, PromiseObjectRef* promise, ValueRef* value, PromiseRejectEvent event);
 
     // Register PromiseHook (PromiseHook is used by third party app)
     void registerPromiseHook(PromiseHook promiseHook);
     void unregisterPromiseHook();
+    // Register a callback to call if this promise is rejected, but it does not have a reject handler
+    void registerPromiseRejectCallback(PromiseRejectCallback);
+    void unregisterPromiseRejectCallback();
 
     // this function enforce do gc,
     // remove every compiled bytecodes,
@@ -1761,6 +1772,9 @@ public:
     ObjectRef* then(ExecutionStateRef* state, ValueRef* onFulfilled, ValueRef* onRejected);
     void fulfill(ExecutionStateRef* state, ValueRef* value);
     void reject(ExecutionStateRef* state, ValueRef* reason);
+
+    bool hasResolveHandlers();
+    bool hasRejectHandlers();
 };
 
 class ESCARGOT_EXPORT ProxyObjectRef : public ObjectRef {

--- a/src/runtime/PromiseObject.cpp
+++ b/src/runtime/PromiseObject.cpp
@@ -151,7 +151,11 @@ void PromiseObject::reject(ExecutionState& state, Value reason)
 {
     m_state = PromiseState::Rejected;
     m_promiseResult = reason;
-    triggerPromiseReactions(state, m_rejectReactions);
+    if (LIKELY(hasRejectHandlers() > 0)) {
+        triggerPromiseReactions(state, m_rejectReactions);
+    } else if (state.context()->vmInstance()->isPromiseRejectCallbackRegistered()) {
+        state.context()->vmInstance()->triggerPromiseRejectCallback(state, this, reason, VMInstance::PromiseRejectEvent::PromiseRejectWithNoHandler);
+    }
 
     m_fulfillReactions.clear();
     m_rejectReactions.clear();

--- a/src/runtime/PromiseObject.h
+++ b/src/runtime/PromiseObject.h
@@ -154,6 +154,9 @@ public:
     // https://tc39.es/ecma262/#sec-promise.any-reject-element-functions
     static Value promiseAnyRejectElementFunction(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget);
 
+    bool hasResolveHandlers() const { return m_fulfillReactions.size() > 0; }
+    bool hasRejectHandlers() const { return m_rejectReactions.size() > 0; }
+
 protected:
     static inline void fillGCDescriptor(GC_word* desc)
     {

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -357,6 +357,8 @@ VMInstance::VMInstance(const char* locale, const char* timezone, const char* bas
     , m_errorCreationCallbackPublic(nullptr)
     , m_promiseHook(nullptr)
     , m_promiseHookPublic(nullptr)
+    , m_promiseRejectCallback(nullptr)
+    , m_promiseRejectCallbackPublic(nullptr)
     , m_cachedUTC(nullptr)
 {
     GC_REGISTER_FINALIZER_NO_ORDER(this, [](void* obj, void*) {


### PR DESCRIPTION
* PromiseRejectCallback is invoked when a Promise is rejected but it does not have any reject handler

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>