### PR TITLE
Remove redundant string allocation in debugger

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -2844,8 +2844,7 @@ bool ContextRef::isWaitBeforeExit()
 void ContextRef::printDebugger(StringRef* output)
 {
 #ifdef ESCARGOT_DEBUGGER
-    StringView* outputStr = new StringView(toImpl(output));
-    toImpl(this)->printDebugger(outputStr);
+    toImpl(this)->printDebugger(toImpl(output));
 #endif /* ESCARGOT_DEBUGGER */
 }
 

--- a/src/debugger/Debugger.h
+++ b/src/debugger/Debugger.h
@@ -341,7 +341,7 @@ public:
 
     void sendType(uint8_t type);
     void sendSubtype(uint8_t type, uint8_t subType);
-    void sendString(uint8_t type, String* string);
+    void sendString(uint8_t type, const String* string);
     void sendPointer(uint8_t type, const void* ptr);
 
     virtual void init(const char* options, Context* context) = 0;

--- a/src/runtime/Context.cpp
+++ b/src/runtime/Context.cpp
@@ -158,7 +158,7 @@ bool Context::debuggerEnabled() const
     return m_debugger != nullptr;
 }
 
-void Context::printDebugger(StringView* output)
+void Context::printDebugger(String* output)
 {
     if (debuggerEnabled()) {
         m_debugger->consoleOut(output);

--- a/src/runtime/Context.h
+++ b/src/runtime/Context.h
@@ -321,7 +321,7 @@ public:
     void initDebugger(Debugger* debugger);
     void removeDebugger();
     bool debuggerEnabled() const;
-    void printDebugger(StringView* output);
+    void printDebugger(String* output);
     void pumpDebuggerEvents();
     void setAsAlwaysStopState();
     bool inDebuggingCodeMode() const;

--- a/src/runtime/StringView.h
+++ b/src/runtime/StringView.h
@@ -26,6 +26,12 @@ namespace Escargot {
 
 class StringView : public String {
 public:
+    // For temporal StringView that is allocated on the stack
+    void* operator new(size_t size, void* p)
+    {
+        return p;
+    }
+
     ALWAYS_INLINE StringView(String* str, const size_t s, const size_t e)
         : String()
     {


### PR DESCRIPTION
* no need to newly allocate string for string send
* sendString takes a constant string to guarantee that send operation would not modify the original string

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>