### PR TITLE
Rename tagging operations

### DIFF
--- a/src/runtime/AtomicString.cpp
+++ b/src/runtime/AtomicString.cpp
@@ -130,7 +130,7 @@ void AtomicString::init(AtomicStringMap* map, const char* src, size_t len, bool 
         }
         map->insert(newStr);
         m_string = newStr;
-        newStr->m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
+        newStr->m_typeTag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
     } else {
         m_string = iter.operator*();
     }
@@ -188,7 +188,7 @@ void AtomicString::init(AtomicStringMap* map, const LChar* src, size_t len)
         Latin1String* newStr = new Latin1String(src, len);
         map->insert(newStr);
         m_string = newStr;
-        newStr->m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
+        newStr->m_typeTag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
     } else {
         m_string = iter.operator*();
     }
@@ -251,7 +251,7 @@ void AtomicString::init(AtomicStringMap* map, const char16_t* src, size_t len)
         }
         map->insert(newStr);
         m_string = newStr;
-        newStr->m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
+        newStr->m_typeTag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
     } else {
         m_string = iter.operator*();
     }
@@ -259,7 +259,7 @@ void AtomicString::init(AtomicStringMap* map, const char16_t* src, size_t len)
 
 AtomicString::AtomicString(Context* c, const StringView& sv)
 {
-    size_t v = sv.getTagInFirstDataArea();
+    size_t v = sv.getTypeTag();
     if (v > POINTER_VALUE_STRING_TAG_IN_DATA) {
         m_string = (String*)(v & ~POINTER_VALUE_STRING_TAG_IN_DATA);
         return;
@@ -278,10 +278,10 @@ AtomicString::AtomicString(Context* c, const StringView& sv)
         ec->insert(newString);
         ASSERT(ec->find(newString) != ec->end());
         m_string = newString;
-        const_cast<StringView&>(sv).m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
+        const_cast<StringView&>(sv).m_typeTag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
     } else {
         m_string = iter.operator*();
-        const_cast<StringView&>(sv).m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
+        const_cast<StringView&>(sv).m_typeTag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
     }
 }
 
@@ -290,7 +290,7 @@ void AtomicString::initStaticString(AtomicStringMap* ec, String* name)
     ASSERT(ec->find(name) == ec->end());
     ec->insert(name);
     m_string = name;
-    name->m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
+    name->m_typeTag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
 }
 
 void AtomicString::init(Context* c, String* name)
@@ -310,10 +310,10 @@ void AtomicString::init(Context* c, String* name)
         ec->insert(name);
         ASSERT(ec->find(name) != ec->end());
         m_string = name;
-        name->m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
+        name->m_typeTag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
     } else {
         m_string = iter.operator*();
-        name->m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
+        name->m_typeTag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)m_string;
     }
 }
 } // namespace Escargot

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -82,7 +82,7 @@ public:
     ALWAYS_INLINE AtomicString(Context* c, String* name)
     {
         // fast path
-        size_t v = name->getTagInFirstDataArea();
+        size_t v = name->getTypeTag();
         if (v > POINTER_VALUE_STRING_TAG_IN_DATA) {
             m_string = (String*)(v & ~POINTER_VALUE_STRING_TAG_IN_DATA);
             return;

--- a/src/runtime/BigInt.cpp
+++ b/src/runtime/BigInt.cpp
@@ -153,7 +153,7 @@ void BigInt::initFinalizer()
 }
 
 BigInt::BigInt()
-    : m_tag(POINTER_VALUE_BIGINT_TAG_IN_DATA)
+    : m_typeTag(POINTER_VALUE_BIGINT_TAG_IN_DATA)
 {
     bf_init(ThreadLocal::bfContext(), &m_bf);
     initFinalizer();
@@ -199,7 +199,7 @@ BigInt::BigInt(BigIntData&& n)
 }
 
 BigInt::BigInt(bf_t bf)
-    : m_tag(POINTER_VALUE_BIGINT_TAG_IN_DATA)
+    : m_typeTag(POINTER_VALUE_BIGINT_TAG_IN_DATA)
     , m_bf(bf)
 {
     initFinalizer();

--- a/src/runtime/BigInt.h
+++ b/src/runtime/BigInt.h
@@ -122,7 +122,7 @@ private:
 
     void initFinalizer();
 
-    size_t m_tag;
+    size_t m_typeTag;
     bf_t m_bf;
 };
 } // namespace Escargot

--- a/src/runtime/EncodedValue.h
+++ b/src/runtime/EncodedValue.h
@@ -53,7 +53,7 @@ public:
     }
 #else
         : m_value(v)
-        , m_tag(POINTER_VALUE_NUMBER_TAG_IN_DATA)
+        , m_typeTag(POINTER_VALUE_NUMBER_TAG_IN_DATA)
     {
     }
 #endif
@@ -94,7 +94,7 @@ private:
     uint32_t m_buffer[3];
 #else
     Value m_value;
-    size_t m_tag;
+    size_t m_typeTag;
 #endif
 };
 #pragma pack(pop)

--- a/src/runtime/Global.cpp
+++ b/src/runtime/Global.cpp
@@ -24,6 +24,7 @@
 #include "runtime/ArrayObject.h"
 #include "runtime/PrototypeObject.h"
 #include "runtime/ScriptFunctionObject.h"
+#include "runtime/ScriptSimpleFunctionObject.h"
 
 namespace Escargot {
 
@@ -48,12 +49,18 @@ void Global::initialize(Platform* platform)
 
     // initialize PointerValue tag values
     // tag values should be initialized once and not changed
-    PointerValue::g_objectTag = Object().getTag();
-    PointerValue::g_prototypeObjectTag = PrototypeObject().getTag();
-    PointerValue::g_arrayObjectTag = ArrayObject().getTag();
-    PointerValue::g_arrayPrototypeObjectTag = ArrayPrototypeObject().getTag();
-    PointerValue::g_scriptFunctionObjectTag = ScriptFunctionObject().getTag();
-    PointerValue::g_objectRareDataTag = ObjectRareData(nullptr).getTag();
+    PointerValue::g_objectTag = Object().getVTag();
+    PointerValue::g_prototypeObjectTag = PrototypeObject().getVTag();
+    PointerValue::g_arrayObjectTag = ArrayObject().getVTag();
+    PointerValue::g_arrayPrototypeObjectTag = ArrayPrototypeObject().getVTag();
+    PointerValue::g_scriptFunctionObjectTag = ScriptFunctionObject().getVTag();
+    PointerValue::g_objectRareDataTag = ObjectRareData(nullptr).getVTag();
+    // tag values for ScriptSimpleFunctionObject
+#define INIT_SCRIPTSIMPLEFUNCTION_TAGS(STRICT, CLEAR, isStrict, isClear, SIZE) \
+    PointerValue::g_scriptSimpleFunctionObject##STRICT##CLEAR##SIZE##Tag = ScriptSimpleFunctionObject<isStrict, isClear, SIZE>().getVTag();
+
+    DECLARE_SCRIPTSIMPLEFUNCTION_LIST(INIT_SCRIPTSIMPLEFUNCTION_TAGS);
+#undef INIT_SCRIPTSIMPLEFUNCTION_TAGS
 
     called_once = false;
     inited = true;

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -64,7 +64,7 @@ ObjectStructurePropertyName::ObjectStructurePropertyName(ExecutionState& state, 
     }
 
     String* string = value.toString(state);
-    size_t v = string->getTagInFirstDataArea();
+    size_t v = string->getTypeTag();
     if (v > POINTER_VALUE_STRING_TAG_IN_DATA) {
         ASSERT(v == ((v & ~POINTER_VALUE_STRING_TAG_IN_DATA) | OBJECT_PROPERTY_NAME_ATOMIC_STRING_VIAS));
         m_data = v;
@@ -620,8 +620,8 @@ bool Object::setPrototype(ExecutionState& state, const Value& proto)
 
 void Object::markAsPrototypeObject(ExecutionState& state)
 {
-    if (hasTag(g_objectTag)) {
-        writeTag(g_prototypeObjectTag);
+    if (hasVTag(g_objectTag)) {
+        writeVTag(g_prototypeObjectTag);
     } else {
         ensureRareData()->m_isEverSetAsPrototypeObject = true;
     }

--- a/src/runtime/PointerValue.cpp
+++ b/src/runtime/PointerValue.cpp
@@ -30,6 +30,12 @@ size_t PointerValue::g_arrayObjectTag;
 size_t PointerValue::g_arrayPrototypeObjectTag;
 size_t PointerValue::g_scriptFunctionObjectTag;
 size_t PointerValue::g_objectRareDataTag;
+// tag values for ScriptSimpleFunctionObject
+#define DEFINE_SCRIPTSIMPLEFUNCTION_TAGS(STRICT, CLEAR, isStrict, isClear, SIZE) \
+    size_t PointerValue::g_scriptSimpleFunctionObject##STRICT##CLEAR##SIZE##Tag;
+
+DECLARE_SCRIPTSIMPLEFUNCTION_LIST(DEFINE_SCRIPTSIMPLEFUNCTION_TAGS);
+#undef DEFINE_SCRIPTSIMPLEFUNCTION_TAGS
 
 Value PointerValue::call(ExecutionState& state, const Value& thisValue, const size_t argc, Value* argv)
 {

--- a/src/runtime/ScriptSimpleFunctionObject.h
+++ b/src/runtime/ScriptSimpleFunctionObject.h
@@ -31,9 +31,10 @@
 
 namespace Escargot {
 
-template <bool isStrict = false, bool shouldClearStack = false, unsigned registerFileSize = 12>
+// ScriptSimpleFunctionObject currently supports only 4 registerFileSize (4, 8, 16, 24)
+template <bool isStrict = false, bool shouldClearStack = false, unsigned registerFileSize = 4>
 class ScriptSimpleFunctionObject : public ScriptFunctionObject {
-    friend class ScriptFunctionObject;
+    friend class Global;
 
 protected:
     ScriptSimpleFunctionObject() // ctor for reading tag

--- a/src/runtime/String.cpp
+++ b/src/runtime/String.cpp
@@ -618,7 +618,7 @@ void String::initEmptyString()
     String* emptyStr = new (NoGC) ASCIIString("");
     // mark empty string as AtomicString source
     // because empty string is the default string value of empty AtomicString
-    emptyStr->m_tag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)emptyStr;
+    emptyStr->m_typeTag = (size_t)POINTER_VALUE_STRING_TAG_IN_DATA | (size_t)emptyStr;
 
     ASSERT(emptyStr->isAtomicStringSource());
     String::emptyString = emptyStr;

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -217,7 +217,7 @@ class String : public PointerValue {
 protected:
     String()
     {
-        m_tag = POINTER_VALUE_STRING_TAG_IN_DATA;
+        m_typeTag = POINTER_VALUE_STRING_TAG_IN_DATA;
     }
 
     struct StringBufferData {
@@ -382,7 +382,7 @@ public:
 
     bool isAtomicStringSource() const
     {
-        return (m_tag > POINTER_VALUE_STRING_TAG_IN_DATA);
+        return (m_typeTag > POINTER_VALUE_STRING_TAG_IN_DATA);
     }
 
     bool equals(const String* src) const;
@@ -552,7 +552,7 @@ public:
     String* trim(StringTrimWhere where = StringTrimWhere::TrimBoth);
 
 private:
-    size_t m_tag;
+    size_t m_typeTag;
 
 protected:
     StringBufferData m_bufferData;

--- a/src/runtime/StringBuilder.cpp
+++ b/src/runtime/StringBuilder.cpp
@@ -38,11 +38,9 @@ String* StringBuilderBase::finalizeBase(StringBuilderPiece* piecesInlineStorage,
 
     if (m_has8BitContent) {
         Latin1StringData retString;
-        LChar* retArray;
-        LChar* ret;
+        LChar* ret = nullptr;
         if (m_contentLength <= LATIN1_LARGE_INLINE_BUFFER_MAX_SIZE) {
-            retArray = static_cast<LChar*>(alloca(m_contentLength));
-            ret = retArray;
+            ret = static_cast<LChar*>(alloca(m_contentLength));
         } else {
             retString.resizeWithUninitializedValues(m_contentLength);
             ret = retString.data();
@@ -105,7 +103,7 @@ String* StringBuilderBase::finalizeBase(StringBuilderPiece* piecesInlineStorage,
 
         clear();
         if (currentLength <= LATIN1_LARGE_INLINE_BUFFER_MAX_SIZE) {
-            return String::fromLatin1(retArray, currentLength);
+            return String::fromLatin1(ret, currentLength);
         } else {
             return new Latin1String(std::move(retString));
         }

--- a/src/runtime/Symbol.h
+++ b/src/runtime/Symbol.h
@@ -29,7 +29,7 @@ class VMInstance;
 class Symbol : public PointerValue {
 public:
     explicit Symbol(Optional<String*> desc = nullptr)
-        : m_tag(POINTER_VALUE_SYMBOL_TAG_IN_DATA)
+        : m_typeTag(POINTER_VALUE_SYMBOL_TAG_IN_DATA)
         , m_description(desc)
     {
     }
@@ -44,7 +44,7 @@ public:
     static Symbol* fromGlobalSymbolRegistry(VMInstance* vm, String* stringKey);
 
 private:
-    size_t m_tag;
+    size_t m_typeTag;
     Optional<String*> m_description;
 };
 } // namespace Escargot

--- a/src/runtime/ValueInlines.h
+++ b/src/runtime/ValueInlines.h
@@ -115,7 +115,7 @@ inline Value::Value(FromPayloadTag, intptr_t ptr)
 inline Value::Value(PointerValue* ptr)
 {
     // other type of PointerValue(Object) has pointer in first data area
-    if (ptr->getTagInFirstDataArea() & (POINTER_VALUE_NOT_OBJECT_TAG_IN_DATA)) {
+    if (ptr->getTypeTag() & (POINTER_VALUE_NOT_OBJECT_TAG_IN_DATA)) {
         u.asBits.tag = OtherPointerTag;
     } else {
         u.asBits.tag = ObjectPointerTag;


### PR DESCRIPTION
* rename tagging operations to clearly recognize typeTag and tag (vtable address)
* add global tag values for ScriptSimpleFunctionObject
* fix uninitialized address usage in StringBuilder

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>