### PR TITLE
Mark String::emptyString as source of AtomicString

### DIFF
--- a/src/runtime/String.cpp
+++ b/src/runtime/String.cpp
@@ -612,6 +612,18 @@ ASCIIStringDataNonGCStd dtoa(double number)
     return str;
 }
 
+void String::initEmptyString()
+{
+    ASSERT(!String::emptyString);
+    String* emptyStr = new (NoGC) ASCIIString("");
+    // mark empty string as AtomicString source
+    // because empty string is the default string value of empty AtomicString
+    emptyStr->m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)emptyStr;
+
+    ASSERT(emptyStr->isAtomicStringSource());
+    String::emptyString = emptyStr;
+}
+
 #define LATIN1_LARGE_INLINE_BUFFER(F) \
     F(1)                              \
     F(2)                              \

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -325,6 +325,10 @@ public:
         return false;
     }
 
+    // initialize String::emptyString value
+    // its called only once by VMInstance constructor
+    static void initEmptyString();
+
     template <const size_t srcLen>
     static String* fromASCII(const char (&src)[srcLen])
     {

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -384,7 +384,8 @@ VMInstance::VMInstance(const char* locale, const char* timezone, const char* bas
     RELEASE_ASSERT(((size_t)m_stackStartAddress) % sizeof(size_t) == 0);
 
     if (!String::emptyString) {
-        String::emptyString = new (NoGC) ASCIIString("");
+        String::initEmptyString();
+        ASSERT(!!String::emptyString && String::emptyString->isAtomicStringSource());
     }
     m_staticStrings.initStaticStrings();
 


### PR DESCRIPTION
* String::emptyString is the default string value of empty AtomicString
* so, mark emptyString as source of AtomicString too

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>