### PR TITLE
Fix detached ArrayBuffer and OOB access in Atomics operations

### DIFF
--- a/build/target.cmake
+++ b/build/target.cmake
@@ -90,6 +90,10 @@ ELSEIF (${CMAKE_CXX_COMPILER_ID} MATCHES  "Clang") #include Clang and AppleClang
         # this feature supported after clang version 11
         SET (ESCARGOT_CXXFLAGS ${ESCARGOT_CXXFLAGS} -Wno-unsupported-floating-point-opt)
     endif()
+    IF (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19)
+        # this feature supported after clang version 20
+        SET (ESCARGOT_CXXFLAGS ${ESCARGOT_CXXFLAGS} -Wno-invalid-specialization)
+    endif()
     SET (ESCARGOT_CXXFLAGS_DEBUG -O0 -Wall -Wextra -Werror)
     SET (ESCARGOT_CXXFLAGS_RELEASE -O2 -fno-stack-protector -fno-omit-frame-pointer)
     IF (ESCARGOT_SMALL_CONFIG)

--- a/src/builtins/BuiltinAtomics.cpp
+++ b/src/builtins/BuiltinAtomics.cpp
@@ -77,6 +77,21 @@ static size_t validateAtomicAccess(ExecutionState& state, TypedArrayObject* type
     return (static_cast<size_t>(accessIndex) * elementSize) + offset;
 }
 
+// Revalidate atomic access after potential user code execution (valueOf, etc.)
+// This prevents OOB access if the buffer was detached or resized during coercion
+static void revalidateAtomicAccess(ExecutionState& state, ArrayBuffer* buffer, size_t indexedPosition, size_t elementSize)
+{
+    // Check if buffer is detached
+    if (buffer->isDetachedBuffer()) {
+        ErrorObject::throwBuiltinError(state, ErrorCode::TypeError, "ArrayBuffer is detached");
+    }
+
+    // Re-check bounds against current buffer length
+    if (UNLIKELY(indexedPosition + elementSize > buffer->byteLength())) {
+        ErrorObject::throwBuiltinError(state, ErrorCode::RangeError, ErrorObject::Messages::GlobalObject_RangeError);
+    }
+}
+
 template <typename T>
 static T atomicOperation(volatile uint8_t* rawStart, int64_t v, AtomicBinaryOps op)
 {
@@ -179,6 +194,10 @@ static Value atomicReadModifyWrite(ExecutionState& state, Value typedArray, Valu
         v = Value(Value::DoubleToIntConvertibleTestNeeds, value.toInteger(state));
     }
 
+    // Revalidate access after potential user code execution (valueOf, etc.)
+    size_t elemSize = TypedArrayHelper::elementSize(type);
+    revalidateAtomicAccess(state, buffer, indexedPosition, elemSize);
+
     return getModifySetValueInBuffer(state, buffer, indexedPosition, type, v, op);
 }
 
@@ -218,8 +237,10 @@ static Value builtinAtomicsCompareExchange(ExecutionState& state, Value thisValu
         replacement = Value(Value::DoubleToIntConvertibleTestNeeds, argv[3].toInteger(state));
     }
 
+    // Revalidate access after potential user code execution (valueOf in toInteger/toBigInt)
     size_t elemSize = TypedArrayHelper::elementSize(type);
-    ASSERT(indexedPosition + elemSize <= buffer->byteLength());
+    revalidateAtomicAccess(state, buffer, indexedPosition, elemSize);
+
     uint8_t* expectedBytes = ALLOCA(8, uint8_t);
     TypedArrayHelper::numberToRawBytes(state, type, expected, expectedBytes);
     uint8_t* rawStart = const_cast<uint8_t*>(buffer->data()) + indexedPosition;
@@ -289,6 +310,10 @@ static Value builtinAtomicsLoad(ExecutionState& state, Value thisValue, size_t a
     size_t indexedPosition = validateAtomicAccess(state, TA, argv[1]);
     TypedArrayType type = TA->typedArrayType();
 
+    // Revalidate access after potential user code execution (valueOf in toIndex)
+    size_t elemSize = TypedArrayHelper::elementSize(type);
+    revalidateAtomicAccess(state, buffer, indexedPosition, elemSize);
+
     return buffer->getValueFromBuffer(state, indexedPosition, type);
 }
 
@@ -311,6 +336,10 @@ static Value builtinAtomicsStore(ExecutionState& state, Value thisValue, size_t 
     } else {
         v = Value(Value::DoubleToIntConvertibleTestNeeds, value.toInteger(state));
     }
+
+    // Revalidate access after potential user code execution (valueOf in toInteger)
+    size_t elemSize = TypedArrayHelper::elementSize(type);
+    revalidateAtomicAccess(state, buffer, indexedPosition, elemSize);
 
     buffer->setValueInBuffer(state, indexedPosition, type, v);
     return v;

--- a/src/runtime/ArrayBufferObject.cpp
+++ b/src/runtime/ArrayBufferObject.cpp
@@ -183,9 +183,16 @@ void* ArrayBufferObject::operator new(size_t size)
 Value ArrayBufferObject::getValueFromBuffer(ExecutionState& state, size_t byteindex, TypedArrayType type, bool isLittleEndian)
 {
     // If isLittleEndian is not present, set isLittleEndian to either true or false.
-    ASSERT(byteLength());
+    // Always check for detached buffer (not just in debug builds)
+    if (UNLIKELY(isDetachedBuffer())) {
+        ErrorObject::throwBuiltinError(state, ErrorCode::TypeError, "ArrayBuffer is detached");
+    }
+
     size_t elemSize = TypedArrayHelper::elementSize(type);
-    ASSERT(byteindex + elemSize <= byteLength());
+    // Always check bounds (not just in debug builds)
+    if (UNLIKELY(byteindex + elemSize > byteLength())) {
+        ErrorObject::throwBuiltinError(state, ErrorCode::RangeError, "Invalid byte index in getValueFromBuffer");
+    }
     uint8_t* rawStart = data() + byteindex;
     if (LIKELY(isLittleEndian)) {
         return TypedArrayHelper::rawBytesToNumber(state, type, rawStart);
@@ -201,9 +208,16 @@ Value ArrayBufferObject::getValueFromBuffer(ExecutionState& state, size_t bytein
 void ArrayBufferObject::setValueInBuffer(ExecutionState& state, size_t byteindex, TypedArrayType type, const Value& val, bool isLittleEndian)
 {
     // If isLittleEndian is not present, set isLittleEndian to either true or false.
-    ASSERT(byteLength());
+    // Always check for detached buffer (not just in debug builds)
+    if (UNLIKELY(isDetachedBuffer())) {
+        ErrorObject::throwBuiltinError(state, ErrorCode::TypeError, "ArrayBuffer is detached");
+    }
+
     size_t elemSize = TypedArrayHelper::elementSize(type);
-    ASSERT(byteindex + elemSize <= byteLength());
+    // Always check bounds (not just in debug builds)
+    if (UNLIKELY(byteindex + elemSize > byteLength())) {
+        ErrorObject::throwBuiltinError(state, ErrorCode::RangeError, "Invalid byte index in setValueInBuffer");
+    }
     uint8_t* rawStart = data() + byteindex;
     uint8_t* rawBytes = ALLOCA(8, uint8_t);
     TypedArrayHelper::numberToRawBytes(state, type, val, rawBytes);

--- a/src/runtime/String.cpp
+++ b/src/runtime/String.cpp
@@ -209,7 +209,7 @@ bool isIndexString(String* str)
 
 static const char32_t offsetsFromUTF8[6] = { 0x00000000UL, 0x00003080UL, 0x000E2080UL, 0x03C82080UL, static_cast<char32_t>(0xFA082080UL), static_cast<char32_t>(0x82082080UL) };
 
-char32_t readUTF8Sequence(const char*& sequence, bool& valid, int& charlen)
+char32_t readUTF8Sequence(const char*& sequence, bool& valid, int& charlen, size_t remainingLength)
 {
     unsigned length;
     const char sch = *sequence;
@@ -217,17 +217,33 @@ char32_t readUTF8Sequence(const char*& sequence, bool& valid, int& charlen)
     if ((sch & 0x80) == 0)
         length = 1;
     else {
+        // Check bounds before reading ahead to prevent heap buffer overflow
+        if (remainingLength < 2) {
+            valid = false;
+            sequence++;
+            return -1;
+        }
         unsigned char ch2 = static_cast<unsigned char>(*(sequence + 1));
         if ((sch & 0xE0) == 0xC0
             && (ch2 & 0xC0) == 0x80)
             length = 2;
         else {
+            if (remainingLength < 3) {
+                valid = false;
+                sequence++;
+                return -1;
+            }
             unsigned char ch3 = static_cast<unsigned char>(*(sequence + 2));
             if ((sch & 0xF0) == 0xE0
                 && (ch2 & 0xC0) == 0x80
                 && (ch3 & 0xC0) == 0x80)
                 length = 3;
             else {
+                if (remainingLength < 4) {
+                    valid = false;
+                    sequence++;
+                    return -1;
+                }
                 unsigned char ch4 = static_cast<unsigned char>(*(sequence + 3));
                 if ((sch & 0xF8) == 0xF0
                     && (ch2 & 0xC0) == 0x80
@@ -268,7 +284,7 @@ UTF16StringDataNonGCStd utf8StringToUTF16StringNonGC(const char* buf, const size
     int charlen;
     bool valid;
     while (source < buf + len) {
-        char32_t ch = readUTF8Sequence(source, valid, charlen);
+        char32_t ch = readUTF8Sequence(source, valid, charlen, buf + len - source);
         if (!valid) { // Invalid sequence
             str += 0xFFFD;
         } else if ((uint32_t)(ch) <= 0xffff) { // BMP

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -78,7 +78,7 @@ bool isAllASCII(const char* buf, const size_t len);
 bool isAllASCII(const char16_t* buf, const size_t len);
 bool isAllLatin1(const char16_t* buf, const size_t len);
 bool isIndexString(String* str);
-char32_t readUTF8Sequence(const char*& sequence, bool& valid, int& charlen);
+char32_t readUTF8Sequence(const char*& sequence, bool& valid, int& charlen, size_t remainingLength = SIZE_MAX);
 UTF16StringData utf8StringToUTF16String(const char* buf, const size_t len);
 UTF8StringData utf16StringToUTF8String(const char16_t* buf, const size_t len);
 ASCIIStringData utf16StringToASCIIString(const char16_t* buf, const size_t len);


### PR DESCRIPTION
Add revalidation of atomic access after user code execution (valueOf, etc.) to prevent OOB access if the buffer was detached or resized during coercion.

- Add revalidateAtomicAccess helper function
- Check detached buffer and bounds in BuiltinAtomics.cpp
- Add detached buffer and bounds checks in ArrayBufferObject::getValueFromBuffer
- Add detached buffer and bounds checks in ArrayBufferObject::setValueInBuffer