### PR TITLE
Minor fix for debugger

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -4336,6 +4336,12 @@ ScriptParserRef::InitializeFunctionScriptResult ScriptParserRef::initializeFunct
         Script* script = internalResult.script.value();
         InterpretedCodeBlock* codeBlock = script->topCodeBlock()->childBlockAt(0);
 
+#ifdef ESCARGOT_DEBUGGER
+        // enable first breakpoint for debugger
+        ASSERT(codeBlock->byteCodeBlock());
+        ByteCodeGenerator::enableFirstBreakPoint(codeBlock->byteCodeBlock());
+#endif
+
         // create FunctionObject
         LexicalEnvironment* globalEnvironment = new LexicalEnvironment(new GlobalEnvironmentRecord(state, script->topCodeBlock(), state.context()->globalObject(), state.context()->globalDeclarativeRecord(), state.context()->globalDeclarativeStorage()), nullptr);
         Object* proto = state.context()->globalObject()->functionPrototype();

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -900,6 +900,8 @@ public:
 #endif
 };
 
+COMPILE_ASSERT(sizeof(BreakpointDisabled) == sizeof(BreakpointEnabled), "");
+
 class CreateObject : public ByteCode {
 public:
     CreateObject(const ByteCodeLOC& loc, const size_t registerIndex)

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -166,14 +166,14 @@ void ByteCodeGenerateContext::insertBreakpointAt(size_t line, Node* node)
     }
 }
 
-ByteCodeBreakpointContext::ByteCodeBreakpointContext(Debugger* debugger, InterpretedCodeBlock* codeBlock)
+ByteCodeBreakpointContext::ByteCodeBreakpointContext(Debugger* debugger, InterpretedCodeBlock* codeBlock, bool addBreakpointLocationsInfoToDebugger)
     : m_lastBreakpointLineOffset(0)
     , m_lastBreakpointIndexOffset(0)
     , m_originSourceLineOffset(codeBlock->script()->originSourceLineOffset())
     , m_breakpointLocations()
 {
     m_breakpointLocations = new Debugger::BreakpointLocationsInfo(reinterpret_cast<Debugger::WeakCodeRef*>(codeBlock));
-    if (debugger && codeBlock->markDebugging()) {
+    if (debugger && codeBlock->markDebugging() && addBreakpointLocationsInfoToDebugger) {
         debugger->appendBreakpointLocations(m_breakpointLocations);
     }
 }
@@ -297,7 +297,9 @@ void ByteCodeGenerator::collectByteCodeLOCData(Context* context, InterpretedCode
     ctx.m_locData = locData;
 
 #ifdef ESCARGOT_DEBUGGER
-    ByteCodeBreakpointContext breakpointContext(context->debugger(), codeBlock);
+    // create a dummy ByteCodeBreakpointContext because we just calculate location info only
+    // unnecessary BreakpointLocationsInfoToDebugger insertion would incur incorrect debugger operations
+    ByteCodeBreakpointContext breakpointContext(context->debugger(), codeBlock, false);
     ctx.m_breakpointContext = &breakpointContext;
 #endif /* ESCARGOT_DEBUGGER */
 

--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -377,6 +377,10 @@ public:
     static void collectByteCodeLOCData(Context* context, InterpretedCodeBlock* codeBlock, std::vector<std::pair<size_t, size_t>, std::allocator<std::pair<size_t, size_t>>>* locData);
     static void relocateByteCode(ByteCodeBlock* block);
 
+#ifdef ESCARGOT_DEBUGGER
+    static bool enableFirstBreakPoint(ByteCodeBlock* block);
+#endif
+
 #ifndef NDEBUG
     static void printByteCode(Context* context, ByteCodeBlock* block);
 #endif

--- a/src/interpreter/ByteCodeGenerator.h
+++ b/src/interpreter/ByteCodeGenerator.h
@@ -58,7 +58,7 @@ struct ByteCodeBreakpointContext {
     Debugger::BreakpointLocationsInfo* m_breakpointLocations;
     bool m_parsingEnabled;
 
-    ByteCodeBreakpointContext(Debugger* debugger, InterpretedCodeBlock* codeBlock);
+    ByteCodeBreakpointContext(Debugger* debugger, InterpretedCodeBlock* codeBlock, bool addBreakpointLocationsInfoToDebugger = true);
 };
 #endif /* ESCARGOT_DEBUGGER */
 

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -479,6 +479,10 @@ Value Script::execute(ExecutionState& state, bool isExecuteOnEvalFunction, bool 
 
     Value resultValue;
     if (LIKELY(!m_topCodeBlock->isAsync())) {
+#ifdef ESCARGOT_DEBUGGER
+        // set the next(first) breakpoint to be stopped in a newer script execution
+        context()->setAsAlwaysStopState();
+#endif
         resultValue = ByteCodeInterpreter::interpret(codeExecutionState, byteCodeBlock, 0, registerFile);
         clearStack<512>();
 

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -424,7 +424,7 @@ ScriptParser::InitializeScriptResult ScriptParser::initializeScript(String* orig
 {
     ASSERT(m_context->astAllocator().isInitialized());
 #ifdef ESCARGOT_DEBUGGER
-    if (LIKELY(needByteCodeGeneration) && m_context->debuggerEnabled() && !m_context->debugger()->skipSourceCode(srcName)) {
+    if (LIKELY(needByteCodeGeneration) && m_context->debuggerEnabled() && srcName->length() && !m_context->debugger()->skipSourceCode(srcName)) {
         return initializeScriptWithDebugger(originSource, originLineOffset, source, srcName, parentCodeBlock, isModule, isEvalMode, isEvalCodeInFunction, inWithOperation, strictFromOutside, allowSuperCall, allowSuperProperty, allowNewTarget);
     }
 #endif /* ESCARGOT_DEBUGGER */
@@ -569,6 +569,9 @@ void ScriptParser::recursivelyGenerateChildrenByteCode(InterpretedCodeBlock* par
 
 ScriptParser::InitializeScriptResult ScriptParser::initializeScriptWithDebugger(String* originSource, size_t originLineOffset, String* source, String* srcName, InterpretedCodeBlock* parentCodeBlock, bool isModule, bool isEvalMode, bool isEvalCodeInFunction, bool inWithOperation, bool strictFromOutside, bool allowSuperCall, bool allowSuperProperty, bool allowNewTarget)
 {
+    // src name should have valid string
+    ASSERT(srcName && srcName->length());
+
     GC_disable();
     if (m_context->debuggerEnabled()) {
         m_context->debugger()->setInDebuggingCodeMode(true);

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -259,8 +259,6 @@ FunctionObject::FunctionSource FunctionObject::createDynamicFunctionScript(Execu
 
 ScriptParser::InitializeScriptResult FunctionObject::createFunctionScript(ExecutionState& state, String* sourceName, AtomicString functionName, size_t argCount, Value* argArray, Value bodyString, bool useStrict)
 {
-    ASSERT(sourceName->length() > 0);
-
     String* sourceBodyString = bodyString.toString(state);
     ASSERT(sourceBodyString->length());
 

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -1044,7 +1044,6 @@ int main(int argc, char* argv[])
     }
 
     if (wait_before_exit || context->isWaitBeforeExit()) {
-        context->setAsAlwaysStopState();
         auto evalResult = Evaluator::execute(context, [](ExecutionStateRef* state, ScriptRef* script) -> ValueRef* {
             return script->execute(state);
         },


### PR DESCRIPTION
* debugger always stops at the start of new Script execution
* BreakpointLocationsInfo is added to debugger when Escargot generates bytecode for execution only

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>