### PR TITLE
Fixup ClassBodyNode

### DIFF
--- a/build/target.cmake
+++ b/build/target.cmake
@@ -94,6 +94,10 @@ ELSEIF (${CMAKE_CXX_COMPILER_ID} MATCHES  "Clang") #include Clang and AppleClang
         # this feature supported after clang version 20
         SET (ESCARGOT_CXXFLAGS ${ESCARGOT_CXXFLAGS} -Wno-invalid-specialization)
     endif()
+    IF (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 20)
+        # this feature supported after clang version 21
+        SET (ESCARGOT_CXXFLAGS ${ESCARGOT_CXXFLAGS} -Wno-character-conversion)
+    endif()
     SET (ESCARGOT_CXXFLAGS_DEBUG -O0 -Wall -Wextra -Werror)
     SET (ESCARGOT_CXXFLAGS_RELEASE -O2 -fno-stack-protector -fno-omit-frame-pointer)
     IF (ESCARGOT_SMALL_CONFIG)

--- a/src/parser/ast/ClassBodyNode.h
+++ b/src/parser/ast/ClassBodyNode.h
@@ -258,7 +258,16 @@ public:
                 if (hasKeyName) {
                     codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), keyIndex, p->key()->asIdentifier()->name().string()), context, this->m_loc.index);
                 } else {
+                    // Save class constructor to temp register before evaluating computed key
+                    // to prevent the key expression from overwriting the constructor register
+                    ByteCodeRegisterIndex savedConstructorIndex = context->getRegister();
+                    codeBlock->pushCode(Move(ByteCodeLOC(m_loc.index), context->m_classInfo.m_constructorIndex, savedConstructorIndex), context, this->m_loc.index);
+
                     p->key()->generateExpressionByteCode(codeBlock, context, keyIndex);
+
+                    // Restore class constructor from temp register
+                    codeBlock->pushCode(Move(ByteCodeLOC(m_loc.index), savedConstructorIndex, context->m_classInfo.m_constructorIndex), context, this->m_loc.index);
+                    context->giveUpRegister(); // for savedConstructorIndex
                 }
 
                 if (p->isStatic()) {


### PR DESCRIPTION
* Save class constructor to temp register before evaluating computed key to prevent the key expression from overwriting the constructor register