### PR TITLE
implement: code review bot

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,109 @@
+name: Review Bot (PR)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [ "master" ]
+
+concurrency:
+  group: review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: [self-hosted, escargot-review]
+
+    steps:
+      - name: Compute diff range (incremental on synchronize)
+        id: shas
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const action = context.payload.action;
+            const pr = context.payload.pull_request.number;
+            const baseSha = context.payload.pull_request.base.sha;
+            const headSha = context.payload.pull_request.head.sha;
+
+            let base = baseSha;
+            let skip = false;
+            if (action === 'synchronize') {
+              const before = context.payload.before;
+              if (before) {
+                base = before;
+              } else {
+                skip = true;
+              }
+            }
+
+            core.setOutput('base', base);
+            core.setOutput('head', headSha);
+            core.setOutput('pr', pr);
+            core.setOutput('skip', String(skip));
+      - name: Skip review (no before on synchronize)
+        if: ${{ steps.shas.outputs.skip == 'true' }}
+        run: |
+          echo "[Review Bot] Skipping review: 'before' SHA missing on synchronize event."
+      - name: Call review server
+        id: call
+        if: ${{ steps.shas.outputs.skip != 'true' }}
+        env:
+          REVIEW_SERVER: ${{ secrets.REVIEW_SERVER }}
+        run: |
+          set -euo pipefail
+          REVIEW_SERVER="${REVIEW_SERVER}"
+          BASE_SHA="${{ steps.shas.outputs.base }}"
+          HEAD_SHA="${{ steps.shas.outputs.head }}"
+          PR_NUMBER="${{ steps.shas.outputs.pr }}"
+
+          curl -sS --fail-with-body --show-error \
+            --connect-timeout 10 --max-time 7200 \
+            -X POST "${REVIEW_SERVER}/review" \
+            -H "Content-Type: application/json" \
+            -d "{\"base_sha\":\"${BASE_SHA}\",\"head_sha\":\"${HEAD_SHA}\",\"pull_request_number\":${PR_NUMBER}}" \
+            -o review.json
+
+          echo "==== review.json ===="
+          cat review.json
+
+      - name: Post review comments
+        if: ${{ steps.shas.outputs.skip != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const pr = context.payload.pull_request.number;
+            let raw;
+            try {
+              raw = fs.readFileSync('review.json', 'utf8');
+            } catch (e) {
+              core.warning(`review.json not found: ${e}`);
+              return;
+            }
+            let data;
+            try {
+              data = JSON.parse(raw);
+            } catch (e) {
+              core.warning(`Failed to parse review.json as JSON: ${e}`);
+              return;
+            }
+            const comments = Array.isArray(data.comments) ? data.comments : [];
+
+            for (const c of comments) {
+              await github.request('POST /repos/{owner}/{repo}/pulls/{pull_number}/comments', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr,
+                body: c.body,
+                commit_id: c.commit_id,
+                path: c.path,
+                line: c.line,
+                side: c.side,
+                headers: { 'accept': 'application/vnd.github+json' }
+              });
+
+              await new Promise(r => setTimeout(r, 200));
+            }


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow to enable automated code reviews for pull requests.  
This PR adds `.github/workflows/code-review.yml` only. The review server code is hosted separately in the repository: [escargot-review-bot](https://github.com/2Jaeheon/escargot-review-bot).

The “Escargot Review Server” is a self‑hosted FastAPI service that receives `{base, head, pr}`, computes a diff, and uses a local LLM (Ollama) in two passes (defects → refactors) to generate review comments. Outputs are JSON‑validated and anchored to HEAD before posting back via the GitHub API. It’s optimized for self‑hosted runners (speed/cost/privacy) and operated via systemd/journald; implementation and operational details live in the external repository above.

## Migration to organization
- If a new GitHub Organization is created (by the professor), we plan to migrate:
  - Move `escargot-review-bot` to the org and transfer ownership/ops there.
- No functional changes expected; this PR’s workflow can remain as‑is until the migration occurs.

## Self-hosted runner (required)
This workflow requires a self-hosted GitHub Actions runner.
- Runner location: Repository Settings → Actions → Runners
- Label requirement: the runner must have the label `escargot-review`
- Default: `REVIEW_SERVER=http://127.0.0.1:8000`

## What’s included
- Add workflow `Review Bot (PR)` triggered on `pull_request_target` (`opened`, `synchronize`, `reopened`)
- Concurrency per PR with `cancel-in-progress: true`
- Minimal permissions: `contents: read`, `pull-requests: write`
- Self‑hosted runner label: `escargot-review`
- Steps:
  - Compute diff range (full for opened/reopened; incremental for synchronize using `before..head`)
  - Call local review server: `POST /review` with `{base_sha, head_sha, pr}`
  - Read `review.json` and post comments back to the PR (200ms spacing)
  - Safe skip if `before` SHA is missing on `synchronize`

## Architecture (high-level)
- GitHub Actions (this workflow) → calls the review server with the target SHAs
- Review Server (FastAPI) → computes `git diff`, parses hunks, builds prompts
- LLM via Ollama → two-pass generation (defects then refactors), schema-validated
- Anchoring to HEAD → comments posted back via GitHub API
- Server code and ops: [escargot-review-bot](https://github.com/2Jaeheon/escargot-review-bot) (managed via systemd/journald; operational details live in that repo’s README/ops docs)

## Rationale and safety
- Uses `pull_request_target` to avoid executing untrusted PR code
- Minimal write scope: only posts review comments
- Concurrency guard prevents overlapping runs per PR
- Robust failure handling: curl `--fail-with-body`, safe skip path, JSON parse guarded

## Rollback
- Revert this PR to disable the review workflow.