### PR TITLE
Reimplement JNI memory management

### DIFF
--- a/build/android/escargot/src/androidTest/java/com/samsung/lwe/escargot/EscargotTest.java
+++ b/build/android/escargot/src/androidTest/java/com/samsung/lwe/escargot/EscargotTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(AndroidJUnit4.class)
 public class EscargotTest {
@@ -18,14 +17,15 @@ public class EscargotTest {
     public void initTest() {
         Globals.initializeGlobals();
         VMInstance vmInstance = VMInstance.create(Optional.of("en-US"), Optional.of("Asia/Seoul"));
-        assertTrue(vmInstance.hasValidNativePointer());
         Context context = Context.create(vmInstance);
-        assertTrue(context.hasValidNativePointer());
 
-        context.destroy();
-        assertFalse(context.hasValidNativePointer());
-        vmInstance.destroy();
-        assertFalse(vmInstance.hasValidNativePointer());
+        for (int i = 0; i < 300000; i ++) {
+            // alloc many trach objects for testing memory management
+            JavaScriptValue.create("asdf");
+        }
+
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
 
@@ -70,9 +70,7 @@ public class EscargotTest {
         Globals.initializeGlobals();
 
         VMInstance vmInstance = VMInstance.create(Optional.of("en-US"), Optional.of("Asia/Seoul"));
-        assertTrue(vmInstance.hasValidNativePointer());
         Context context = Context.create(vmInstance);
-        assertTrue(context.hasValidNativePointer());
 
         // test script parsing error
         assertFalse(Evaluator.evalScript(context, "@@", "invalid", true).isPresent());
@@ -82,6 +80,8 @@ public class EscargotTest {
         assertTrue(Evaluator.evalScript(context, "a = 1", "from_java.js", true).get().toString(context).get().toJavaString().equals("1"));
         assertTrue(Evaluator.evalScript(context, "a", "from_java2.js", true).get().toString(context).get().toJavaString().equals("1"));
 
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
 
@@ -96,6 +96,8 @@ public class EscargotTest {
         assertTrue(Evaluator.evalScript(context,
                 "const koDtf = new Intl.DateTimeFormat(\"ko\", { dateStyle: \"long\" }); koDtf.format(a)", "from_java4.js", true).get().toString(context).get().toJavaString().contains("2000"));
 
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
 
@@ -104,7 +106,7 @@ public class EscargotTest {
         Globals.initializeGlobals();
 
         VMInstance vmInstance = VMInstance.create(Optional.of("en-US"), Optional.of("Asia/Seoul"));
-        final Context context = Context.create(vmInstance);
+        Context context = Context.create(vmInstance);
 
         class TestBridge extends Bridge.Adapter {
             public boolean called = false;
@@ -139,8 +141,8 @@ public class EscargotTest {
         assertTrue(Evaluator.evalScript(context, "Native.returnString()", "from_java6.js", true).get().asScriptString().toJavaString().equals("string from java"));
         assertTrue(Evaluator.evalScript(context, "Native.returnNothing() === undefined", "from_java7.js", true).get().toString(context).get().toJavaString().equals("true"));
 
-        context.destroy();
-        vmInstance.destroy();
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
 
@@ -216,8 +218,8 @@ public class EscargotTest {
         assertTrue(result.isPresent());
         assertEquals(result.get().toJavaString(), Integer.MAX_VALUE+"");
 
-        context.destroy();
-        vmInstance.destroy();
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
 
@@ -239,8 +241,8 @@ public class EscargotTest {
         assertFalse(JavaScriptValue.createUndefined().toObject(context).isPresent());
         assertTrue(context.lastThrownException().isPresent());
 
-        context.destroy();
-        vmInstance.destroy();
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
 
@@ -272,8 +274,8 @@ public class EscargotTest {
         JavaScriptSymbol symbol2 = JavaScriptSymbol.fromGlobalSymbolRegistry(vmInstance, JavaScriptString.create("foo"));
         assertTrue(symbol1.equalsTo(context, symbol2).get().booleanValue());
 
-        context.destroy();
-        vmInstance.destroy();
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
 
@@ -293,8 +295,8 @@ public class EscargotTest {
 
         assertTrue(obj.getOwnProperty(context, JavaScriptValue.create("qwer")).get().toNumber(context).get().doubleValue() == 123);
 
-        context.destroy();
-        vmInstance.destroy();
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
 
@@ -311,8 +313,8 @@ public class EscargotTest {
         assertTrue(arr.get(context, JavaScriptValue.create("length")).get().toInt32(context).get().intValue() == 4);
         assertTrue(arr.length(context) == 4);
 
-        context.destroy();
-        vmInstance.destroy();
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
 
@@ -338,8 +340,9 @@ public class EscargotTest {
         result.asScriptObject().set(context, JavaScriptValue.create(123), JavaScriptValue.create(456));
         assertEquals(context.getGlobalObject().jsonStringify(context, result).get().toJavaString(), "{\"123\":456,\"a\":\"asdf\"}");
 
-        context.destroy();
-        vmInstance.destroy();
+        context = null;
+        vmInstance = null;
         Globals.finalizeGlobals();
     }
+
 }

--- a/build/android/escargot/src/main/java/com/samsung/lwe/escargot/Context.java
+++ b/build/android/escargot/src/main/java/com/samsung/lwe/escargot/Context.java
@@ -3,6 +3,10 @@ package com.samsung.lwe.escargot;
 import java.util.Optional;
 
 public class Context extends NativePointerHolder {
+    protected Context(long nativePointer)
+    {
+        super(nativePointer);
+    }
     public native static Context create(VMInstance vmInstance);
     public boolean exceptionWasThrown()
     {
@@ -15,12 +19,6 @@ public class Context extends NativePointerHolder {
         return lastThrownException;
     }
     public native JavaScriptGlobalObject getGlobalObject();
-
-    native protected void releaseNativePointer();
-    @Override
-    public void destroy() {
-        releaseNativePointer();
-    }
 
     protected Optional<JavaScriptValue> m_lastThrownException = Optional.empty();
 }

--- a/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptArrayObject.java
+++ b/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptArrayObject.java
@@ -1,6 +1,10 @@
 package com.samsung.lwe.escargot;
 
 public class JavaScriptArrayObject extends JavaScriptObject {
+    protected JavaScriptArrayObject(long nativePointer)
+    {
+        super(nativePointer);
+    }
     static public native JavaScriptArrayObject create(Context context);
     public native long length(Context context);
 }

--- a/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptGlobalObject.java
+++ b/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptGlobalObject.java
@@ -3,6 +3,10 @@ package com.samsung.lwe.escargot;
 import java.util.Optional;
 
 public class JavaScriptGlobalObject extends JavaScriptObject {
+    protected JavaScriptGlobalObject(long nativePointer)
+    {
+        super(nativePointer);
+    }
     /**
      *
      * @param context

--- a/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptObject.java
+++ b/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptObject.java
@@ -3,6 +3,10 @@ package com.samsung.lwe.escargot;
 import java.util.Optional;
 
 public class JavaScriptObject extends JavaScriptValue {
+    protected JavaScriptObject(long nativePointer)
+    {
+        super(nativePointer);
+    }
     static public native JavaScriptObject create(Context context);
     /**
      * return thisObject[propertyName];

--- a/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptString.java
+++ b/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptString.java
@@ -1,5 +1,9 @@
 package com.samsung.lwe.escargot;
 
 public class JavaScriptString extends JavaScriptValue {
+    protected JavaScriptString(long nativePointer)
+    {
+        super(nativePointer);
+    }
     native public String toJavaString();
 }

--- a/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptSymbol.java
+++ b/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptSymbol.java
@@ -3,6 +3,10 @@ package com.samsung.lwe.escargot;
 import java.util.Optional;
 
 public class JavaScriptSymbol extends JavaScriptValue {
+    protected JavaScriptSymbol(long nativePointer)
+    {
+        super(nativePointer);
+    }
     native public Optional<JavaScriptString> description();
     native public JavaScriptString symbolDescriptiveString();
 

--- a/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptValue.java
+++ b/build/android/escargot/src/main/java/com/samsung/lwe/escargot/JavaScriptValue.java
@@ -3,6 +3,11 @@ package com.samsung.lwe.escargot;
 import java.util.Optional;
 
 public class JavaScriptValue extends NativePointerHolder {
+    protected JavaScriptValue(long nativePointer)
+    {
+        super(nativePointer);
+    }
+
     native static public JavaScriptValue createUndefined();
     native static public JavaScriptValue createNull();
     native static public JavaScriptValue create(boolean value);
@@ -64,10 +69,4 @@ public class JavaScriptValue extends NativePointerHolder {
      * @return
      */
     native public Optional<Boolean> instanceOf(Context context, JavaScriptValue other);
-
-    native protected void releaseNativePointer();
-    @Override
-    public void destroy() {
-        releaseNativePointer();
-    }
 }

--- a/build/android/escargot/src/main/java/com/samsung/lwe/escargot/NativePointerHolder.java
+++ b/build/android/escargot/src/main/java/com/samsung/lwe/escargot/NativePointerHolder.java
@@ -1,15 +1,49 @@
 package com.samsung.lwe.escargot;
 
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.ArrayList;
+import java.util.List;
+
 public abstract class NativePointerHolder {
+    static ThreadLocal<ReferenceQueue<NativePointerHolder>> s_referenceQueue = ThreadLocal.withInitial(() -> new ReferenceQueue<>());
+    static ThreadLocal<List<NativePointerHolderPhantomReference>> s_referenceList = ThreadLocal.withInitial(() -> new ArrayList<>());
     static { Escargot.init(); }
-    abstract public void destroy();
-    public boolean hasValidNativePointer()
-    {
-        return m_nativePointer != 0;
+
+    public static class NativePointerHolderPhantomReference extends PhantomReference<NativePointerHolder> {
+        public NativePointerHolderPhantomReference(NativePointerHolder nativePointerHolder, ReferenceQueue<NativePointerHolder> queue)
+        {
+            super(nativePointerHolder, queue);
+            m_nativePointer = nativePointerHolder.m_nativePointer;
+        }
+        long m_nativePointer;
     }
-    protected void finalize()
+
+    NativePointerHolder(long nativePointer)
     {
-        destroy();
+        m_nativePointer = nativePointer;
+        s_referenceList.get().add(new NativePointerHolderPhantomReference(this, s_referenceQueue.get()));
     }
+
+    public static void cleanUp()
+    {
+        try {
+            for (NativePointerHolderPhantomReference reference : s_referenceList.get()) {
+                reference.refersTo(null);
+            }
+        } catch (NoSuchMethodError e) {
+            for (NativePointerHolderPhantomReference reference : s_referenceList.get()) {
+                reference.isEnqueued();
+            }
+        }
+
+        Reference<? extends NativePointerHolder> ref;
+        while ((ref = s_referenceQueue.get().poll()) != null) {
+            releaseNativePointerMemory(((NativePointerHolderPhantomReference)ref).m_nativePointer);
+            ref.clear();
+        }
+    }
+    static private native void releaseNativePointerMemory(long pointer);
     protected long m_nativePointer;
 }

--- a/build/android/escargot/src/main/java/com/samsung/lwe/escargot/VMInstance.java
+++ b/build/android/escargot/src/main/java/com/samsung/lwe/escargot/VMInstance.java
@@ -3,13 +3,11 @@ package com.samsung.lwe.escargot;
 import java.util.Optional;
 
 public class VMInstance extends NativePointerHolder {
+    protected VMInstance(long nativePointer)
+    {
+        super(nativePointer);
+    }
     // you can to provide timezone as TZ database name like "US/Pacific".
     // if you don't provide, we try to detect system timezone.
     public native static VMInstance create(Optional<String> locale, Optional<String> timezone);
-    native protected void releaseNativePointer();
-
-    @Override
-    public void destroy() {
-        releaseNativePointer();
-    }
 }

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -313,14 +313,20 @@ VMInstance::~VMInstance()
         Optional<GCEventListenerSet::EventListenerVector*> msListeners = list.markStartListeners();
         ASSERT(msListeners.hasValue());
         auto iter = std::find(msListeners->begin(), msListeners->end(), std::make_pair(vmMarkStartCallback, static_cast<void*>(this)));
-        ASSERT(iter != msListeners->end());
-        msListeners->erase(iter);
+        // the pointer could pointer end
+        // because ThreadLocal can be differ regard to multiple init-deinit
+        if (iter != msListeners->end()) {
+            msListeners->erase(iter);
+        }
 
         Optional<GCEventListenerSet::EventListenerVector*> reListeners = list.reclaimEndListeners();
         ASSERT(reListeners.hasValue());
         iter = std::find(reListeners->begin(), reListeners->end(), std::make_pair(vmReclaimEndCallback, static_cast<void*>(this)));
-        ASSERT(iter != reListeners->end());
-        reListeners->erase(iter);
+        // the pointer could pointer end
+        // because ThreadLocal can be differ regard to multiple init-deinit
+        if (iter != reListeners->end()) {
+            reListeners->erase(iter);
+        }
     }
 
     if (m_onVMInstanceDestroy) {


### PR DESCRIPTION
* Use PhantomReference and ReferenceQueue instead of finalizer. finalizer could be called by another thread like FinalizerDaemon and it is deprecated.

* Remove NativePointerHolder::destroy function.