### PR TITLE
Fix finalizer to prevent any possible memory defect

### DIFF
--- a/src/parser/ast/ArrayExpressionNode.h
+++ b/src/parser/ast/ArrayExpressionNode.h
@@ -98,14 +98,14 @@ public:
         codeBlock->m_shouldClearStack = true;
 
         if (m_additionalPropertyExpression) {
-            ByteCodeRegisterIndex additionalPropertyExpressionRegsiter = m_additionalPropertyExpression->getRegister(codeBlock, context);
-            m_additionalPropertyExpression->generateExpressionByteCode(codeBlock, context, additionalPropertyExpressionRegsiter);
-            codeBlock->pushCode(ObjectDefineOwnPropertyWithNameOperation(ByteCodeLOC(m_loc.index), dstRegister, m_additionalPropertyName, additionalPropertyExpressionRegsiter, ObjectPropertyDescriptor::NotPresent), context, this);
+            ByteCodeRegisterIndex additionalPropertyExpressionRegister = m_additionalPropertyExpression->getRegister(codeBlock, context);
+            m_additionalPropertyExpression->generateExpressionByteCode(codeBlock, context, additionalPropertyExpressionRegister);
+            codeBlock->pushCode(ObjectDefineOwnPropertyWithNameOperation(ByteCodeLOC(m_loc.index), dstRegister, m_additionalPropertyName, additionalPropertyExpressionRegister, ObjectPropertyDescriptor::NotPresent), context, this);
 
             if (m_isTaggedTemplateExpression) {
                 auto freezeFunctionRegister = context->getRegister();
                 codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), freezeFunctionRegister, Value(codeBlock->m_codeBlock->context()->globalObject()->objectFreeze())), context, this);
-                codeBlock->pushCode(CallFunction(ByteCodeLOC(m_loc.index), freezeFunctionRegister, additionalPropertyExpressionRegsiter, freezeFunctionRegister, 1), context, this);
+                codeBlock->pushCode(CallFunction(ByteCodeLOC(m_loc.index), freezeFunctionRegister, additionalPropertyExpressionRegister, freezeFunctionRegister, 1), context, this);
                 context->giveUpRegister();
             }
 

--- a/src/parser/ast/CallExpressionNode.h
+++ b/src/parser/ast/CallExpressionNode.h
@@ -102,7 +102,9 @@ public:
             return std::make_pair(argStartIndex, hasSpreadElement);
         }
 
-        return std::make_pair(REGISTER_LIMIT, false);
+        // set default register index as `0` for non-argument case
+        // if REGISTER_LIMIT is used, then call operation would access a too far stack location which will never be read
+        return std::make_pair(0, false);
     }
 
     static bool canUseDirectRegister(ByteCodeGenerateContext* context, Node* callee, const NodeList& args)

--- a/src/runtime/ArrayBuffer.h
+++ b/src/runtime/ArrayBuffer.h
@@ -114,13 +114,6 @@ public:
     void* operator new[](size_t size) = delete;
 
 protected:
-    static inline void fillGCDescriptor(GC_word* desc)
-    {
-        Object::fillGCDescriptor(desc);
-        GC_set_bit(desc, GC_WORD_OFFSET(ArrayBuffer, m_observerItems));
-        GC_set_bit(desc, GC_WORD_OFFSET(ArrayBuffer, m_backingStore));
-    }
-
     static void arrayBufferFinalizer(Object* obj, void* data)
     {
         ArrayBuffer* self = reinterpret_cast<ArrayBuffer*>(obj);

--- a/src/runtime/ArrayBufferObject.cpp
+++ b/src/runtime/ArrayBufferObject.cpp
@@ -142,7 +142,9 @@ void* ArrayBufferObject::operator new(size_t size)
     static MAY_THREAD_LOCAL GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(ArrayBufferObject)] = { 0 };
-        ArrayBuffer::fillGCDescriptor(obj_bitmap);
+        Object::fillGCDescriptor(obj_bitmap);
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArrayBufferObject, m_observerItems));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(ArrayBufferObject, m_backingStore));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(ArrayBufferObject));
         typeInited = true;
     }

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -59,11 +59,13 @@ struct ObjectPrivateMemberDataChain : public gc {
 
 struct ObjectExtendedExtraData : public gc {
     void* m_extraData;
+    size_t m_removedFinalizerCount;
     TightVector<std::pair<ObjectFinalizer, void*>, GCUtil::gc_malloc_atomic_allocator<std::pair<ObjectFinalizer, void*>>> m_finalizer;
     Optional<ObjectPrivateMemberDataChain*> m_privateMemberChain;
     Optional<FunctionObject*> m_meaningfulConstructor;
     ObjectExtendedExtraData(void* e)
         : m_extraData(e)
+        , m_removedFinalizerCount(0)
     {
     }
 };
@@ -1195,7 +1197,18 @@ protected:
         return (ObjectRareData*)m_prototype;
     }
 
-    ObjectExtendedExtraData* ensureObjectExtendedExtraData()
+    inline bool hasExtendedExtraData() const
+    {
+        return (hasRareData() && rareData()->m_hasExtendedExtraData);
+    }
+
+    ObjectExtendedExtraData* extendedExtraData()
+    {
+        ASSERT(hasExtendedExtraData());
+        return rareData()->m_extendedExtraData;
+    }
+
+    ObjectExtendedExtraData* ensureExtendedExtraData()
     {
         auto rd = ensureRareData();
         if (!rd->m_hasExtendedExtraData) {

--- a/src/runtime/SharedArrayBufferObject.cpp
+++ b/src/runtime/SharedArrayBufferObject.cpp
@@ -112,7 +112,9 @@ void* SharedArrayBufferObject::operator new(size_t size)
     static MAY_THREAD_LOCAL GC_descr descr;
     if (!typeInited) {
         GC_word obj_bitmap[GC_BITMAP_SIZE(SharedArrayBufferObject)] = { 0 };
-        ArrayBuffer::fillGCDescriptor(obj_bitmap);
+        Object::fillGCDescriptor(obj_bitmap);
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SharedArrayBufferObject, m_observerItems));
+        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(SharedArrayBufferObject, m_backingStore));
         descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(SharedArrayBufferObject));
         typeInited = true;
     }

--- a/src/runtime/TypedArrayObject.cpp
+++ b/src/runtime/TypedArrayObject.cpp
@@ -278,6 +278,9 @@ bool TypedArrayObject::integerIndexedElementSet(ExecutionState& state, double in
     Value TYPE##ArrayObject::getIndexedPropertyValue(ExecutionState& state, const Value& property, const Value& receiver)                       \
     {                                                                                                                                           \
         if (LIKELY(property.isUInt32() && (size_t)property.asUInt32() < arrayLength())) {                                                       \
+            if (UNLIKELY(buffer()->isDetachedBuffer())) {                                                                                       \
+                return Value();                                                                                                                 \
+            }                                                                                                                                   \
             size_t indexedPosition = property.asUInt32() * siz;                                                                                 \
             return getDirectValueFromBuffer(state, indexedPosition);                                                                            \
         }                                                                                                                                       \


### PR DESCRIPTION
* replace erase operation of vector with non-memory operations
* erase operation requires additional memory allocations which may incur other GC in sequence
* fix GCutil to make gc finalizer not to be invoked in nested calls
* for non-argument call case, interpreter may access a too far stack address which will never be read
* fix typos in ArrayExpressionNode too