### PR TITLE
Fix bugs

### DIFF
--- a/build/android/escargot/src/main/cpp/CMakeLists.txt
+++ b/build/android/escargot/src/main/cpp/CMakeLists.txt
@@ -42,6 +42,7 @@ if (ENABLE_SHELL)
         (${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../third_party/GCutil/bdwgc/include)
         (${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../src))
     TARGET_LINK_LIBRARIES (escargot-shell PRIVATE escargot ${LOG_LIBRARY})
+    ADD_DEFINITIONS(-DNDEBUG)
 
     ADD_EXECUTABLE(test262-runner ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../tools/test/test262/test-data-runner.cpp)
     TARGET_COMPILE_OPTIONS(test262-runner PRIVATE -std=c++11)

--- a/build/config.cmake
+++ b/build/config.cmake
@@ -69,7 +69,7 @@ ELSEIF (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     SET (ESCARGOT_CXXFLAGS ${ESCARGOT_CXXFLAGS} -fno-fast-math -fno-unsafe-math-optimizations -fdenormal-fp-math=ieee)
     SET (ESCARGOT_CXXFLAGS ${ESCARGOT_CXXFLAGS} -Wno-unsupported-floating-point-opt -Wno-parentheses-equality -Wno-dynamic-class-memaccess -Wno-deprecated-register
             -Wno-expansion-to-defined -Wno-return-type -Wno-overloaded-virtual -Wno-unused-private-field -Wno-deprecated-copy -Wno-atomic-alignment
-            -Wno-ambiguous-reversed-operator -Wno-deprecated-enum-enum-conversion -Wno-deprecated-enum-float-conversion)
+            -Wno-ambiguous-reversed-operator -Wno-deprecated-enum-enum-conversion -Wno-deprecated-enum-float-conversion -Wno-braced-scalar-init)
 ELSE()
     MESSAGE (FATAL_ERROR ${CMAKE_CXX_COMPILER_ID} " is Unsupported Compiler")
 ENDIF()

--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -217,10 +217,6 @@ if (f.type == Type::B) { puts("failed in msvc."); }
 #define ENSURE_ENUM_UNSIGNED
 #endif
 
-#if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
-#define HAVE_BUILTIN_ATOMIC_FUNCTIONS
-#endif
-
 #if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
 #define CPU_X86_64
 
@@ -235,6 +231,11 @@ if (f.type == Type::B) { puts("failed in msvc."); }
 
 #else
 #error "Could't find cpu arch."
+#endif
+
+// FIXME arm devices raise SIGBUS when using unaligned address to __atomic_* functions
+#if (defined(COMPILER_GCC) || defined(COMPILER_CLANG)) && !defined(CPU_ARM32) && !defined(CPU_ARM64)
+#define HAVE_BUILTIN_ATOMIC_FUNCTIONS
 #endif
 
 #if defined(COMPILER_MSVC)

--- a/src/builtins/BuiltinAtomics.cpp
+++ b/src/builtins/BuiltinAtomics.cpp
@@ -562,8 +562,13 @@ static Value builtinAtomicsNotify(ExecutionState& state, Value thisValue, size_t
 static Value builtinAtomicsIsLockFree(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget)
 {
     const auto size = argv[0].toInteger(state);
+    // https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.islockfree
+    // Atomics.isLockFree(4) always returns true as that can be supported on all known relevant hardware. Being able to assume this will generally simplify programs.
+    if (size == 4) {
+        return Value(true);
+    }
 #if defined(HAVE_BUILTIN_ATOMIC_FUNCTIONS)
-    if (size == 1 || size == 2 || size == 4 || size == 8) {
+    if (size == 1 || size == 2 || size == 8) {
         return Value(true);
     }
     return Value(false);

--- a/src/builtins/BuiltinRegExp.cpp
+++ b/src/builtins/BuiltinRegExp.cpp
@@ -108,7 +108,7 @@ static Value builtinRegExpExec(ExecutionState& state, Value thisValue, size_t ar
         if (option & RegExpObject::Option::Unicode) {
             char16_t utfRes = str->charAt(e);
             const char* buf = reinterpret_cast<const char*>(&utfRes);
-            size_t len = strlen(buf);
+            size_t len = strnlen(buf, 2);
             size_t eUTF = str->find(buf, len, 0);
             if (eUTF >= str->length()) {
                 e = str->length();


### PR DESCRIPTION
* Replace strlen with strnlen in BuiltinRegExp
* Don't use compiler builtin atomic operation in ARM
* Atomics.isLockFree(4) always returns true