### PR TITLE
Add optional verbose logging to the Devtools Debugger

### DIFF
--- a/src/debugger/DebuggerDevtools.cpp
+++ b/src/debugger/DebuggerDevtools.cpp
@@ -68,7 +68,9 @@ bool DebuggerDevtools::sendMessage(const std::string& msg, const size_t length)
 
     const bool result = send(0, msg.c_str(), length == static_cast<size_t>(-1) ? msg.length() : length);
     if (result) {
-        ESCARGOT_LOG_INFO("Sent message: %s\n", msg.c_str());
+        if (m_verboseLogging) {
+            ESCARGOT_LOG_INFO("Escargot -> Devtools: %s\n", msg.c_str());
+        }
     } else {
         ESCARGOT_LOG_ERROR("Error sending message!");
     }
@@ -101,7 +103,9 @@ void DebuggerDevtools::init(const char* options, Context* context)
 
 bool DebuggerDevtools::skipSourceCode(String* srcName) const
 {
-    ESCARGOT_LOG_INFO("Implement this: DebuggerDevtools::skipSourceCode\n");
+    if (m_verboseLogging) {
+        ESCARGOT_LOG_INFO("Implement this: DebuggerDevtools::skipSourceCode\n");
+    }
     return false;
 }
 
@@ -549,17 +553,19 @@ std::string objectToStringTypeName(const Value object)
 
 bool DebuggerDevtools::sendProperties(rapidjson::Document& jsonMessage, ExecutionState* state)
 {
-    if (jsonMessage["params"]["ownProperties"].GetBool()) {
-        ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'ownProperties' is not supported!\n");
-    }
-    if (jsonMessage["params"]["accessorPropertiesOnly"].GetBool()) {
-        ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'accessorPropertiesOnly' is not supported!\n");
-    }
-    if (!jsonMessage["params"]["nonIndexedPropertiesOnly"].GetBool()) {
-        ESCARGOT_LOG_ERROR("Warning: getProperties: sending indexed properties is not supported!\n");
-    }
-    if (jsonMessage["params"]["generatePreview"].GetBool()) {
-        ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'generatePreview' is not supported!\n");
+    if (m_verboseLogging) {
+        if (jsonMessage["params"]["ownProperties"].GetBool()) {
+            ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'ownProperties' is not supported!\n");
+        }
+        if (jsonMessage["params"]["accessorPropertiesOnly"].GetBool()) {
+            ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'accessorPropertiesOnly' is not supported!\n");
+        }
+        if (!jsonMessage["params"]["nonIndexedPropertiesOnly"].GetBool()) {
+            ESCARGOT_LOG_ERROR("Warning: getProperties: sending indexed properties is not supported!\n");
+        }
+        if (jsonMessage["params"]["generatePreview"].GetBool()) {
+            ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'generatePreview' is not supported!\n");
+        }
     }
 
     rapidjson::Document reply;
@@ -742,7 +748,7 @@ bool DebuggerDevtools::setBreakpointsActive(rapidjson::Document& jsonMessage)
 bool DebuggerDevtools::setBreakpointByUrl(rapidjson::Document& jsonMessage)
 {
     const std::string breakpointCondition = jsonMessage["params"]["condition"].GetString();
-    if (!breakpointCondition.empty()) {
+    if (!breakpointCondition.empty() && m_verboseLogging) {
         ESCARGOT_LOG_ERROR("Warning: Breakpoint conditions are not supported!");
     }
 
@@ -820,7 +826,7 @@ bool DebuggerDevtools::removeBreakpoint(rapidjson::Document& jsonMessage)
 
 bool DebuggerDevtools::sendPossibleBreakpoints(rapidjson::Document& jsonMessage)
 {
-    if (jsonMessage["params"]["restrictToFunction"].GetBool()) {
+    if (jsonMessage["params"]["restrictToFunction"].GetBool() && m_verboseLogging) {
         ESCARGOT_LOG_ERROR("Warning: restrictToFunction is not supported\n");
     }
 
@@ -832,7 +838,7 @@ bool DebuggerDevtools::sendPossibleBreakpoints(rapidjson::Document& jsonMessage)
         return replyOK(jsonMessage);
     }
 
-    if (scriptId != std::stoi(jsonMessage["params"]["end"]["scriptId"].GetString())) {
+    if (scriptId != std::stoi(jsonMessage["params"]["end"]["scriptId"].GetString()) && m_verboseLogging) {
         ESCARGOT_LOG_ERROR("Error: Script ranges across multiple scripts not supported!\n");
         return replyMethodNotFound(jsonMessage);
     }
@@ -953,6 +959,9 @@ bool DebuggerDevtools::evaluate(rapidjson::Document& jsonMessage, ExecutionState
         result = state->context()->globalObject()->evalLocal(*state, evalExpression, state->thisValue(), byteCodeBlock->m_codeBlock, true);
     } catch (const Value& val) {
         result = val;
+        if (m_verboseLogging) {
+            ESCARGOT_LOG_ERROR("Eval failed: %s\n", result.toStringWithoutException(*state)->toUTF8StringData().data());
+        }
     }
     m_stopState = ESCARGOT_DEBUGGER_IN_WAIT_MODE;
 
@@ -1092,7 +1101,9 @@ bool DebuggerDevtools::processEvents(ExecutionState* state, Optional<ByteCodeBlo
             }
         }
 
-        printf("MESSAGE: %.*s\n", static_cast<int>(length), reinterpret_cast<const char*>(buffer));
+        if (m_verboseLogging) {
+            ESCARGOT_LOG_INFO("Devtools -> Escargot: %.*s\n", static_cast<int>(length), reinterpret_cast<const char*>(buffer));
+        }
 
         rapidjson::Document document;
         document.Parse(reinterpret_cast<const rapidjson::GenericDocument<rapidjson::UTF8<>>::Ch*>(buffer));
@@ -1103,7 +1114,7 @@ bool DebuggerDevtools::processEvents(ExecutionState* state, Optional<ByteCodeBlo
             return false;
         }
         const char* methodName = jsonMessage["method"].GetString();
-        if (UNLIKELY(methodName == nullptr)) {
+        if (UNLIKELY(methodName == nullptr) && m_verboseLogging) {
             ESCARGOT_LOG_ERROR("Debugger method not provided: %s\n", reinterpret_cast<const char*>(buffer));
             return false;
         }

--- a/src/debugger/DebuggerDevtools.h
+++ b/src/debugger/DebuggerDevtools.h
@@ -47,8 +47,9 @@ typedef Vector<PropertyNameValueMap*, GCUtil::gc_malloc_allocator<PropertyNameVa
 
 class DebuggerDevtools : public DebuggerTcp {
 public:
-    DebuggerDevtools(EscargotSocket socket, String* skipSource)
+    DebuggerDevtools(EscargotSocket socket, String* skipSource, const bool verbose = false)
         : DebuggerTcp(socket, skipSource, ESCARGOT_WS_BUFFER_SIZE, ESCARGOT_DEBUGGER_WEBSOCKET_TEXT_FRAME)
+        , m_verboseLogging(verbose)
     {
     }
 
@@ -104,6 +105,7 @@ private:
 
     uint8_t registerScript(String* url, String* source);
 
+    bool m_verboseLogging = false;
     bool m_networkEnabled = false;
     bool m_debuggerEnabled = false;
     bool m_runtimeEnabled = false;

--- a/src/debugger/DebuggerTcp.cpp
+++ b/src/debugger/DebuggerTcp.cpp
@@ -323,6 +323,7 @@ Debugger* DebuggerTcp::createDebugger(const char* options, Context* context)
 {
     uint16_t port = 6501;
     int timeout = -1;
+    bool verbose = false;
 
     String* skipSourceName = nullptr;
     EscargotSocket clientSocket = 0;
@@ -332,6 +333,7 @@ Debugger* DebuggerTcp::createDebugger(const char* options, Context* context)
         const char portOption[] = "--port=";
         const char acceptTimeoutOption[] = "--accept-timeout=";
         const char skipOption[] = "--skip=";
+        const char verboseOption[] = "--verbose";
         for (size_t i = 0; i < v.size(); i++) {
             const std::string& s = v[i];
             if (s.find(portOption) == 0) {
@@ -345,6 +347,8 @@ Debugger* DebuggerTcp::createDebugger(const char* options, Context* context)
                 const char* skipStr = const_cast<const char*>(s.data() + sizeof(skipOption) - 1);
                 size_t skipLen = strlen(skipStr);
                 skipSourceName = String::fromASCII(skipStr, skipLen);
+            } else if (s.find(verboseOption) == 0) {
+                verbose = true;
             }
         }
     }
@@ -450,7 +454,7 @@ Debugger* DebuggerTcp::createDebugger(const char* options, Context* context)
     if (httpRouter.client() == DebuggerClient::Escargot) {
         client = new DebuggerEscargot(clientSocket, skipSourceName);
     } else {
-        client = new DebuggerDevtools(clientSocket, skipSourceName);
+        client = new DebuggerDevtools(clientSocket, skipSourceName, verbose);
     }
 
     client->enable(context);

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -1248,8 +1248,12 @@ int main(int argc, char* argv[])
                     fileName = argv[i] + sizeof("--filename-as=") - 1;
                     continue;
                 }
-                if (strcmp(argv[i], "--start-debug-server") == 0) {
-                    context->initDebugger(nullptr);
+                if (strstr(argv[i], "--start-debug-server") == argv[i]) {
+                    char* options = nullptr;
+                    if (*(argv[i] + sizeof("--start-debug-server") - 1) == '=') {
+                        options = argv[i] + sizeof("--start-debug-server");
+                    }
+                    context->initDebugger(options);
                     continue;
                 }
                 if (strcmp(argv[i], "--debugger-wait-source") == 0) {
@@ -1288,7 +1292,7 @@ int main(int argc, char* argv[])
                     continue;
                 }
             }
-            fprintf(stderr, "Cannot recognize option `%s`", argv[i]);
+            fprintf(stderr, "Cannot recognize option `%s`\n", argv[i]);
             continue;
         }
 


### PR DESCRIPTION
Disabled by default, enable by using: `--start-debug-server=--verbose`