### PR TITLE
Fix out-of-bounds read in lexer comment/hashbang skipping

### DIFF
--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -755,7 +755,7 @@ void Scanner::skipSingleLine()
         ++this->index;
 
         if (isLineTerminator(ch)) {
-            if (ch == 13 && this->peekCharWithoutEOF() == 10) {
+            if (ch == 13 && !this->eof() && this->peekCharWithoutEOF() == 10) {
                 ++this->index;
             }
             ++this->lineNumber;
@@ -772,7 +772,7 @@ void Scanner::skipSingleLineComment(void)
         ++this->index;
 
         if (isLineTerminator(ch)) {
-            if (ch == 13 && this->peekCharWithoutEOF() == 10) {
+            if (ch == 13 && !this->eof() && this->peekCharWithoutEOF() == 10) {
                 ++this->index;
             }
             ++this->lineNumber;
@@ -790,12 +790,12 @@ void Scanner::skipMultiLineComment(void)
         ++this->index;
 
         if (isLineTerminator(ch)) {
-            if (ch == 0x0D && this->peekCharWithoutEOF() == 0x0A) {
+            if (ch == 0x0D && !this->eof() && this->peekCharWithoutEOF() == 0x0A) {
                 ++this->index;
             }
             ++this->lineNumber;
             this->lineStart = this->index;
-        } else if (ch == 0x2A && this->peekCharWithoutEOF() == 0x2F) {
+        } else if (ch == 0x2A && !this->eof() && this->peekCharWithoutEOF() == 0x2F) {
             // Block comment ends with '*/'.
             ++this->index;
             return;


### PR DESCRIPTION
Fixes #1568.

`skipSingleLine`, `skipSingleLineComment`, and `skipMultiLineComment` increment the source index and then call `peekCharWithoutEOF()` without re-checking `eof()`. For inputs ending with a bare `\r` or trailing `*`, the second peek reads one byte past the source buffer (caught by ASan; the underlying `peekCharWithoutEOF` asserts `!eof()` in debug builds). Guard each follow-up peek with `!this->eof()`.

Reproducer from the issue:
```js
//1234567890123\r
```