### PR TITLE
Implement fast path for Promise then function call

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -3517,7 +3517,7 @@ NEVER_INLINE void ByteCodeInterpreter::callFunctionComplexCase(ExecutionState& s
         ExtendedNativeFunctionObject* onRejected = new ExtendedNativeFunctionObjectImpl<1>(state, NativeFunctionInfo(AtomicString(), callDynamicImportRejected, 1));
         onRejected->setInternalSlotAsPointer(0, promiseCapability.m_promise);
         // Perform ! PerformPromiseThen(capability.[[Promise]], onFulfilled, onRejected).
-        innerPromiseCapability.m_promise->asPromiseObject()->then(state, onFulfilled, onRejected);
+        innerPromiseCapability.m_promise->asPromiseObject()->then(state, onFulfilled, onRejected, PromiseReaction::Capability());
 
         Global::platform()->hostImportModuleDynamically(byteCodeBlock->m_codeBlock->context(),
                                                         referencingScriptOrModule, specifierString, innerPromiseCapability.m_promise->asPromiseObject());

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -1252,7 +1252,7 @@ void Script::moduleExecuteAsyncModule(ExecutionState& state)
     ExtendedNativeFunctionObject* onRejected = new ExtendedNativeFunctionObjectImpl<1>(state, NativeFunctionInfo(AtomicString(), asyncModuleRejectedFunction, 1));
     onRejected->setInternalSlotAsPointer(0, this);
     // Perform ! PerformPromiseThen(capability.[[Promise]], onFulfilled, onRejected).
-    capability.m_promise->asPromiseObject()->then(state, onFulfilled, onRejected);
+    capability.m_promise->asPromiseObject()->then(state, onFulfilled, onRejected, PromiseReaction::Capability());
 
     // Perform ! module.ExecuteModule(capability).
     moduleExecute(state, capability);

--- a/src/runtime/AsyncGeneratorObject.cpp
+++ b/src/runtime/AsyncGeneratorObject.cpp
@@ -170,7 +170,7 @@ Value AsyncGeneratorObject::asyncGeneratorResumeNext(ExecutionState& state, Asyn
                 ExtendedNativeFunctionObject* onRejected = new ExtendedNativeFunctionObjectImpl<1>(state, NativeFunctionInfo(AtomicString(), asyncGeneratorResumeNextReturnProcessorRejectedFunction, 1));
                 onRejected->setInternalSlot(AsyncGeneratorObject::BuiltinFunctionSlot::Generator, generator);
                 // Perform ! PerformPromiseThen(promise, onFulfilled, onRejected).
-                promise->then(state, onFulfilled, onRejected);
+                promise->then(state, onFulfilled, onRejected, PromiseReaction::Capability());
                 // Return undefined.
                 return Value();
             } else {

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -179,7 +179,8 @@ class FunctionObject;
 
 #define GLOBALOBJECT_BUILTIN_PROMISE(F, objName) \
     F(promise, FunctionObject, objName)          \
-    F(promisePrototype, Object, objName)
+    F(promisePrototype, Object, objName)         \
+    F(promiseThen, FunctionObject, objName)
 #define GLOBALOBJECT_BUILTIN_PROXY(F, objName) \
     F(proxy, FunctionObject, objName)
 #define GLOBALOBJECT_BUILTIN_REFLECT(F, objName) \

--- a/src/runtime/Job.cpp
+++ b/src/runtime/Job.cpp
@@ -112,6 +112,11 @@ SandBox::SandBoxResult PromiseResolveThenableJob::run()
 
         SandBox sb(state.context());
         auto res = sb.run([&]() -> Value {
+            if (LIKELY(m_thenable->isPromiseObject() && m_then == state.context()->globalObject()->promiseThen())) {
+                // fast path for then call
+                return m_thenable->asPromiseObject()->then(state, capability.m_resolveFunction, capability.m_rejectFunction);
+            }
+
             Value arguments[] = { capability.m_resolveFunction, capability.m_rejectFunction };
             return Object::call(state, m_then, m_thenable, 2, arguments);
         });

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -1993,14 +1993,14 @@ ValueVectorWithInlineStorage Object::enumerableOwnProperties(ExecutionState& sta
 
 Value Object::speciesConstructor(ExecutionState& state, const Value& defaultConstructor)
 {
-    ASSERT(isObject());
+    ASSERT(isObject() & defaultConstructor.isObject());
     Value C = asObject()->get(state, state.context()->staticStrings().constructor).value(state, this);
 
-    if (C.isUndefined()) {
+    if (UNLIKELY(C.isUndefined())) {
         return defaultConstructor;
     }
 
-    if (!C.isObject()) {
+    if (UNLIKELY(!C.isObject())) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "constructor is not an object");
     }
 

--- a/src/runtime/PromiseObject.cpp
+++ b/src/runtime/PromiseObject.cpp
@@ -174,17 +174,20 @@ Object* PromiseObject::then(ExecutionState& state, Value handler)
     return then(state, handler, Value(), newPromiseResultCapability(state)).value();
 }
 
+Object* PromiseObject::then(ExecutionState& state, Value onFulfilled, Value onRejected)
+{
+    return then(state, onFulfilled, onRejected, newPromiseResultCapability(state)).value();
+}
+
 Object* PromiseObject::catchOperation(ExecutionState& state, Value handler)
 {
     return then(state, Value(), handler, newPromiseResultCapability(state)).value();
 }
 
-Optional<Object*> PromiseObject::then(ExecutionState& state, Value onFulfilledValue, Value onRejectedValue, Optional<PromiseReaction::Capability> resultCapability)
+Optional<Object*> PromiseObject::then(ExecutionState& state, Value onFulfilledValue, Value onRejectedValue, PromiseReaction::Capability capability)
 {
     Object* onFulfilled = onFulfilledValue.isCallable() ? onFulfilledValue.asObject() : (Object*)(1);
     Object* onRejected = onRejectedValue.isCallable() ? onRejectedValue.asObject() : (Object*)(2);
-
-    PromiseReaction::Capability capability = resultCapability.hasValue() ? resultCapability.value() : PromiseReaction::Capability(nullptr, nullptr, nullptr);
 
 #ifdef ESCARGOT_DEBUGGER
     if (state.context()->debugger() != nullptr) {
@@ -211,11 +214,7 @@ Optional<Object*> PromiseObject::then(ExecutionState& state, Value onFulfilledVa
         break;
     }
 
-    if (resultCapability) {
-        return capability.m_promise;
-    } else {
-        return nullptr;
-    }
+    return capability.m_promise;
 }
 
 void PromiseObject::triggerPromiseReactions(ExecutionState& state, PromiseObject::Reactions& reactions)

--- a/src/runtime/PromiseObject.h
+++ b/src/runtime/PromiseObject.h
@@ -130,10 +130,11 @@ public:
     }
 
     Object* then(ExecutionState& state, Value handler);
+    Object* then(ExecutionState& state, Value onFulfilled, Value onRejected);
     Object* catchOperation(ExecutionState& state, Value handler);
     // http://www.ecma-international.org/ecma-262/10.0/#sec-performpromisethen
     // You can get return value when you give resultCapability
-    Optional<Object*> then(ExecutionState& state, Value onFulfilled, Value onRejected, Optional<PromiseReaction::Capability> resultCapability = Optional<PromiseReaction::Capability>());
+    Optional<Object*> then(ExecutionState& state, Value onFulfilled, Value onRejected, PromiseReaction::Capability capability);
 
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;

--- a/src/runtime/ScriptAsyncFunctionObject.cpp
+++ b/src/runtime/ScriptAsyncFunctionObject.cpp
@@ -156,7 +156,7 @@ PromiseObject* ScriptAsyncFunctionObject::awaitOperationBeforePause(ExecutionSta
     FunctionObject* onRejected = new ScriptAsyncFunctionHelperFunctionObject(state, NativeFunctionInfo(AtomicString(), awaitRejectedFunction, 1), executionPauser, source);
 
     // Perform ! PerformPromiseThen(promise, onFulfilled, onRejected).
-    promise->then(state, onFulfilled, onRejected, Optional<PromiseReaction::Capability>());
+    promise->then(state, onFulfilled, onRejected, PromiseReaction::Capability());
 
     return promise;
 }


### PR DESCRIPTION
* In most cases, `then` call could be replaced by internal PromiseObject::then() method call directly

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>