### PR TITLE
Mark non-fast mode ArrayObject by existing fast-mode data

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -487,7 +487,7 @@ Value ByteCodeInterpreter::interpret(ExecutionState* state, ByteCodeBlock* byteC
                 obj = willBeObject.asObject();
                 if (LIKELY(obj->hasArrayObjectTag())) {
                     ArrayObject* arr = reinterpret_cast<ArrayObject*>(obj);
-                    if (LIKELY(arr->hasFastModeDataBuffer())) {
+                    if (LIKELY(arr->isFastModeArray())) {
                         uint32_t idx = property.tryToUseAsIndexProperty(*state);
                         if (LIKELY(idx < arr->arrayLength(*state))) {
                             registerFile[code->m_storeRegisterIndex] = arr->m_fastModeData[idx].toValue<true>();
@@ -512,7 +512,7 @@ Value ByteCodeInterpreter::interpret(ExecutionState* state, ByteCodeBlock* byteC
             const Value& property = registerFile[code->m_propertyRegisterIndex];
             if (LIKELY(willBeObject.isObject() && (willBeObject.asPointerValue())->hasArrayObjectTag())) {
                 ArrayObject* arr = willBeObject.asObject()->asArrayObject();
-                if (LIKELY(arr->hasFastModeDataBuffer())) {
+                if (LIKELY(arr->isFastModeArray())) {
                     uint32_t idx = property.tryToUseAsIndexProperty(*state);
                     if (LIKELY(idx < arr->arrayLength(*state))) {
                         arr->m_fastModeData[idx] = registerFile[code->m_loadRegisterIndex];

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -108,7 +108,6 @@ ObjectStructurePropertyName ObjectPropertyName::toObjectStructurePropertyNameUin
 ObjectRareData::ObjectRareData(Object* obj)
     : m_isExtensible(true)
     , m_isEverSetAsPrototypeObject(false)
-    , m_isFastModeArrayObject(true)
     , m_isArrayObjectLengthWritable(true)
     , m_isSpreadArrayObject(false)
     , m_isFinalizerRegistered(false)

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -70,7 +70,6 @@ struct ObjectExtendedExtraData : public gc {
 struct ObjectRareData : public PointerValue {
     bool m_isExtensible : 1;
     bool m_isEverSetAsPrototypeObject : 1;
-    bool m_isFastModeArrayObject : 1;
     bool m_isArrayObjectLengthWritable : 1;
     bool m_isSpreadArrayObject : 1;
     bool m_isFinalizerRegistered : 1;

--- a/src/util/TightVector.h
+++ b/src/util/TightVector.h
@@ -370,6 +370,14 @@ public:
         return m_buffer;
     }
 
+    // used for specific case
+    // should not have any valid data
+    void reset(T* resetData)
+    {
+        ASSERT(!m_buffer);
+        m_buffer = resetData;
+    }
+
 protected:
     T* m_buffer;
 };


### PR DESCRIPTION
* set dummy element address to denote non-fast mode array
* represent non-fast mode array without creating ObjectRareData

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>