### PR TITLE
Fix crash with ObjectStructureWithMap and inline cache

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -2410,6 +2410,7 @@ NEVER_INLINE void InterpreterSlowPath::getObjectPrecomputedCaseOperation(Executi
 
     while (true) {
         auto s = obj->structure();
+        s->markReferencedByInlineCache();
         cachedhiddenClassChain.push_back(s);
         auto result = s->findProperty(propertyName);
 
@@ -4139,6 +4140,8 @@ NEVER_INLINE void InterpreterSlowPath::objectDefineOwnPropertyWithNameOperation(
                     byteCodeBlock->m_otherLiteralData.push_back(newStructure);
                     code->m_inlineCachedStructureBefore = oldStructure;
                     code->m_inlineCachedStructureAfter = newStructure;
+                    oldStructure->markReferencedByInlineCache();
+                    newStructure->markReferencedByInlineCache();
                 } else {
                     // failed to cache
                 }

--- a/src/runtime/ObjectStructure.h
+++ b/src/runtime/ObjectStructure.h
@@ -148,6 +148,11 @@ public:
     virtual ObjectStructure* convertToNonTransitionStructure() = 0;
     virtual bool inTransitionMode() = 0;
 
+    void markReferencedByInlineCache()
+    {
+        m_isReferencedByInlineCache = true;
+    }
+
     bool hasIndexPropertyName() const
     {
         return m_hasIndexPropertyName;
@@ -163,6 +168,11 @@ public:
         return m_hasEnumerableProperty;
     }
 
+    bool isReferencedByInlineCache() const
+    {
+        return m_isReferencedByInlineCache;
+    }
+
 protected:
     ObjectStructure(bool hasIndexPropertyName,
                     bool hasSymbolPropertyName, bool hasEnumerableProperty)
@@ -171,6 +181,7 @@ protected:
         , m_hasSymbolPropertyName(hasSymbolPropertyName)
         , m_hasNonAtomicPropertyName(false)
         , m_hasEnumerableProperty(hasEnumerableProperty)
+        , m_isReferencedByInlineCache(false)
         , m_transitionTableVectorBufferSize(0)
         , m_transitionTableVectorBufferCapacity(0)
     {
@@ -183,6 +194,7 @@ protected:
         , m_hasSymbolPropertyName(hasSymbolPropertyName)
         , m_hasNonAtomicPropertyName(hasNonAtomicPropertyName)
         , m_hasEnumerableProperty(hasEnumerableProperty)
+        , m_isReferencedByInlineCache(false)
         , m_transitionTableVectorBufferSize(0)
         , m_transitionTableVectorBufferCapacity(0)
     {
@@ -195,6 +207,7 @@ protected:
     bool m_hasSymbolPropertyName : 1;
     bool m_hasNonAtomicPropertyName : 1;
     bool m_hasEnumerableProperty : 1;
+    bool m_isReferencedByInlineCache : 1;
     uint8_t m_transitionTableVectorBufferSize : 8;
     uint8_t m_transitionTableVectorBufferCapacity : 8;
 };


### PR DESCRIPTION
If inline cache refers ObjectStructure, ObjectStructure should keep its contents.