### PR TITLE
Add ErrorThrowCallback API

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -1096,18 +1096,32 @@ void VMInstanceRef::setOnVMInstanceDelete(OnVMInstanceDelete cb)
                                        (void*)cb);
 }
 
-void VMInstanceRef::registerErrorCreationCallback(ErrorCreationCallback cb)
+void VMInstanceRef::registerErrorCreationCallback(ErrorCallback cb)
 {
     toImpl(this)->registerErrorCreationCallback([](ExecutionState& state, ErrorObject* err, void* cb) -> void {
         ASSERT(!!cb);
-        (reinterpret_cast<ErrorCreationCallback>(cb))(toRef(&state), toRef(err));
+        (reinterpret_cast<ErrorCallback>(cb))(toRef(&state), toRef(err));
     },
                                                 (void*)cb);
+}
+
+void VMInstanceRef::registerErrorThrowCallback(ErrorCallback cb)
+{
+    toImpl(this)->registerErrorThrowCallback([](ExecutionState& state, ErrorObject* err, void* cb) -> void {
+        ASSERT(!!cb);
+        (reinterpret_cast<ErrorCallback>(cb))(toRef(&state), toRef(err));
+    },
+                                             (void*)cb);
 }
 
 void VMInstanceRef::unregisterErrorCreationCallback()
 {
     toImpl(this)->unregisterErrorCreationCallback();
+}
+
+void VMInstanceRef::unregisterErrorThrowCallback()
+{
+    toImpl(this)->unregisterErrorThrowCallback();
 }
 
 void VMInstanceRef::registerPromiseHook(PromiseHook promiseHook)

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -634,11 +634,13 @@ public:
     typedef void (*OnVMInstanceDelete)(VMInstanceRef* instance);
     void setOnVMInstanceDelete(OnVMInstanceDelete cb);
 
-    // register ErrorCreationCallback which is triggered when each Error constructor (e.g. new TypeError()) invoked
-    // parameter `err` is newly created ErrorObject
-    typedef void (*ErrorCreationCallback)(ExecutionStateRef* state, ErrorObjectRef* err);
-    void registerErrorCreationCallback(ErrorCreationCallback cb);
+    // register ErrorCallback which is triggered when each Error constructor (e.g. new TypeError()) invoked or thrown
+    // parameter `err` stands for the newly created ErrorObject
+    typedef void (*ErrorCallback)(ExecutionStateRef* state, ErrorObjectRef* err);
+    void registerErrorCreationCallback(ErrorCallback cb);
+    void registerErrorThrowCallback(ErrorCallback cb);
     void unregisterErrorCreationCallback();
+    void unregisterErrorThrowCallback();
 
     enum PromiseHookType {
         Init,

--- a/src/runtime/Context.cpp
+++ b/src/runtime/Context.cpp
@@ -96,6 +96,11 @@ Context::Context(VMInstance* instance)
 void Context::throwException(ExecutionState& state, const Value& exception)
 {
     if (LIKELY(vmInstance()->currentSandBox() != nullptr)) {
+        ASSERT(!!m_instance);
+        if (UNLIKELY(m_instance->isErrorThrowCallbackRegistered() && exception.isObject() && exception.asObject()->isErrorObject())) {
+            // trigger ErrorThrowCallback when an ErrorObject is thrown
+            m_instance->triggerErrorThrowCallback(state, exception.asObject()->asErrorObject());
+        }
         vmInstance()->currentSandBox()->throwException(state, exception);
     } else {
         ESCARGOT_LOG_ERROR("there is no sandbox but exception occurred");

--- a/src/runtime/SandBox.cpp
+++ b/src/runtime/SandBox.cpp
@@ -452,8 +452,8 @@ void SandBox::fillStackDataIntoErrorObject(const Value& e)
         ErrorObject* obj = e.asObject()->asErrorObject();
         ExecutionState state(m_context);
 
-        if (UNLIKELY(m_context->vmInstance()->isErrorCreationCallbackRegistered() && obj->hasOwnProperty(state, ObjectPropertyName(m_context->staticStrings().stack)))) {
-            // if ErrorCreationCallback is registered and this callback already inserts `stack` property for evert created ErrorObject,
+        if (UNLIKELY((m_context->vmInstance()->isErrorCreationCallbackRegistered() || m_context->vmInstance()->isErrorThrowCallbackRegistered()) && obj->hasOwnProperty(state, ObjectPropertyName(m_context->staticStrings().stack)))) {
+            // if ErrorCreationCallback or ErrorThrowCallback is registered and this callback already inserts `stack` property for the created ErrorObject,
             // we just ignore adding `stack` data here
             return;
         }

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -349,6 +349,8 @@ VMInstance::VMInstance(const char* locale, const char* timezone, const char* bas
     , m_onVMInstanceDestroyData(nullptr)
     , m_errorCreationCallback(nullptr)
     , m_errorCreationCallbackPublic(nullptr)
+    , m_errorThrowCallback(nullptr)
+    , m_errorThrowCallbackPublic(nullptr)
     , m_promiseHook(nullptr)
     , m_promiseHookPublic(nullptr)
     , m_promiseRejectCallback(nullptr)

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -241,10 +241,21 @@ public:
         return !!m_errorCreationCallback;
     }
 
-    void registerErrorCreationCallback(void (*ErrorCreationCallback)(ExecutionState& state, ErrorObject* err, void* cb), void* callbackPublic)
+    bool isErrorThrowCallbackRegistered()
     {
-        m_errorCreationCallback = ErrorCreationCallback;
+        return !!m_errorThrowCallback;
+    }
+
+    void registerErrorCreationCallback(void (*ErrorCallback)(ExecutionState& state, ErrorObject* err, void* cb), void* callbackPublic)
+    {
+        m_errorCreationCallback = ErrorCallback;
         m_errorCreationCallbackPublic = callbackPublic;
+    }
+
+    void registerErrorThrowCallback(void (*ErrorCallback)(ExecutionState& state, ErrorObject* err, void* cb), void* callbackPublic)
+    {
+        m_errorThrowCallback = ErrorCallback;
+        m_errorThrowCallbackPublic = callbackPublic;
     }
 
     void unregisterErrorCreationCallback()
@@ -253,11 +264,25 @@ public:
         m_errorCreationCallbackPublic = nullptr;
     }
 
+    void unregisterErrorThrowCallback()
+    {
+        m_errorThrowCallback = nullptr;
+        m_errorThrowCallbackPublic = nullptr;
+    }
+
     void triggerErrorCreationCallback(ExecutionState& state, ErrorObject* error)
     {
         ASSERT(!!m_errorCreationCallback);
         if (m_errorCreationCallbackPublic) {
             m_errorCreationCallback(state, error, m_errorCreationCallbackPublic);
+        }
+    }
+
+    void triggerErrorThrowCallback(ExecutionState& state, ErrorObject* error)
+    {
+        ASSERT(!!m_errorThrowCallback);
+        if (m_errorThrowCallbackPublic) {
+            m_errorThrowCallback(state, error, m_errorThrowCallbackPublic);
         }
     }
 
@@ -381,6 +406,8 @@ private:
 
     void (*m_errorCreationCallback)(ExecutionState& state, ErrorObject* err, void* cb);
     void* m_errorCreationCallbackPublic;
+    void (*m_errorThrowCallback)(ExecutionState& state, ErrorObject* err, void* cb);
+    void* m_errorThrowCallbackPublic;
 
     // PromiseHook is triggered for each Promise event
     // Third party app registers PromiseHook when it is necessary


### PR DESCRIPTION
* ErrorThrowCallback is invoked when an Error is thrown
* ErrorThrowCallback overwrites the result of ErrorCreationCallback

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>