### PR TITLE
Update LICENSE.BOEHM-GC

### DIFF
--- a/LICENSE.BOEHM-GC
+++ b/LICENSE.BOEHM-GC
@@ -1,30 +1,33 @@
-Copyright (c) 1988, 1989 Hans-J. Boehm, Alan J. Demers
+MIT-style License
+
+Copyright (c) 1988-1989 Hans-J. Boehm, Alan J. Demers
 Copyright (c) 1991-1996 by Xerox Corporation.  All rights reserved.
 Copyright (c) 1996-1999 by Silicon Graphics.  All rights reserved.
-Copyright (c) 1999-2004 Hewlett-Packard Development Company, L.P.
-
-The file linux_threads.c is also
 Copyright (c) 1998 by Fergus Henderson.  All rights reserved.
+Copyright (c) 1999-2001 by Red Hat, Inc.  All rights reserved.
+Copyright (c) 1999-2011 Hewlett-Packard Development Company, L.P.
+Copyright (c) 2004-2005 Andrei Polushin
+Copyright (c) 2007 Free Software Foundation, Inc.
+Copyright (c) 2008-2022 Ivan Maidanski
+Copyright (c) 2011 Ludovic Courtes
+Copyright (c) 2018 Petter A. Urkedal
 
-The files Makefile.am, and configure.in are
-Copyright (c) 2001 by Red Hat Inc. All rights reserved.
-
-Several files supporting GNU-style builds are copyrighted by the Free
-Software Foundation, and carry a different license from that given
-below.
 
 THIS MATERIAL IS PROVIDED AS IS, WITH ABSOLUTELY NO WARRANTY EXPRESSED
 OR IMPLIED.  ANY USE IS AT YOUR OWN RISK.
 
 Permission is hereby granted to use or copy this program
-for any purpose,  provided the above notices are retained on all copies.
+for any purpose, provided the above notices are retained on all copies.
 Permission to modify the code and to distribute modified code is granted,
 provided the above notices are retained, and a notice that the code was
 modified is included with the above copyright notice.
 
-A few of the files needed to use the GNU-style build procedure come with
-slightly different licenses, though they are all similar in spirit.  A few
-are GPL'ed, but with an exception that should cover all uses in the
-collector.  (If you are concerned about such things, I recommend you look
-at the notice in config.guess or ltmain.sh.)
 
+Several files (gc/gc_allocator.h, extra/msvc_dbg.c) come with slightly
+different licenses, though they are all similar in spirit (the exact
+licensing terms are given at the beginning of the corresponding source file).
+
+A few of the files needed to use the GNU-style build procedure come with
+a modified GPL license that appears not to significantly restrict use of
+the collector, though use of those files for a purpose other than building
+the collector may require the resulting code to be covered by the GPL.


### PR DESCRIPTION
The license file is copied from [third_party/GCutil/LICENSE](https://github.com/Samsung/gcutil/blob/bdwgc_8_3_pre_main/LICENSE).