### PR TITLE
Fix OOB read in string::rfind

### DIFF
--- a/src/runtime/String.cpp
+++ b/src/runtime/String.cpp
@@ -1061,11 +1061,10 @@ size_t String::rfind(String* str, size_t pos)
     if (srcStrLen == 0)
         return pos <= size ? pos : -1;
     if (srcStrLen <= size) {
+        if (pos > size - srcStrLen)
+            pos = size - srcStrLen;
         do {
             bool same = true;
-            if (pos >= size) {
-                continue;
-            }
             for (size_t k = 0; k < srcStrLen; k++) {
                 if (charAt(pos + k) != str->charAt(k)) {
                     same = false;


### PR DESCRIPTION
Fixes crash4 in #1577 
```charAt(pos + k)``` could go OOB(off by one) if ```pos > size - srcStrLen```
Clamping the ```pos``` to its ```max value```  whenever ^above condition is true , fixes this bug.