### PR TITLE
Fix wrong node position in switch statement

### DIFF
--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -3683,8 +3683,7 @@ public:
 
         closeBlock(blockContext);
 
-        MetaNode node = this->createNode();
-        return this->finalize(node, builder.createBlockStatementNode(block, blockContext.childLexicalBlockIndex));
+        return this->finalize(this->createNode(), builder.createBlockStatementNode(block, blockContext.childLexicalBlockIndex));
     }
 
     // ECMA-262 13.3.1 Let and Const Declarations
@@ -4508,6 +4507,7 @@ public:
         this->expectKeyword(SwitchKeyword);
 
         this->expect(LeftParenthesis);
+        MetaNode node = this->createNode();
         ASTNode discriminant = this->parseExpression(builder);
         this->expect(RightParenthesis);
 
@@ -4555,7 +4555,7 @@ public:
         closeBlock(blockContext);
 
         this->context->inSwitch = previousInSwitch;
-        return this->finalize(this->createNode(), builder.createSwitchStatementNode(discriminant, casesA, deflt, casesB, blockContext.childLexicalBlockIndex));
+        return this->finalize(node, builder.createSwitchStatementNode(discriminant, casesA, deflt, casesB, blockContext.childLexicalBlockIndex));
     }
 
     // ECMA-262 13.13 Labelled Statements
@@ -4708,6 +4708,7 @@ public:
     ASTNode parseTryStatement(ASTBuilder& builder)
     {
         this->expectKeyword(TryKeyword);
+        MetaNode node = this->createNode();
 
         if (!this->match(LeftBrace)) {
             this->throwUnexpectedToken(this->lookahead);
@@ -4726,7 +4727,7 @@ public:
             this->throwError(Messages::NoCatchOrFinally);
         }
 
-        return this->finalize(this->createNode(), builder.createTryStatementNode(block, handler, finalizer));
+        return this->finalize(node, builder.createTryStatementNode(block, handler, finalizer));
     }
 
     // ECMA-262 13.16 The debugger statement

--- a/tools/debugger/tests/do_break_switch.cmd
+++ b/tools/debugger/tests/do_break_switch.cmd
@@ -1,0 +1,7 @@
+break do_break_switch.js:26
+b do_break_switch.js:38
+b test
+c
+c
+c
+c

--- a/tools/debugger/tests/do_break_switch.expected
+++ b/tools/debugger/tests/do_break_switch.expected
@@ -1,0 +1,17 @@
+Connecting to: localhost:6501
+Connection created!!!
+Stopped at tools/debugger/tests/do_break_switch.js:42
+(escargot-debugger) break do_break_switch.js:26
+Breakpoint 1 at tools/debugger/tests/do_break_switch.js:26 (in test() at line:21, col:1)
+(escargot-debugger) b do_break_switch.js:38
+Breakpoint 2 at tools/debugger/tests/do_break_switch.js:38 (in f() at line:36, col:1)
+(escargot-debugger) b test
+Breakpoint 3 at tools/debugger/tests/do_break_switch.js:24 (in test() at line:21, col:1)
+(escargot-debugger) c
+Stopped at breakpoint:2 tools/debugger/tests/do_break_switch.js:38 (in f() at line:36, col:1)
+(escargot-debugger) c
+Stopped at breakpoint:3 tools/debugger/tests/do_break_switch.js:24 (in test() at line:21, col:1)
+(escargot-debugger) c
+Stopped at breakpoint:1 tools/debugger/tests/do_break_switch.js:26 (in test() at line:21, col:1)
+(escargot-debugger) c
+Connection closed.

--- a/tools/debugger/tests/do_break_switch.js
+++ b/tools/debugger/tests/do_break_switch.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+
+function test(x)
+{
+  /* Comment. */
+  switch(x) {
+    case 0:
+      return ++x;
+    case 1:
+      return 1;
+    case 2:
+      return 2;
+    default:
+      return x++;
+  }
+}
+
+function f(x) {
+  /* Comment. */
+  return test(x);
+}
+
+var
+  x =
+    0;
+
+f(x);


### PR DESCRIPTION
* switch statement has the last location in switch block which incurs an index error in BreakPoint insertion
* fix switch statement to have the start position as its node location
* fix try and throw statement to have its location info before keyword as well

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>