### PR TITLE
Refactor basic String classes

### DIFF
--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -517,10 +517,6 @@ typedef uint16_t LexicalBlockIndex;
 #define REGEXP_CACHE_SIZE_MAX 64
 #endif
 
-#ifndef ROPE_STRING_MIN_LENGTH
-#define ROPE_STRING_MIN_LENGTH 24
-#endif
-
 #include "EscargotInfo.h"
 #include "heap/Heap.h"
 #include "util/Util.h"

--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -503,7 +503,7 @@ void PersistentValueRefMap::clear()
 
 StringRef* StringRef::createFromASCII(const char* s, size_t len)
 {
-    return toRef(new ASCIIString(s, len));
+    return toRef(String::fromASCII(s, len));
 }
 
 StringRef* StringRef::createFromUTF8(const char* s, size_t len, bool maybeASCII)
@@ -518,7 +518,7 @@ StringRef* StringRef::createFromUTF16(const char16_t* s, size_t len)
 
 StringRef* StringRef::createFromLatin1(const unsigned char* s, size_t len)
 {
-    return toRef(new Latin1String(s, len));
+    return toRef(String::fromLatin1(s, len));
 }
 
 StringRef* StringRef::createExternalFromASCII(const char* s, size_t len)

--- a/src/builtins/BuiltinJSON.cpp
+++ b/src/builtins/BuiltinJSON.cpp
@@ -116,16 +116,17 @@ static Value parseJSONWorker(ExecutionState& state, rapidjson::GenericValue<JSON
             const char16_t* chars = (const char16_t*)value.GetString();
             unsigned len = value.GetStringLength();
             if (isAllLatin1(chars, len)) {
-                return new Latin1String(chars, len);
+                return String::fromLatin1(chars, len);
             } else {
                 return new UTF16String(chars, len);
             }
         } else {
             const char* valueAsString = (const char*)value.GetString();
-            if (isAllASCII(valueAsString, strlen(valueAsString))) {
-                return new ASCIIString(valueAsString);
+            size_t len = strlen(valueAsString);
+            if (isAllASCII(valueAsString, len)) {
+                return String::fromASCII(valueAsString, len);
             } else {
-                return new UTF16String(utf8StringToUTF16String(valueAsString, strlen(valueAsString)));
+                return new UTF16String(utf8StringToUTF16String(valueAsString, len));
             }
         }
     } else if (value.IsArray()) {

--- a/src/builtins/BuiltinNumber.cpp
+++ b/src/builtins/BuiltinNumber.cpp
@@ -133,7 +133,8 @@ static Value builtinNumberToFixed(ExecutionState& state, Value thisValue, size_t
     char buffer[NUMBER_TO_STRING_BUFFER_LENGTH];
     double_conversion::StringBuilder builder(buffer, NUMBER_TO_STRING_BUFFER_LENGTH);
     double_conversion::DoubleToStringConverter::EcmaScriptConverter().ToFixed(number, digit, &builder);
-    return Value(new ASCIIString(builder.Finalize()));
+    auto len = builder.position();
+    return Value(String::fromASCII(builder.Finalize(), len));
 }
 
 static Value builtinNumberToExponential(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
@@ -174,7 +175,8 @@ static Value builtinNumberToExponential(ExecutionState& state, Value thisValue, 
     } else {
         double_conversion::DoubleToStringConverter::EcmaScriptConverter().ToExponential(number, digit, &builder);
     }
-    return Value(new ASCIIString(builder.Finalize()));
+    auto len = builder.position();
+    return Value(String::fromASCII(builder.Finalize(), len));
 }
 
 static Value builtinNumberToPrecision(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
@@ -215,7 +217,8 @@ static Value builtinNumberToPrecision(ExecutionState& state, Value thisValue, si
     char buffer[NUMBER_TO_STRING_BUFFER_LENGTH];
     double_conversion::StringBuilder builder(buffer, NUMBER_TO_STRING_BUFFER_LENGTH);
     double_conversion::DoubleToStringConverter::EcmaScriptConverter().ToPrecision(number, p, &builder);
-    return Value(new ASCIIString(builder.Finalize()));
+    auto len = builder.position();
+    return Value(String::fromASCII(builder.Finalize(), len));
 }
 
 static Value builtinNumberToString(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
@@ -255,12 +258,12 @@ static Value builtinNumberToString(ExecutionState& state, Value thisValue, size_
         } else {
             itoa(static_cast<int64_t>(number), buffer, radix);
         }
-        return new ASCIIString(buffer);
+        return String::fromASCII(buffer, strlen(buffer));
     } else {
         ASSERT(Value(number).isDouble());
         NumberObject::RadixBuffer s;
         const char* str = NumberObject::toStringWithRadix(state, s, number, radix);
-        return new ASCIIString(str);
+        return String::fromASCII(str, strlen(str));
     }
 }
 

--- a/src/builtins/BuiltinRegExp.cpp
+++ b/src/builtins/BuiltinRegExp.cpp
@@ -107,7 +107,9 @@ static Value builtinRegExpExec(ExecutionState& state, Value thisValue, size_t ar
         int e = result.m_matchResults[0][0].m_end;
         if (option & RegExpObject::Option::Unicode) {
             char16_t utfRes = str->charAt(e);
-            size_t eUTF = str->find(new ASCIIString((const char*)&utfRes), 0);
+            const char* buf = reinterpret_cast<const char*>(&utfRes);
+            size_t len = strlen(buf);
+            size_t eUTF = str->find(buf, len, 0);
             if (eUTF >= str->length()) {
                 e = str->length();
             } else if ((int)eUTF > e || e == (int)str->length()) {

--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -693,7 +693,7 @@ void Scanner::ScannerResult::constructStringLiteral(Scanner* scannerInstance)
 
     String* newStr;
     if (isEveryCharLatin1) {
-        newStr = new Latin1String(stringUTF16.data(), stringUTF16.length());
+        newStr = String::fromLatin1(stringUTF16.data(), stringUTF16.length());
     } else {
         newStr = new UTF16String(stringUTF16.data(), stringUTF16.length());
     }
@@ -1924,7 +1924,7 @@ String* Scanner::scanRegExpFlags()
     }
 
     if (isAllASCII(flags.data(), flags.length())) {
-        return new ASCIIString(flags.data(), flags.length());
+        return String::fromLatin1(flags.data(), flags.length());
     }
 
     return new UTF16String(flags.data(), flags.length());

--- a/src/runtime/AtomicString.cpp
+++ b/src/runtime/AtomicString.cpp
@@ -127,11 +127,11 @@ void AtomicString::init(AtomicStringMap* map, const char* src, size_t len, bool 
 
     auto iter = map->find(&stringForSearch);
     if (map->end() == iter) {
-        ASCIIString* newStr;
+        String* newStr;
         if (fromExternalMemory) {
             newStr = new ASCIIStringFromExternalMemory(src, len);
         } else {
-            newStr = new ASCIIString(src, len);
+            newStr = String::fromLatin1(reinterpret_cast<const LChar*>(src), len);
         }
         map->insert(newStr);
         m_string = newStr;
@@ -250,7 +250,7 @@ void AtomicString::init(AtomicStringMap* map, const char16_t* src, size_t len)
     if (map->end() == iter) {
         String* newStr;
         if (isAllASCII(src, len)) {
-            newStr = new ASCIIString(src, len);
+            newStr = String::fromLatin1(src, len);
         } else {
             newStr = new UTF16String(src, len);
         }
@@ -276,7 +276,7 @@ AtomicString::AtomicString(Context* c, const StringView& sv)
         String* newString;
         auto buffer = sv.bufferAccessData();
         if (buffer.has8BitContent) {
-            newString = new Latin1String((const char*)buffer.buffer, buffer.length);
+            newString = String::fromLatin1(reinterpret_cast<const LChar*>(buffer.buffer), buffer.length);
         } else {
             newString = new UTF16String((const char16_t*)buffer.buffer, buffer.length);
         }
@@ -316,7 +316,7 @@ void AtomicString::init(AtomicStringMap* ec, String* name)
         if (name->isStringView()) {
             auto buffer = name->bufferAccessData();
             if (buffer.has8BitContent) {
-                name = new Latin1String((const char*)buffer.buffer, buffer.length);
+                name = String::fromLatin1(reinterpret_cast<const LChar*>(buffer.buffer), buffer.length);
             } else {
                 name = new UTF16String((const char16_t*)buffer.buffer, buffer.length);
             }

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -120,7 +120,7 @@ public:
 
     Option option()
     {
-        return m_option;
+        return static_cast<Option>(m_option >> 1);
     }
 
     JSC::Yarr::YarrPattern* yarrPatern()
@@ -162,13 +162,14 @@ public:
     ArrayObject* createRegExpMatchedArray(ExecutionState& state, const RegexMatchResult& result, String* input);
     void pushBackToRegExpMatchedArray(ExecutionState& state, ArrayObject* array, size_t& index, const size_t limit, const RegexMatchResult& result, String* str);
 
-    void* operator new(size_t size);
-    void* operator new[](size_t size) = delete;
-
 protected:
     explicit RegExpObject(ExecutionState& state, Object* proto, bool hasLastIndex = true);
 
 private:
+    void setOptionValueForGC(const Option& option)
+    {
+        m_option = static_cast<Option>(option << 1 | 1);
+    }
     void setOption(const Option& option);
     void internalInit(ExecutionState& state, String* source, Option option = None);
 
@@ -178,12 +179,12 @@ private:
 
     String* m_source;
     String* m_optionString;
-    Option m_option;
+    Option m_option : 16;
+    bool m_legacyFeaturesEnabled : 1;
     JSC::Yarr::YarrPattern* m_yarrPattern;
     JSC::Yarr::BytecodePattern* m_bytecodePattern;
     EncodedValue m_lastIndex;
     const String* m_lastExecutedString;
-    bool m_legacyFeaturesEnabled;
 };
 
 class RegExpStringIteratorObject : public IteratorObject {

--- a/src/runtime/RopeString.h
+++ b/src/runtime/RopeString.h
@@ -82,7 +82,7 @@ public:
 
     virtual char16_t charAt(const size_t idx) const override;
 
-    void* operator new(size_t size);
+    void* operator new(size_t size, bool is8Bit);
     void* operator new[](size_t size) = delete;
 
 protected:


### PR DESCRIPTION
* Implement String with inline buffer. this reduce malloc count & reduce memory usage
* Remove typed-gc-malloc from some classes.
  typed malloc classes should have storage for descriptor each malloc.

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>