### PR TITLE
ci: fix-windows build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,11 +174,13 @@ jobs:
         git config --global core.eol lf
     - uses: actions/checkout@v4
       with:
-        submodules: true
+        submodules: recursive
     - uses: szenius/set-timezone@v2.0
       with:
         timezoneWindows: "Pacific Standard Time"
     - uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: "~3.25.0"
     - uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
       with:
         sdk-version: 26100
@@ -200,7 +202,7 @@ jobs:
         }
     - name: Build ${{ matrix.arch }}
       run: |
-        CMake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION:STRING="10.0" -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} -DESCARGOT_ARCH=${{ matrix.arch }} -Bout/ -DESCARGOT_OUTPUT=shell -DESCARGOT_LIBICU_SUPPORT=ON -DESCARGOT_LIBICU_SUPPORT_WITH_DLOPEN=OFF -DESCARGOT_THREADING=ON -DESCARGOT_TCO=ON -DESCARGOT_TEST=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -G Ninja -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=release
+        CMake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION:STRING="10.0" -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} -DESCARGOT_ARCH=${{ matrix.arch }} -Bout/ -DESCARGOT_OUTPUT=shell -DESCARGOT_LIBICU_SUPPORT=ON -DESCARGOT_WASM=ON -DESCARGOT_THREADING=ON -DESCARGOT_TCO=ON -DESCARGOT_TEST=ON -DESCARGOT_SHADOWREALM=ON -G Ninja -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=release
         CMake --build out/ --config Release
     - name: Check
       run: |


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` workflow to improve build configuration and dependency management for Windows releases. The main changes include more precise submodule checkout, specifying the CMake version, and enabling additional build options.

Build configuration improvements:
* Modified to function correctly based on es-actions, and confirmed successful release in a personal fork repository
* When setting the submodule to true, we identified an issue within the submodule and confirmed functionality by changing it to `recursive`
* Added explicit specification of the CMake version (`~3.25.0`) in the setup step to ensure consistent build tooling.

Build options enhancements:
* Enabled new build flags in the CMake invocation: `DESCARGOT_WASM=ON` and `DESCARGOT_SHADOWREALM=ON`