### PR TITLE
Change build scripts after move bdwgc files to gcutil repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #error_report
-escargot
+/escargot
 escargot.x*
 .project
 .cproject

--- a/build/android/escargot/src/main/cpp/CMakeLists.txt
+++ b/build/android/escargot/src/main/cpp/CMakeLists.txt
@@ -50,9 +50,7 @@ if (ENABLE_SHELL)
     ADD_LINK_OPTIONS(-static-libstdc++)
     ADD_EXECUTABLE(escargot-shell ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../src/shell/Shell.cpp)
     TARGET_INCLUDE_DIRECTORIES(escargot-shell PRIVATE ADD_SUBDIRECTORY
-        (${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../third_party/GCutil/)
-        (${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../third_party/GCutil/bdwgc/include)
-        (${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../third_party/GCutil/bdwgc/include/gc)
+        (${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../third_party/GCutil/include)
         (${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../src))
     TARGET_LINK_LIBRARIES (escargot-shell PRIVATE escargot ${LOG_LIBRARY})
 

--- a/packaging/escargot.spec
+++ b/packaging/escargot.spec
@@ -280,7 +280,7 @@ cmake --build build/out_tizen_%{rpm}
 CXXFLAGS+=' -DESCARGOT_ENABLE_TEST '
 %endif
 
-g++ src/shell/Shell.cpp -std=c++11 -Lbuild/out_tizen_%{rpm} -Isrc/ -Ithird_party/GCutil -Ithird_party/GCutil/bdwgc/include/gc -o build/out_tizen_%{rpm}/escargot -O2 -DNDEBUG -Wl,-rpath=\$ORIGIN -Wl,-rpath=%{_libdir}/escargot ${CXXFLAGS} -lescargot -lpthread
+g++ src/shell/Shell.cpp -std=c++11 -Lbuild/out_tizen_%{rpm} -Isrc/ -Ithird_party/GCutil/include -o build/out_tizen_%{rpm}/escargot -O2 -DNDEBUG -Wl,-rpath=\$ORIGIN -Wl,-rpath=%{_libdir}/escargot ${CXXFLAGS} -lescargot -lpthread
 g++ tools/test/test-data-runner/test-data-runner.cpp -o build/out_tizen_%{rpm}/test-data-runner -std=c++11 ${CXXFLAGS} -lpthread
 %endif
 

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -131,7 +131,8 @@ void btSighandler(int sig, struct sigcontext ctx)
 }
 #endif
 
-#include <GCUtil.h>
+#include "GCUtil.h"
+
 void doFullGCWithoutSeeingStack()
 {
     GC_register_mark_stack_func([]() {


### PR DESCRIPTION
This is a follow up of https://github.com/Samsung/gcutil/pull/34

Remove include dir ${GCUTIL_ROOT}.
Change include dir ${GCUTIL_ROOT}/bdwgc/include to ${GCUTIL_ROOT}/include.

Also, do not git-ignore build/android/escargot.