### PR TITLE
Add bytecode generate process that removing unused function parameters

### DIFF
--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -168,10 +168,12 @@ int getValidValueInInterpretedCodeBlock(void* ptr, GC_mark_custom_result* arr)
     arr[4].to = (GC_word*)current->m_children;
     arr[5].from = (GC_word*)&current->m_parameterNames;
     arr[5].to = (GC_word*)current->m_parameterNames.data();
-    arr[6].from = (GC_word*)&current->m_identifierInfos;
-    arr[6].to = (GC_word*)current->m_identifierInfos.data();
-    arr[7].from = (GC_word*)&current->m_blockInfos;
-    arr[7].to = (GC_word*)current->m_blockInfos;
+    arr[6].from = (GC_word*)&current->m_parameterUsed;
+    arr[6].to = (GC_word*)current->m_parameterUsed.data();
+    arr[7].from = (GC_word*)&current->m_identifierInfos;
+    arr[7].to = (GC_word*)current->m_identifierInfos.data();
+    arr[8].from = (GC_word*)&current->m_blockInfos;
+    arr[8].to = (GC_word*)current->m_blockInfos;
     return 0;
 }
 
@@ -190,12 +192,14 @@ int getValidValueInInterpretedCodeBlockWithRareData(void* ptr, GC_mark_custom_re
     arr[4].to = (GC_word*)current->m_children;
     arr[5].from = (GC_word*)&current->m_parameterNames;
     arr[5].to = (GC_word*)current->m_parameterNames.data();
-    arr[6].from = (GC_word*)&current->m_identifierInfos;
-    arr[6].to = (GC_word*)current->m_identifierInfos.data();
-    arr[7].from = (GC_word*)&current->m_blockInfos;
-    arr[7].to = (GC_word*)current->m_blockInfos;
-    arr[8].from = (GC_word*)&current->m_rareData;
-    arr[8].to = (GC_word*)current->m_rareData;
+    arr[6].from = (GC_word*)&current->m_parameterUsed;
+    arr[6].to = (GC_word*)current->m_parameterUsed.data();
+    arr[7].from = (GC_word*)&current->m_identifierInfos;
+    arr[7].to = (GC_word*)current->m_identifierInfos.data();
+    arr[8].from = (GC_word*)&current->m_blockInfos;
+    arr[8].to = (GC_word*)current->m_blockInfos;
+    arr[9].from = (GC_word*)&current->m_rareData;
+    arr[9].to = (GC_word*)current->m_rareData;
     return 0;
 }
 
@@ -290,12 +294,12 @@ void initializeCustomAllocators()
                                                                               TRUE);
 
     s_gcKinds[HeapObjectKind::InterpretedCodeBlockKind] = GC_new_kind(GC_new_free_list(),
-                                                                      GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 8>), 0),
+                                                                      GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 9>), 0),
                                                                       FALSE,
                                                                       TRUE);
 
     s_gcKinds[HeapObjectKind::InterpretedCodeBlockWithRareDataKind] = GC_new_kind(GC_new_free_list(),
-                                                                                  GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlockWithRareData, 9>), 0),
+                                                                                  GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlockWithRareData, 10>), 0),
                                                                                   FALSE,
                                                                                   TRUE);
 

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -339,8 +339,8 @@ bool InterpretedCodeBlock::isParameterUsed(ASTScopeContext* scopeCtx, AtomicStri
 void InterpretedCodeBlock::recordParameterUsage(ASTScopeContext* scopeCtx)
 {
     for (size_t i = 0; i < m_parameterUsed.size(); i++) {
-        if (isParameterUsed(scopeCtx, m_parameterUsed[i].name)) {
-            m_parameterUsed[i].isUsed = true;
+        if (isParameterUsed(scopeCtx, m_parameterUsed[i].m_name)) {
+            m_parameterUsed[i].m_isUsed = true;
         }
     }
 
@@ -437,9 +437,9 @@ void InterpretedCodeBlock::recordFunctionParsingInfo(ASTScopeContext* scopeCtx, 
         for (size_t i = 0; i < parameterNamesCount; i++) {
             m_parameterNames[i] = parameterNames[i];
 
-            ParamUsed paramUsedInfo;
-            paramUsedInfo.name = parameterNames[i];
-            paramUsedInfo.isUsed = false;
+            ParameterUsed paramUsedInfo;
+            paramUsedInfo.m_name = parameterNames[i];
+            paramUsedInfo.m_isUsed = false;
             m_parameterUsed[i] = paramUsedInfo;
         }
 

--- a/src/parser/CodeBlock.h
+++ b/src/parser/CodeBlock.h
@@ -43,13 +43,6 @@ typedef HashMap<AtomicString, StorePositiveNumberAsOddNumber, std::hash<AtomicSt
 // only in construct call, newTarget have Object*
 typedef Value (*NativeFunctionPointer)(ExecutionState& state, Value thisValue, size_t argc, Value* argv, Optional<Object*> newTarget);
 
-typedef struct ParameterUsed {
-    AtomicString name;
-    bool isUsed;
-} ParamUsed;
-
-typedef TightVector<ParamUsed, GCUtil::gc_malloc_atomic_allocator<ParamUsed>> ParamUsedVector;
-
 struct NativeFunctionInfo {
     enum Flags {
         Strict = 1,
@@ -411,6 +404,13 @@ public:
         LexicalBlockIndex m_blockIndex;
         BlockIdentifierInfoVector m_identifiers;
     };
+
+    struct ParameterUsed {
+        AtomicString m_name;
+        bool m_isUsed;
+    };
+
+    typedef TightVector<ParameterUsed, GCUtil::gc_malloc_atomic_allocator<ParameterUsed>> ParameterUsedVector;
 
     struct IdentifierInfo {
         bool m_needToAllocateOnStack : 1;
@@ -949,8 +949,8 @@ public:
     bool checkParameterUsed(const AtomicString& name)
     {
         for (size_t i = 0; i < m_parameterUsed.size(); i++) {
-            if (m_parameterUsed[i].name == name) {
-                return m_parameterUsed[i].isUsed;
+            if (m_parameterUsed[i].m_name == name) {
+                return m_parameterUsed[i].m_isUsed;
             }
         }
         return false;
@@ -987,7 +987,7 @@ protected:
 
     // all parameter names including targets of patterns and rest element
     AtomicStringTightVector m_parameterNames;
-    ParamUsedVector m_parameterUsed;
+    ParameterUsedVector m_parameterUsed;
     IdentifierInfoVector m_identifierInfos;
     BlockInfo** m_blockInfos;
     static constexpr size_t maxBlockInfosLength = ((1 << 24) - 1);

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -5032,7 +5032,14 @@ public:
                 Node* param = this->parseFormalParameter(builder, options);
 
                 switch (param->type()) {
-                case Identifier:
+                case Identifier: {
+                    if (this->codeBlock->checkParameterUsed(param->asIdentifier()->name())) {
+                        Node* init = this->finalize(node, builder.createInitializeParameterExpressionNode(param, paramIndex));
+                        Node* statement = this->finalize(node, builder.createExpressionStatementNode(init));
+                        container->appendChild(statement);
+                    }
+                    break;
+                }
                 case AssignmentPattern:
                 case ArrayPattern:
                 case ObjectPattern: {

--- a/test/cctest/testapi.cpp
+++ b/test/cctest/testapi.cpp
@@ -2733,7 +2733,7 @@ DebuggerOperationsRef::ResumeBreakpointOperation DebuggerTest::stopAtBreakpoint(
         EXPECT_EQ(properties.size(), 1);
         EXPECT_TRUE(properties[0].key->equalsWithASCIIString("arg", 3));
         EXPECT_TRUE(properties[0].value.hasValue());
-        EXPECT_TRUE(properties[0].value->isNull());
+        EXPECT_TRUE(properties[0].value->isUndefined());
 
         return DebuggerOperationsRef::Finish;
     }

--- a/tools/debugger/tests/do_variables.expected
+++ b/tools/debugger/tests/do_variables.expected
@@ -30,7 +30,7 @@ Global Environment
 (escargot-debugger) variables
 c: undefined
 (escargot-debugger) variables 1
-a: number: 1
+a: undefined
 b: number: 2
 (escargot-debugger) s
 Stopped at tools/debugger/tests/do_variables.js:37


### PR DESCRIPTION
This PR removes some bytecodes that generate function parameters which are not used during execution.
Due to some tests are not good to handle this change, I also edit result of some tests; test debugger and testapi.

