### PR TITLE
Apply TCO for sequence and logical operations located at the end of the return statement

### DIFF
--- a/src/parser/ast/BinaryExpressionLogicalAndNode.h
+++ b/src/parser/ast/BinaryExpressionLogicalAndNode.h
@@ -42,19 +42,55 @@ public:
             context->m_canSkipCopyToRegister = false;
         }
 
-        size_t resultRegisterExpected = dstRegister;
+        if (UNLIKELY(m_left->isLiteral())) {
+            ExecutionState stateForTest(codeBlock->m_codeBlock->context());
+            bool boolVal = m_left->asLiteral()->value().toBoolean(stateForTest);
+            if (boolVal) {
+                m_right->generateExpressionByteCode(codeBlock, context, dstRegister);
+            } else {
+                m_left->generateExpressionByteCode(codeBlock, context, dstRegister);
+            }
+        } else {
+            m_left->generateExpressionByteCode(codeBlock, context, dstRegister);
+            codeBlock->pushCode<JumpIfFalse>(JumpIfFalse(ByteCodeLOC(m_loc.index), dstRegister), context, this->m_loc.index);
+            size_t pos = codeBlock->lastCodePosition<JumpIfFalse>();
 
-        m_left->generateExpressionByteCode(codeBlock, context, resultRegisterExpected);
-
-        codeBlock->pushCode<JumpIfFalse>(JumpIfFalse(ByteCodeLOC(m_loc.index), resultRegisterExpected), context, this->m_loc.index);
-        size_t pos = codeBlock->lastCodePosition<JumpIfFalse>();
-
-        m_right->generateExpressionByteCode(codeBlock, context, resultRegisterExpected);
-
-        codeBlock->peekCode<JumpIfFalse>(pos)->m_jumpPosition = codeBlock->currentCodeSize();
+            m_right->generateExpressionByteCode(codeBlock, context, dstRegister);
+            codeBlock->peekCode<JumpIfFalse>(pos)->m_jumpPosition = codeBlock->currentCodeSize();
+        }
 
         context->m_canSkipCopyToRegister = directBefore;
     }
+
+#if defined(ENABLE_TCO)
+    virtual void generateTCOExpressionByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex dstRegister, bool& isTailCall) override
+    {
+        bool isSlow = !canUseDirectRegister(context, m_left, m_right);
+        bool directBefore = context->m_canSkipCopyToRegister;
+        if (isSlow) {
+            context->m_canSkipCopyToRegister = false;
+        }
+
+        if (UNLIKELY(m_left->isLiteral())) {
+            ExecutionState stateForTest(codeBlock->m_codeBlock->context());
+            bool boolVal = m_left->asLiteral()->value().toBoolean(stateForTest);
+            if (boolVal) {
+                m_right->generateTCOExpressionByteCode(codeBlock, context, dstRegister, isTailCall);
+            } else {
+                m_left->generateTCOExpressionByteCode(codeBlock, context, dstRegister, isTailCall);
+            }
+        } else {
+            m_left->generateExpressionByteCode(codeBlock, context, dstRegister);
+            codeBlock->pushCode<JumpIfFalse>(JumpIfFalse(ByteCodeLOC(m_loc.index), dstRegister), context, this->m_loc.index);
+            size_t pos = codeBlock->lastCodePosition<JumpIfFalse>();
+
+            m_right->generateExpressionByteCode(codeBlock, context, dstRegister);
+            codeBlock->peekCode<JumpIfFalse>(pos)->m_jumpPosition = codeBlock->currentCodeSize();
+        }
+
+        context->m_canSkipCopyToRegister = directBefore;
+    }
+#endif
 
     virtual void iterateChildrenIdentifier(const std::function<void(AtomicString name, bool isAssignment)>& fn) override
     {

--- a/src/parser/ast/WhileStatementNode.h
+++ b/src/parser/ast/WhileStatementNode.h
@@ -54,7 +54,7 @@ public:
         size_t whileStart = codeBlock->currentCodeSize();
         size_t testPos = SIZE_MAX;
         ExecutionState stateForTest(codeBlock->m_codeBlock->context());
-        if (m_test->isLiteral() && m_test->asLiteral()->value().isPrimitive() && m_test->asLiteral()->value().toBoolean(stateForTest)) {
+        if (m_test->isLiteral() && m_test->asLiteral()->value().toBoolean(stateForTest)) {
             // skip generate code
         } else {
             if (m_test->isRelationOperation()) {

--- a/tools/test/test262/excludelist.orig.xml
+++ b/tools/test/test262/excludelist.orig.xml
@@ -5070,7 +5070,6 @@
     <test id="language/expressions/class/scope-name-lex-open-heritage"><reason>TODO</reason></test>
     <test id="language/expressions/coalesce/chainable-if-parenthesis-covered-logical-and"><reason>TODO</reason></test>
     <test id="language/expressions/coalesce/chainable-if-parenthesis-covered-logical-or"><reason>TODO</reason></test>
-    <test id="language/expressions/comma/tco-final"><reason>TODO</reason></test>
     <test id="language/expressions/compound-assignment/S11.13.2_A6.10_T1"><reason>TODO</reason></test>
     <test id="language/expressions/compound-assignment/S11.13.2_A6.11_T1"><reason>TODO</reason></test>
     <test id="language/expressions/compound-assignment/S11.13.2_A6.1_T1"><reason>TODO</reason></test>
@@ -5121,7 +5120,6 @@
     <test id="language/expressions/generators/eval-var-scope-syntax-err"><reason>TODO</reason></test>
     <test id="language/expressions/generators/generator-created-after-decl-inst"><reason>TODO</reason></test>
     <test id="language/expressions/generators/yield-as-generator-expression-binding-identifier"><reason>TODO</reason></test>
-    <test id="language/expressions/logical-and/tco-right"><reason>TODO</reason></test>
     <test id="language/expressions/logical-assignment/lgcl-and-assignment-operator-namedevaluation-arrow-function"><reason>TODO</reason></test>
     <test id="language/expressions/logical-assignment/lgcl-and-assignment-operator-namedevaluation-class-expression"><reason>TODO</reason></test>
     <test id="language/expressions/logical-assignment/lgcl-and-assignment-operator-namedevaluation-function"><reason>TODO</reason></test>
@@ -5131,7 +5129,6 @@
     <test id="language/expressions/logical-assignment/lgcl-or-assignment-operator-namedevaluation-arrow-function"><reason>TODO</reason></test>
     <test id="language/expressions/logical-assignment/lgcl-or-assignment-operator-namedevaluation-class-expression"><reason>TODO</reason></test>
     <test id="language/expressions/logical-assignment/lgcl-or-assignment-operator-namedevaluation-function"><reason>TODO</reason></test>
-    <test id="language/expressions/logical-or/tco-right"><reason>TODO</reason></test>
     <test id="language/expressions/object/__proto__-permitted-dup-shorthand"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/object-rest-proxy-get-not-called-on-dontenum-keys"><reason>TODO</reason></test>
     <test id="language/expressions/object/dstr/object-rest-proxy-gopd-not-called-on-excluded-keys"><reason>TODO</reason></test>


### PR DESCRIPTION
* remove unused parameter in toBoolean method
* optimize bytecode generations in sequence and logical operations