### PR TITLE
Refactor DoubleInEncodedValue

### DIFF
--- a/src/runtime/Global.cpp
+++ b/src/runtime/Global.cpp
@@ -47,7 +47,6 @@ void Global::initialize(Platform* platform)
 
     // initialize PointerValue tag values
     // tag values should be initialized once and not changed
-    PointerValue::g_objectTag = Object().getTag();
     PointerValue::g_arrayObjectTag = ArrayObject().getTag();
     PointerValue::g_arrayPrototypeObjectTag = ArrayPrototypeObject().getTag();
     PointerValue::g_scriptFunctionObjectTag = ScriptFunctionObject().getTag();

--- a/src/runtime/PointerValue.cpp
+++ b/src/runtime/PointerValue.cpp
@@ -24,7 +24,6 @@
 
 namespace Escargot {
 
-size_t PointerValue::g_objectTag;
 size_t PointerValue::g_arrayObjectTag;
 size_t PointerValue::g_arrayPrototypeObjectTag;
 size_t PointerValue::g_scriptFunctionObjectTag;

--- a/src/runtime/PointerValue.h
+++ b/src/runtime/PointerValue.h
@@ -93,8 +93,9 @@ class ExportedFunctionObject;
 #define POINTER_VALUE_STRING_TAG_IN_DATA 1
 #define POINTER_VALUE_SYMBOL_TAG_IN_DATA 1 << 1
 #define POINTER_VALUE_BIGINT_TAG_IN_DATA 1 << 2
+#define POINTER_VALUE_DOUBLE_TAG_IN_DATA (POINTER_VALUE_SYMBOL_TAG_IN_DATA | POINTER_VALUE_BIGINT_TAG_IN_DATA)
 
-#define POINTER_VALUE_NOT_OBJECT_TAG_IN_DATA (POINTER_VALUE_STRING_TAG_IN_DATA | POINTER_VALUE_SYMBOL_TAG_IN_DATA | POINTER_VALUE_BIGINT_TAG_IN_DATA)
+#define POINTER_VALUE_NOT_OBJECT_TAG_IN_DATA (POINTER_VALUE_STRING_TAG_IN_DATA | POINTER_VALUE_SYMBOL_TAG_IN_DATA | POINTER_VALUE_BIGINT_TAG_IN_DATA | POINTER_VALUE_DOUBLE_TAG_IN_DATA)
 // Finding the type of PointerValue operation is widely used during the runtime
 // Only Object, String and Symbol are seen in regular runtime-code
 // We can figure out fastly what the type of PointerValue by tag value
@@ -896,7 +897,6 @@ protected:
 
     // tag values for fast type check
     // these values actually have unique virtual table address of each object class
-    static size_t g_objectTag;
     static size_t g_arrayObjectTag;
     static size_t g_arrayPrototypeObjectTag;
     static size_t g_scriptFunctionObjectTag;

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -133,6 +133,8 @@ public:
 #else
     Value(PointerValue* ptr);
     Value(const PointerValue* ptr);
+    enum FromNonObjectPointerTag { FromNonObjectPointer };
+    Value(const PointerValue* ptr, FromNonObjectPointerTag);
     Value(Object* ptr);
     Value(const Object* ptr);
     Value(String* ptr);

--- a/src/runtime/ValueInlines.h
+++ b/src/runtime/ValueInlines.h
@@ -133,6 +133,13 @@ inline Value::Value(const PointerValue* ptr)
     u.asBits.payload = reinterpret_cast<int32_t>(const_cast<PointerValue*>(ptr));
 }
 
+inline Value::Value(const PointerValue* ptr, FromNonObjectPointerTag)
+{
+    ASSERT(!ptr->isObject());
+    u.asBits.tag = OtherPointerTag;
+    u.asBits.payload = reinterpret_cast<int32_t>(const_cast<PointerValue*>(ptr));
+}
+
 inline Value::Value(String* ptr)
 {
     ASSERT(ptr != NULL);


### PR DESCRIPTION
I store its tag information in the same location with PointerValues
It can reduce memory access count when finding type

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>