### PR TITLE
ci(macos): add ad-hoc codesign for .dylib artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,14 @@ jobs:
         otool -L ./deploy/escargot
         otool -L ./deploy/libicu*.dylib
 
+        # Ad-hoc sign
+        set -e
+        cd deploy
+        for f in libicu*.dylib; do [ -e "$f" ] || continue; codesign -f -s - "$f"; done
+        codesign --force --deep -s - ./escargot
+        for f in ./escargot libicu*.dylib; do [ -e "$f" ] || continue; codesign --verify --strict --verbose=6 "$f"; done
+        cd ..
+
         # run test
         $RUNNER --engine="$GITHUB_WORKSPACE/deploy/escargot" new-es
 


### PR DESCRIPTION
### Summary
Fixed an issue where the binary was immediately killed on macOS (ARM) due to missing code signing for bundled `.dylib` files.

### Problem
- On Apple Silicon macOS, escargot failed to run because the ICU `.dylib` libraries were not code signed.
- macOS security policies prevent execution when unsigned dynamic libraries are loaded.

### Changes
- Added ad-hoc code signing for all `libicu*.dylib` artifacts in the CI pipeline.
- Updated the workflow to verify both the `escargot` binary and the signed `.dylib` files.

### Verification
- Successfully built and tested on macOS ARM (Apple Silicon).
- Verified code signatures using `codesign` and confirmed that the process no longer gets killed on execution.