### PR TITLE
Reject object binding pattern rest followed by a binding pattern (Iss…

### DIFF
--- a/src/parser/esprima_cpp/Messages.h
+++ b/src/parser/esprima_cpp/Messages.h
@@ -81,6 +81,7 @@ public:
     static constexpr const char* ParameterAfterRestParameter = "Rest parameter must be last formal parameter";
     static constexpr const char* DefaultRestParameter = "Unexpected token =";
     static constexpr const char* ObjectPatternAsRestParameter = "Unexpected token {";
+    static constexpr const char* RestElementMustBeFollowedByIdentifier = "`...` must be followed by an identifier in declaration contexts";
     static constexpr const char* DuplicateProtoProperty = "Duplicate __proto__ fields are not allowed in object literals";
     static constexpr const char* ConstructorSpecialMethod = "Class constructor may not be an accessor";
     static constexpr const char* ConstructorGenerator = "Class constructor may not be a generator";

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -1351,10 +1351,15 @@ public:
     }
 
     template <class ASTBuilder>
-    ASTNode parseBindingRestElement(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false)
+    ASTNode parseBindingRestElement(ASTBuilder& builder, SmallScannerResultVector& params, KeywordKind kind = KeywordKindEnd, bool isExplicitVariableDeclaration = false, bool restrictToIdentifier = false)
     {
         MetaNode node = this->createNode();
         this->nextToken();
+        // BindingRestProperty (object binding pattern rest) only accepts a BindingIdentifier,
+        // unlike BindingRestElement (array binding pattern rest) which also accepts a BindingPattern.
+        if (restrictToIdentifier && (this->match(LeftBrace) || this->match(LeftSquareBracket))) {
+            this->throwError(Messages::RestElementMustBeFollowedByIdentifier);
+        }
         ASTNode arg = this->parsePattern(builder, params, kind, isExplicitVariableDeclaration);
         return this->finalize(node, builder.createRestElementNode(arg));
     }
@@ -1459,7 +1464,7 @@ public:
         while (!this->match(RightBrace)) {
             if (this->match(PeriodPeriodPeriod)) {
                 hasRestElement = true;
-                properties.append(this->allocator, this->parseBindingRestElement(builder, params, kind, isExplicitVariableDeclaration));
+                properties.append(this->allocator, this->parseBindingRestElement(builder, params, kind, isExplicitVariableDeclaration, true));
                 break;
             } else {
                 properties.append(this->allocator, this->parsePropertyPattern(builder, params, kind, isExplicitVariableDeclaration));


### PR DESCRIPTION
…ue #1334)

BindingRestProperty in an object binding pattern only accepts a BindingIdentifier, unlike BindingRestElement in an array binding pattern which also accepts a BindingPattern. Throw a SyntaxError when `...` is followed by `{` or `[` in a declaration context.