### PR TITLE
When parsing function parameter with pattern,

### DIFF
--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -1485,9 +1485,11 @@ public:
 
         bool oldInParameterParsing = this->context->inParameterParsing;
         bool oldInParameterNameParsing = this->context->inParameterNameParsing;
+        bool oldIsAssignmentTarget = this->context->isAssignmentTarget;
 
         this->context->inParameterParsing = true;
         this->context->inParameterNameParsing = true;
+        this->context->isAssignmentTarget = true;
 
         if (firstRestricted) {
             options.firstRestricted = *firstRestricted;
@@ -1513,6 +1515,7 @@ public:
 
         this->context->inParameterParsing = oldInParameterParsing;
         this->context->inParameterNameParsing = oldInParameterNameParsing;
+        this->context->isAssignmentTarget = oldIsAssignmentTarget;
     }
 
     bool matchAsyncFunction()


### PR DESCRIPTION
we should update isAssignmentTarget variable.

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>