### PR TITLE
Make compiled bytecode pruning work with incremental GC

### DIFF
--- a/src/codecache/CodeCache.cpp
+++ b/src/codecache/CodeCache.cpp
@@ -826,6 +826,10 @@ ByteCodeBlock* CodeCache::loadByteCodeBlock(Context* context, InterpretedCodeBlo
 
     ByteCodeBlock* block = m_cacheReader->loadByteCodeBlock(context, codeBlock);
 
+    if (LIKELY(block != nullptr)) {
+        block->accountCompiledByteCodeSize();
+    }
+
     // clear and finish
     m_cacheReader->clearBuffer();
     m_status = Status::FINISH;
@@ -878,9 +882,6 @@ void CodeCache::loadAllByteCodeBlockOfFunctions(Context* context, std::vector<In
                 ESCARGOT_LOG_INFO("[CodeCache] Load CodeCache Done (%s: index %zu size %zu)\n", codeBlock->script()->srcName()->toNonGCUTF8StringData().data(),
                                   codeBlock->functionStart().index, codeBlock->src().length());
 #endif
-                auto& currentCodeSizeTotal = context->vmInstance()->compiledByteCodeSize();
-                ASSERT(currentCodeSizeTotal < std::numeric_limits<size_t>::max());
-                currentCodeSizeTotal += codeBlock->m_byteCodeBlock->memoryAllocatedSize();
             }
         }
     }

--- a/src/heap/CustomAllocator.cpp
+++ b/src/heap/CustomAllocator.cpp
@@ -30,6 +30,8 @@
 #include "runtime/FinalizationRegistryObject.h"
 #include "parser/CodeBlock.h"
 #include "interpreter/ByteCode.h"
+#include "runtime/Context.h"
+#include "runtime/VMInstance.h"
 
 namespace Escargot {
 
@@ -154,6 +156,66 @@ void getNextValidInEncodedSmallValueVector(GC_word* ptr, GC_word* end, GC_word**
 }
 #endif
 
+static ByteCodeBlock* byteCodeBlockToTrace(InterpretedCodeBlock* codeBlock)
+{
+    ByteCodeBlock* block = codeBlock->byteCodeBlock();
+    if (block && codeBlock->parent() && codeBlock->context()->vmInstance()->isPruningCompiledByteCodes()) {
+        // a bytecode pruning cycle is in progress: do not trace the ByteCodeBlock reference
+        // so that blocks reachable only through it are collected at the end of this cycle.
+        // blocks in use are kept alive by the conservative stack scan, and dying blocks
+        // disconnect themselves from their CodeBlock in the disclaim callback.
+        // ByteCodeBlocks of top-level CodeBlocks are preserved (managed by Script)
+        return nullptr;
+    }
+    return block;
+}
+
+int getValidValueInInterpretedCodeBlock(void* ptr, GC_mark_custom_result* arr)
+{
+    InterpretedCodeBlock* current = (InterpretedCodeBlock*)ptr;
+    arr[0].from = (GC_word*)&current->m_context;
+    arr[0].to = (GC_word*)current->m_context;
+    arr[1].from = (GC_word*)&current->m_script;
+    arr[1].to = (GC_word*)current->m_script;
+    arr[2].from = (GC_word*)&current->m_byteCodeBlock;
+    arr[2].to = (GC_word*)byteCodeBlockToTrace(current);
+    arr[3].from = (GC_word*)&current->m_parent;
+    arr[3].to = (GC_word*)current->m_parent;
+    arr[4].from = (GC_word*)&current->m_children;
+    arr[4].to = (GC_word*)current->m_children;
+    arr[5].from = (GC_word*)&current->m_parameterNames;
+    arr[5].to = (GC_word*)current->m_parameterNames.data();
+    arr[6].from = (GC_word*)&current->m_identifierInfos;
+    arr[6].to = (GC_word*)current->m_identifierInfos.data();
+    arr[7].from = (GC_word*)&current->m_blockInfos;
+    arr[7].to = (GC_word*)current->m_blockInfos;
+    return 0;
+}
+
+int getValidValueInInterpretedCodeBlockWithRareData(void* ptr, GC_mark_custom_result* arr)
+{
+    InterpretedCodeBlockWithRareData* current = (InterpretedCodeBlockWithRareData*)ptr;
+    arr[0].from = (GC_word*)&current->m_context;
+    arr[0].to = (GC_word*)current->m_context;
+    arr[1].from = (GC_word*)&current->m_script;
+    arr[1].to = (GC_word*)current->m_script;
+    arr[2].from = (GC_word*)&current->m_byteCodeBlock;
+    arr[2].to = (GC_word*)byteCodeBlockToTrace(current);
+    arr[3].from = (GC_word*)&current->m_parent;
+    arr[3].to = (GC_word*)current->m_parent;
+    arr[4].from = (GC_word*)&current->m_children;
+    arr[4].to = (GC_word*)current->m_children;
+    arr[5].from = (GC_word*)&current->m_parameterNames;
+    arr[5].to = (GC_word*)current->m_parameterNames.data();
+    arr[6].from = (GC_word*)&current->m_identifierInfos;
+    arr[6].to = (GC_word*)current->m_identifierInfos.data();
+    arr[7].from = (GC_word*)&current->m_blockInfos;
+    arr[7].to = (GC_word*)current->m_blockInfos;
+    arr[8].from = (GC_word*)&current->m_rareData;
+    arr[8].to = (GC_word*)current->m_rareData;
+    return 0;
+}
+
 #if !defined(NDEBUG)
 int getValidValueInArrayObject(void* ptr, GC_mark_custom_result* arr)
 {
@@ -187,52 +249,6 @@ int getValidValueInArrayBufferObject(void* ptr, GC_mark_custom_result* arr)
     arr[4].from = (GC_word*)&current->m_observerItems;
     arr[4].to = (GC_word*)current->m_observerItems.data();
 
-    return 0;
-}
-
-int getValidValueInInterpretedCodeBlock(void* ptr, GC_mark_custom_result* arr)
-{
-    InterpretedCodeBlock* current = (InterpretedCodeBlock*)ptr;
-    arr[0].from = (GC_word*)&current->m_context;
-    arr[0].to = (GC_word*)current->m_context;
-    arr[1].from = (GC_word*)&current->m_script;
-    arr[1].to = (GC_word*)current->m_script;
-    arr[2].from = (GC_word*)&current->m_byteCodeBlock;
-    arr[2].to = (GC_word*)current->m_byteCodeBlock;
-    arr[3].from = (GC_word*)&current->m_parent;
-    arr[3].to = (GC_word*)current->m_parent;
-    arr[4].from = (GC_word*)&current->m_children;
-    arr[4].to = (GC_word*)current->m_children;
-    arr[5].from = (GC_word*)&current->m_parameterNames;
-    arr[5].to = (GC_word*)current->m_parameterNames.data();
-    arr[6].from = (GC_word*)&current->m_identifierInfos;
-    arr[6].to = (GC_word*)current->m_identifierInfos.data();
-    arr[7].from = (GC_word*)&current->m_blockInfos;
-    arr[7].to = (GC_word*)current->m_blockInfos;
-    return 0;
-}
-
-int getValidValueInInterpretedCodeBlockWithRareData(void* ptr, GC_mark_custom_result* arr)
-{
-    InterpretedCodeBlockWithRareData* current = (InterpretedCodeBlockWithRareData*)ptr;
-    arr[0].from = (GC_word*)&current->m_context;
-    arr[0].to = (GC_word*)current->m_context;
-    arr[1].from = (GC_word*)&current->m_script;
-    arr[1].to = (GC_word*)current->m_script;
-    arr[2].from = (GC_word*)&current->m_byteCodeBlock;
-    arr[2].to = (GC_word*)current->m_byteCodeBlock;
-    arr[3].from = (GC_word*)&current->m_parent;
-    arr[3].to = (GC_word*)current->m_parent;
-    arr[4].from = (GC_word*)&current->m_children;
-    arr[4].to = (GC_word*)current->m_children;
-    arr[5].from = (GC_word*)&current->m_parameterNames;
-    arr[5].to = (GC_word*)current->m_parameterNames.data();
-    arr[6].from = (GC_word*)&current->m_identifierInfos;
-    arr[6].to = (GC_word*)current->m_identifierInfos.data();
-    arr[7].from = (GC_word*)&current->m_blockInfos;
-    arr[7].to = (GC_word*)current->m_blockInfos;
-    arr[8].from = (GC_word*)&current->m_rareData;
-    arr[8].to = (GC_word*)current->m_rareData;
     return 0;
 }
 
@@ -317,6 +333,16 @@ void initializeCustomAllocators()
                                                                          TRUE);
 #endif
 
+    s_gcKinds[HeapObjectKind::InterpretedCodeBlockKind] = GC_new_kind(GC_new_free_list(),
+                                                                      GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 8>), 0),
+                                                                      FALSE,
+                                                                      TRUE);
+
+    s_gcKinds[HeapObjectKind::InterpretedCodeBlockWithRareDataKind] = GC_new_kind(GC_new_free_list(),
+                                                                                  GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlockWithRareData, 9>), 0),
+                                                                                  FALSE,
+                                                                                  TRUE);
+
 #ifdef NDEBUG
     GC_word objBitmap[GC_BITMAP_SIZE(ArrayObject)] = { 0 };
     GC_set_bit(objBitmap, GC_WORD_OFFSET(ArrayObject, m_structure));
@@ -339,16 +365,6 @@ void initializeCustomAllocators()
                                                                               GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInArrayBufferObject, 5>), 0),
                                                                               FALSE,
                                                                               TRUE);
-
-    s_gcKinds[HeapObjectKind::InterpretedCodeBlockKind] = GC_new_kind(GC_new_free_list(),
-                                                                      GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlock, 8>), 0),
-                                                                      FALSE,
-                                                                      TRUE);
-
-    s_gcKinds[HeapObjectKind::InterpretedCodeBlockWithRareDataKind] = GC_new_kind(GC_new_free_list(),
-                                                                                  GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInInterpretedCodeBlockWithRareData, 9>), 0),
-                                                                                  FALSE,
-                                                                                  TRUE);
 
     s_gcKinds[HeapObjectKind::WeakRefObjectKind] = GC_new_kind(GC_new_free_list(),
                                                                GC_MAKE_PROC(GC_new_proc(markAndPushCustom<getValidValueInWeakRefObject, 3>), 0),
@@ -498,17 +514,6 @@ ArrayObject* CustomAllocator<ArrayObject>::allocate(size_type GC_n, const void*)
     return (ArrayObject*)GC_GENERIC_MALLOC(sizeof(ArrayObject), kind);
 }
 
-#if !defined(NDEBUG)
-template <>
-ArrayBufferObject* CustomAllocator<ArrayBufferObject>::allocate(size_type GC_n, const void*)
-{
-    // Un-comment this to use default allocator
-    // return (ArrayBufferObject*)GC_MALLOC(sizeof(ArrayBufferObject));
-    ASSERT(GC_n == 1);
-    int kind = s_gcKinds[HeapObjectKind::ArrayBufferObjectKind];
-    return (ArrayBufferObject*)GC_GENERIC_MALLOC(sizeof(ArrayBufferObject), kind);
-}
-
 template <>
 InterpretedCodeBlock* CustomAllocator<InterpretedCodeBlock>::allocate(size_type GC_n, const void*)
 {
@@ -527,6 +532,17 @@ InterpretedCodeBlockWithRareData* CustomAllocator<InterpretedCodeBlockWithRareDa
     ASSERT(GC_n == 1);
     int kind = s_gcKinds[HeapObjectKind::InterpretedCodeBlockWithRareDataKind];
     return (InterpretedCodeBlockWithRareData*)GC_GENERIC_MALLOC(sizeof(InterpretedCodeBlockWithRareData), kind);
+}
+
+#if !defined(NDEBUG)
+template <>
+ArrayBufferObject* CustomAllocator<ArrayBufferObject>::allocate(size_type GC_n, const void*)
+{
+    // Un-comment this to use default allocator
+    // return (ArrayBufferObject*)GC_MALLOC(sizeof(ArrayBufferObject));
+    ASSERT(GC_n == 1);
+    int kind = s_gcKinds[HeapObjectKind::ArrayBufferObjectKind];
+    return (ArrayBufferObject*)GC_GENERIC_MALLOC(sizeof(ArrayBufferObject), kind);
 }
 
 template <>

--- a/src/heap/CustomAllocator.h
+++ b/src/heap/CustomAllocator.h
@@ -60,10 +60,10 @@ enum HeapObjectKind : unsigned {
     EncodedSmallValueVectorKind,
 #endif
     ArrayObjectKind,
-#if !defined(NDEBUG)
-    ArrayBufferObjectKind,
     InterpretedCodeBlockKind,
     InterpretedCodeBlockWithRareDataKind,
+#if !defined(NDEBUG)
+    ArrayBufferObjectKind,
     WeakRefObjectKind,
     FinalizationRegistryObjectItemKind,
     WeakMapObjectDataItemKind,

--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -127,6 +127,12 @@ void ByteCodeBlock::clearByteCodeBlock(void* obj, void* cd)
     self->m_jumpFlowRecordData.clear();
 
     if (!self->m_isOwnerMayFreed) {
+        // disconnect the (untraced during pruning) reference from the owner CodeBlock.
+        // accessing m_codeBlock here is safe since this kind is registered with
+        // mark-unconditionally, which keeps referents of dying blocks alive
+        if (self->m_codeBlock->byteCodeBlock() == self) {
+            self->m_codeBlock->setByteCodeBlock(nullptr);
+        }
         auto& v = self->m_codeBlock->context()->vmInstance()->compiledByteCodeBlocks();
         v.erase(std::find(v.begin(), v.end(), self));
     }

--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -103,6 +103,7 @@ ByteCodeBlock::ByteCodeBlock()
     , m_shouldClearStack(false)
     , m_isOwnerMayFreed(false)
     , m_needsExtendedExecutionState(false)
+    , m_isAccounted(false)
     , m_requiredOperandRegisterNumber(2)
     , m_requiredTotalRegisterNumber(0)
     , m_inlineCacheDataSize(0)
@@ -114,27 +115,30 @@ ByteCodeBlock::ByteCodeBlock()
 void ByteCodeBlock::clearByteCodeBlock(void* obj, void* cd)
 {
     ByteCodeBlock* self = (ByteCodeBlock*)obj;
+    // accessing m_codeBlock here is safe since this kind is registered with
+    // mark-unconditionally, which keeps referents of dying blocks alive
+    // (in debugger builds the finalizer mechanism gives the same guarantee)
+    VMInstance* vm = self->m_codeBlock->context()->vmInstance();
 #ifdef ESCARGOT_DEBUGGER
-    if (!self->m_isOwnerMayFreed) {
+    if (!vm->isFinalized()) {
         Debugger* debugger = self->codeBlock()->context()->debugger();
         if (debugger != nullptr && self->codeBlock()->markDebugging()) {
             debugger->byteCodeReleaseNotification(self);
         }
     }
 #endif
+    size_t accountedByteCodeSize = self->m_isAccounted ? self->m_code.size() : 0;
     self->m_code.clear();
     self->m_numeralLiteralData.clear();
     self->m_jumpFlowRecordData.clear();
 
-    if (!self->m_isOwnerMayFreed) {
-        // disconnect the (untraced during pruning) reference from the owner CodeBlock.
-        // accessing m_codeBlock here is safe since this kind is registered with
-        // mark-unconditionally, which keeps referents of dying blocks alive
+    if (!vm->isFinalized()) {
+        // disconnect the (untraced during pruning) reference from the owner CodeBlock
         if (self->m_codeBlock->byteCodeBlock() == self) {
             self->m_codeBlock->setByteCodeBlock(nullptr);
         }
-        auto& v = self->m_codeBlock->context()->vmInstance()->compiledByteCodeBlocks();
-        v.erase(std::find(v.begin(), v.end(), self));
+        ASSERT(vm->compiledByteCodeSize() >= accountedByteCodeSize);
+        vm->compiledByteCodeSize() -= accountedByteCodeSize;
     }
 }
 
@@ -158,17 +162,34 @@ ByteCodeBlock::ByteCodeBlock(InterpretedCodeBlock* codeBlock)
     , m_shouldClearStack(false)
     , m_isOwnerMayFreed(false)
     , m_needsExtendedExecutionState(false)
+    , m_isAccounted(false)
     , m_requiredOperandRegisterNumber(2)
     , m_requiredTotalRegisterNumber(0)
     , m_inlineCacheDataSize(0)
     , m_codeBlock(codeBlock)
 {
-    auto& v = m_codeBlock->context()->vmInstance()->compiledByteCodeBlocks();
-    v.push_back(this);
-
 #ifdef ESCARGOT_DEBUGGER
     GC_REGISTER_FINALIZER_NO_ORDER(this, clearByteCodeBlock, nullptr, nullptr, nullptr);
 #endif
+}
+
+void ByteCodeBlock::accountCompiledByteCodeSize()
+{
+    ASSERT(!m_isAccounted);
+    m_isAccounted = true;
+    auto& currentCodeSizeTotal = m_codeBlock->context()->vmInstance()->compiledByteCodeSize();
+    ASSERT(currentCodeSizeTotal < std::numeric_limits<size_t>::max() - m_code.size());
+    currentCodeSizeTotal += m_code.size();
+    // Pruning of compiled bytecode only happens as part of a GC cycle, and GC is
+    // triggered by heap allocation pressure which does not account for this size.
+    // On a workload that compiles a lot of code but allocates few objects, the
+    // total can therefore stay above SCRIPT_FUNCTION_OBJECT_BYTECODE_SIZE_MAX
+    // until the next natural GC. If that ever becomes a real problem, consider
+    // starting a collection here (e.g. GC_start_incremental_collection() when
+    // incremental GC is enabled) once the total exceeds the limit — but it needs
+    // hysteresis (skip if a collection is already running, back off if the last
+    // one failed to get below the limit) to avoid thrashing when the live
+    // bytecode legitimately exceeds the limit.
 }
 
 void* ByteCodeBlock::operator new(size_t size)

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -3414,17 +3414,12 @@ public:
         return m_code.size();
     }
 
-    size_t memoryAllocatedSize()
-    {
-        size_t siz = m_code.capacity();
-        siz += sizeof(ByteCodeBlock);
-        siz += m_numeralLiteralData.size() * sizeof(Value);
-        siz += m_jumpFlowRecordData.size() * sizeof(JumpFlowRecord);
-        siz += m_stringLiteralData.size() * sizeof(intptr_t);
-        siz += m_otherLiteralData.size() * sizeof(intptr_t);
-        siz += m_inlineCacheDataSize;
-        return siz;
-    }
+    // adds m_code.size() to VMInstance::compiledByteCodeSize(); the disclaim
+    // callback subtracts the same amount (m_code never changes after generation,
+    // so nothing needs to be remembered). literal data and inline cache memory
+    // are intentionally not counted — they can grow at runtime, which would
+    // break the add/subtract symmetry
+    void accountCompiledByteCodeSize();
 
     bool needsExtendedExecutionState() const
     {
@@ -3439,6 +3434,7 @@ public:
     bool m_shouldClearStack : 1;
     bool m_isOwnerMayFreed : 1;
     bool m_needsExtendedExecutionState : 1;
+    bool m_isAccounted : 1; // whether accountCompiledByteCodeSize() has run
     // number of bytecode registers used for bytecode operation like adding...moving...
     ByteCodeRegisterIndex m_requiredOperandRegisterNumber : REGISTER_INDEX_IN_BIT;
     // precomputed value of total register number which is "m_requiredTotalRegisterNumber + stack allocated variables size"

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -307,6 +307,8 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* context, Interpreted
     ctx.checkAllDataUsed();
 #endif
 
+    block->accountCompiledByteCodeSize();
+
     return block;
 }
 

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -2516,7 +2516,6 @@ NEVER_INLINE void InterpreterSlowPath::getObjectPrecomputedCaseOperation(Executi
         return;
     }
 
-    auto& currentCodeSizeTotal = state.context()->vmInstance()->compiledByteCodeSize();
     VectorWithInlineStorage<GetObjectPreComputedCase::inlineCacheProtoTraverseMaxCount, ObjectStructure*, std::allocator<ObjectStructure*> > cachedhiddenClassChain;
     size_t cachedIndex = 0;
     bool isPlainDataProperty = 0;
@@ -2563,7 +2562,6 @@ NEVER_INLINE void InterpreterSlowPath::getObjectPrecomputedCaseOperation(Executi
         if (code->m_inlineCacheMode != GetObjectPreComputedCase::Simple) {
             code->m_simpleInlineCache = new GetObjectInlineCacheSimpleCaseData(propertyName);
             block->m_inlineCacheDataSize += sizeof(GetObjectInlineCacheSimpleCaseData);
-            currentCodeSizeTotal += sizeof(GetObjectInlineCacheSimpleCaseData);
             code->m_inlineCacheMode = GetObjectPreComputedCase::Simple;
             block->m_otherLiteralData.push_back(code->m_simpleInlineCache);
             code->changeOpcode(Opcode::GetObjectPreComputedCaseSimpleInlineCacheOpcode);
@@ -2598,11 +2596,9 @@ NEVER_INLINE void InterpreterSlowPath::getObjectPrecomputedCaseOperation(Executi
             auto inlineCache = code->m_complexInlineCache = new GetObjectInlineCacheComplexCaseData(propertyName);
             block->m_otherLiteralData.push_back(code->m_complexInlineCache);
             code->m_inlineCacheMode = GetObjectPreComputedCase::Complex;
-            currentCodeSizeTotal += sizeof(GetObjectInlineCacheComplexCaseData) - sizeof(GetObjectInlineCacheSimpleCaseData);
             for (size_t i = 0; i < GetObjectInlineCacheSimpleCaseData::inlineBufferSize && old->m_cachedStructures[i]; i++) {
                 inlineCache->m_cache.pushBack(GetObjectInlineCacheData());
                 block->m_inlineCacheDataSize += sizeof(GetObjectInlineCacheData);
-                currentCodeSizeTotal += sizeof(GetObjectInlineCacheData);
 
                 auto& item = inlineCache->m_cache.back();
                 item.m_cachedhiddenClassChain = (ObjectStructure**)GC_MALLOC(sizeof(ObjectStructure*));
@@ -2618,7 +2614,6 @@ NEVER_INLINE void InterpreterSlowPath::getObjectPrecomputedCaseOperation(Executi
             block->m_otherLiteralData.push_back(code->m_complexInlineCache);
             code->m_inlineCacheMode = GetObjectPreComputedCase::Complex;
             block->m_inlineCacheDataSize += sizeof(GetObjectInlineCacheComplexCaseData);
-            currentCodeSizeTotal += sizeof(GetObjectInlineCacheComplexCaseData);
         }
 
         auto inlineCache = code->m_complexInlineCache;
@@ -2629,7 +2624,6 @@ NEVER_INLINE void InterpreterSlowPath::getObjectPrecomputedCaseOperation(Executi
         } else {
             inlineCache->m_cache.insert(0, GetObjectInlineCacheData());
             block->m_inlineCacheDataSize += sizeof(GetObjectInlineCacheData);
-            currentCodeSizeTotal += sizeof(GetObjectInlineCacheData);
         }
 
         auto& newItem = inlineCache->m_cache[0];
@@ -2638,7 +2632,6 @@ NEVER_INLINE void InterpreterSlowPath::getObjectPrecomputedCaseOperation(Executi
 
         newItem.m_cachedhiddenClassChainLength = cachedhiddenClassChain.size();
         block->m_inlineCacheDataSize += sizeof(size_t) * cachedhiddenClassChain.size();
-        currentCodeSizeTotal += sizeof(size_t) * cachedhiddenClassChain.size();
         newItem.m_cachedhiddenClassChain = (ObjectStructure**)GC_MALLOC(sizeof(ObjectStructure*) * cachedhiddenClassChain.size());
         memcpy(newItem.m_cachedhiddenClassChain, cachedhiddenClassChain.data(), sizeof(ObjectStructure*) * cachedhiddenClassChain.size());
         newItem.m_cachedIndex = cachedIndex;
@@ -2797,13 +2790,11 @@ NEVER_INLINE void InterpreterSlowPath::setObjectPreComputedCaseOperationCacheMis
         return;
     }
 
-    auto& currentCodeSizeTotal = state.context()->vmInstance()->compiledByteCodeSize();
 
     if (code->m_inlineCache == nullptr) {
         // create a new cache data
         code->m_inlineCache = new SetObjectInlineCache();
         block->m_inlineCacheDataSize += sizeof(SetObjectInlineCache);
-        currentCodeSizeTotal += sizeof(SetObjectInlineCache);
         block->m_otherLiteralData.push_back(code->m_inlineCache);
     }
 
@@ -2914,13 +2905,11 @@ NEVER_INLINE void InterpreterSlowPath::setObjectPreComputedCaseOperationCacheMis
         newItem.m_cachedHiddenClassChainData[newItem.m_cachedhiddenClassChainLength] = originalObject->structure();
 
         block->m_inlineCacheDataSize += sizeof(size_t) * newItem.m_cachedhiddenClassChainLength;
-        currentCodeSizeTotal += sizeof(size_t) * newItem.m_cachedhiddenClassChainLength;
 
         if (code->m_inlineCacheProtoTraverseMaxIndex == 0) {
             // convert simple case to complex case
             for (size_t i = 0; i < inlineCache->m_cache.size(); i++) {
                 block->m_inlineCacheDataSize += sizeof(size_t);
-                currentCodeSizeTotal += sizeof(size_t);
 
                 // all previous cached data should be simple case
                 ASSERT(inlineCache->m_cache[i].m_cachedhiddenClassChainLength == 1);
@@ -2942,7 +2931,6 @@ NEVER_INLINE void InterpreterSlowPath::setObjectPreComputedCaseOperationCacheMis
     } else {
         inlineCache->m_cache.insert(0, SetObjectInlineCacheData());
         block->m_inlineCacheDataSize += sizeof(SetObjectInlineCacheData);
-        currentCodeSizeTotal += sizeof(SetObjectInlineCacheData);
     }
 
     inlineCache->m_cache[0] = newItem;

--- a/src/parser/CodeBlock.cpp
+++ b/src/parser/CodeBlock.cpp
@@ -43,26 +43,9 @@ void* NativeCodeBlock::operator new(size_t size)
 
 void* InterpretedCodeBlock::operator new(size_t size)
 {
-#ifdef NDEBUG
-    static MAY_THREAD_LOCAL bool typeInited = false;
-    static MAY_THREAD_LOCAL GC_descr descr;
-    if (!typeInited) {
-        GC_word obj_bitmap[GC_BITMAP_SIZE(InterpretedCodeBlock)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_context));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_script));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_byteCodeBlock));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_parent));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_children));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_parameterNames));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_identifierInfos));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlock, m_blockInfos));
-        descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(InterpretedCodeBlock));
-        typeInited = true;
-    }
-    return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
-#else
+    // uses a custom GC kind (not a static typed descriptor) so that the mark procedure
+    // can skip tracing m_byteCodeBlock while a bytecode pruning cycle is in progress
     return CustomAllocator<InterpretedCodeBlock>().allocate(1);
-#endif
 }
 
 InterpretedCodeBlockWithRareData::InterpretedCodeBlockWithRareData(Context* ctx, Script* script, StringView src, ASTScopeContext* scopeCtx, bool isEvalCode, bool isEvalCodeInFunction)
@@ -87,27 +70,9 @@ InterpretedCodeBlockWithRareData::InterpretedCodeBlockWithRareData(Context* ctx,
 
 void* InterpretedCodeBlockWithRareData::operator new(size_t size)
 {
-#ifdef NDEBUG
-    static MAY_THREAD_LOCAL bool typeInited = false;
-    static MAY_THREAD_LOCAL GC_descr descr;
-    if (!typeInited) {
-        GC_word obj_bitmap[GC_BITMAP_SIZE(InterpretedCodeBlockWithRareData)] = { 0 };
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlockWithRareData, m_context));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlockWithRareData, m_script));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlockWithRareData, m_byteCodeBlock));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlockWithRareData, m_parent));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlockWithRareData, m_children));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlockWithRareData, m_parameterNames));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlockWithRareData, m_identifierInfos));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlockWithRareData, m_blockInfos));
-        GC_set_bit(obj_bitmap, GC_WORD_OFFSET(InterpretedCodeBlockWithRareData, m_rareData));
-        descr = GC_make_descriptor(obj_bitmap, GC_WORD_LEN(InterpretedCodeBlockWithRareData));
-        typeInited = true;
-    }
-    return GC_MALLOC_EXPLICITLY_TYPED(size, descr);
-#else
+    // uses a custom GC kind (not a static typed descriptor) so that the mark procedure
+    // can skip tracing m_byteCodeBlock while a bytecode pruning cycle is in progress
     return CustomAllocator<InterpretedCodeBlockWithRareData>().allocate(1);
-#endif
 }
 
 void* InterpretedCodeBlock::BlockInfo::operator new(size_t size)

--- a/src/runtime/ScriptFunctionObject.cpp
+++ b/src/runtime/ScriptFunctionObject.cpp
@@ -67,9 +67,6 @@ NEVER_INLINE void ScriptFunctionObject::generateByteCodeBlock(ExecutionState& st
 
     state.context()->scriptParser().generateFunctionByteCode(state, interpretedCodeBlock());
 
-    auto& currentCodeSizeTotal = state.context()->vmInstance()->compiledByteCodeSize();
-    ASSERT(currentCodeSizeTotal < std::numeric_limits<size_t>::max());
-    currentCodeSizeTotal += interpretedCodeBlock()->byteCodeBlock()->memoryAllocatedSize();
     auto cb = m_codeBlock->asInterpretedCodeBlock();
 
     if (hasVTag(g_scriptFunctionObjectTag) && !cb->byteCodeBlock()->needsExtendedExecutionState()) {

--- a/src/runtime/ThreadLocal.cpp
+++ b/src/runtime/ThreadLocal.cpp
@@ -237,6 +237,12 @@ static void genericGCEventListener(GC_EventType evtType)
             listeners->at(i).first(listeners->at(i).second);
         }
     }
+
+    if (evtType == GC_EVENT_RECLAIM_END) {
+        // the full GC cycle (if any) is finished now. clearing the flag here (instead of
+        // consuming it in a listener) lets every listener of this cycle observe it
+        list.clearFullGCFlag();
+    }
 }
 
 #if defined(ENABLE_TLS_ACCESS_BY_PTHREAD_KEY)

--- a/src/runtime/ThreadLocal.h
+++ b/src/runtime/ThreadLocal.h
@@ -80,7 +80,8 @@ public:
     }
 
     // set by the bdwgc start callback (GC_set_start_callback), which bdwgc invokes
-    // only right before a full GC; consumed (and cleared) by the next MARK_START event
+    // only right before a full GC; cleared once by the event dispatcher after
+    // all RECLAIM_END listeners of that cycle have run (see genericGCEventListener)
     void markFullGC()
     {
         m_isFullGC = true;
@@ -91,11 +92,9 @@ public:
         return m_isFullGC;
     }
 
-    bool consumeFullGCFlag()
+    void clearFullGCFlag()
     {
-        bool result = m_isFullGC;
         m_isFullGC = false;
-        return result;
     }
 
     void reset();

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -254,24 +254,16 @@ void vmReclaimEndCallback(void* data)
 
     if (self->m_isPruningCompiledByteCodes) {
         // the pruning cycle started at MARK_START is finished.
-        // dead ByteCodeBlocks already removed themselves from compiledByteCodeBlocks()
-        // through the disclaim callback (this kind is swept eagerly since it is registered
-        // with mark-unconditionally), so recompute the total size over the survivors
+        // dead ByteCodeBlocks already subtracted their registered size from
+        // compiledByteCodeSize() through the disclaim callback (this kind is swept
+        // eagerly since it is registered with mark-unconditionally)
         self->m_isPruningCompiledByteCodes = false;
-        if (!self->m_isFinalized) {
-            size_t currentCodeSizeTotal = 0;
-            auto& v = self->compiledByteCodeBlocks();
-            for (size_t i = 0; i < v.size(); i++) {
-                currentCodeSizeTotal += v[i]->memoryAllocatedSize();
-            }
-            self->compiledByteCodeSize() = currentCodeSizeTotal;
-        }
     }
 
     /*
     if (t == GC_EventType::GC_EVENT_RECLAIM_END) {
         printf("Done GC: HeapSize: [%f MB , %f MB]\n", GC_get_memory_use() / 1024.f / 1024.f, GC_get_heap_size() / 1024.f / 1024.f);
-        printf("bytecode Size %f KiB codeblock count %zu\n", self->compiledByteCodeSize() / 1024.f, self->m_compiledByteCodeBlocks.size());
+        printf("bytecode Size %f KiB\n", self->compiledByteCodeSize() / 1024.f);
         printf("regexp cache size %zu\n", self->regexpCache()->size());
     }
     */
@@ -279,12 +271,10 @@ void vmReclaimEndCallback(void* data)
 
 VMInstance::~VMInstance()
 {
-    {
-        auto& v = compiledByteCodeBlocks();
-        for (size_t i = 0; i < v.size(); i++) {
-            v[i]->m_isOwnerMayFreed = true;
-        }
-    }
+    // set this first; the ByteCodeBlock disclaim callback reads it (through
+    // CodeBlocks which outlive this VMInstance) to skip touching dead owners
+    m_isFinalized = true;
+
 #if defined(ENABLE_COMPRESSIBLE_STRING)
     {
         auto& v = compressibleStrings();
@@ -302,7 +292,6 @@ VMInstance::~VMInstance()
     }
 #endif
 
-    m_isFinalized = true;
     // the mark procedure may still read this flag through CodeBlocks
     // which outlive this VMInstance
     m_isPruningCompiledByteCodes = false;

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -214,23 +214,22 @@ void vmMarkStartCallback(void* data)
         self->m_regexpCache->clear();
     }
 
-    auto& currentCodeSizeTotal = self->compiledByteCodeSize();
-    if ((currentCodeSizeTotal > self->maxCompiledByteCodeSize() && (self->m_config & (size_t)VMInstance::ConfigFlag::PruneCompiledByteCodesWhileGC)) || UNLIKELY(inIdleMode && (self->m_config & (size_t)VMInstance::ConfigFlag::PruneCompiledByteCodesEnterIdle))) {
-        currentCodeSizeTotal = std::numeric_limits<size_t>::max();
-
-        auto& v = self->compiledByteCodeBlocks();
-        for (size_t i = 0; i < v.size(); i++) {
-            // ByteCodeBlock of top CodeBlock should be remove by Script class
-            if (v[i]->m_codeBlock->parent()) {
-                v[i]->m_codeBlock->setByteCodeBlock(nullptr);
-            }
-        }
+    if (!self->m_isPruningCompiledByteCodes
+        && ((self->compiledByteCodeSize() > self->maxCompiledByteCodeSize() && (self->m_config & (size_t)VMInstance::ConfigFlag::PruneCompiledByteCodesWhileGC)) || UNLIKELY(inIdleMode && (self->m_config & (size_t)VMInstance::ConfigFlag::PruneCompiledByteCodesEnterIdle)))) {
         // NOTE
-        // we cannot give up gc recalim or marking
-        // since we disconnect ByteCodeBlock
-        // that's why I extend gc time limit
-        self->m_gcTimeLimit = GC_get_time_limit();
-        GC_set_time_limit(GC_TIME_UNLIMITED);
+        // start a bytecode pruning cycle. while this flag is set, the mark procedure of
+        // InterpretedCodeBlock does not trace m_byteCodeBlock references (see CustomAllocator.cpp),
+        // so ByteCodeBlocks reachable only through their CodeBlock are collected at the end of
+        // this GC cycle. references from the stack or from paused execution states (generators)
+        // keep their blocks alive as usual, and the mutator always observes valid references:
+        // dying blocks disconnect themselves from their CodeBlock in the disclaim callback
+        // before their memory is reclaimed.
+        // this works for both non-incremental GC (blocks are swept within the same collection)
+        // and incremental GC (marking may be abandoned and resumed freely; blocks used while
+        // the cycle is in progress survive via the stack rescan of the final mark pause).
+        // MARK_START can be fired multiple times in one incremental cycle (each stopped-mark
+        // attempt), so the flag guards against re-entering
+        self->m_isPruningCompiledByteCodes = true;
     }
 #endif
 }
@@ -239,7 +238,7 @@ void vmReclaimEndCallback(void* data)
 {
     VMInstance* self = (VMInstance*)data;
 
-    if (GC_is_incremental_mode() && !ThreadLocal::gcEventListenerSet().consumeFullGCFlag()) {
+    if (GC_is_incremental_mode() && !ThreadLocal::gcEventListenerSet().isFullGCFlag()) {
         return;
     }
 
@@ -253,25 +252,20 @@ void vmReclaimEndCallback(void* data)
     }
 #endif
 
-    auto& currentCodeSizeTotal = self->compiledByteCodeSize();
-
-    if (currentCodeSizeTotal == std::numeric_limits<size_t>::max()) {
-        GC_invoke_finalizers();
-
-        // we need to check this because ~VMInstance can be called by GC_invoke_finalizers
+    if (self->m_isPruningCompiledByteCodes) {
+        // the pruning cycle started at MARK_START is finished.
+        // dead ByteCodeBlocks already removed themselves from compiledByteCodeBlocks()
+        // through the disclaim callback (this kind is swept eagerly since it is registered
+        // with mark-unconditionally), so recompute the total size over the survivors
+        self->m_isPruningCompiledByteCodes = false;
         if (!self->m_isFinalized) {
-            currentCodeSizeTotal = 0;
+            size_t currentCodeSizeTotal = 0;
             auto& v = self->compiledByteCodeBlocks();
             for (size_t i = 0; i < v.size(); i++) {
-                if (v[i]->m_codeBlock->parent()) {
-                    v[i]->m_codeBlock->setByteCodeBlock(v[i]);
-                    ASSERT(v[i]->m_codeBlock->byteCodeBlock() == v[i]);
-                }
-
                 currentCodeSizeTotal += v[i]->memoryAllocatedSize();
             }
+            self->compiledByteCodeSize() = currentCodeSizeTotal;
         }
-        GC_set_time_limit(self->m_gcTimeLimit);
     }
 
     /*
@@ -309,6 +303,9 @@ VMInstance::~VMInstance()
 #endif
 
     m_isFinalized = true;
+    // the mark procedure may still read this flag through CodeBlocks
+    // which outlive this VMInstance
+    m_isPruningCompiledByteCodes = false;
 
     // remove gc event callback
     if (ThreadLocal::isInited()) {
@@ -358,7 +355,7 @@ VMInstance::VMInstance(const char* locale, const char* timezone, const char* bas
     , m_lastGCMarkStartTickCount(fastTickCount())
     , m_compiledByteCodeSize(0)
     , m_maxCompiledByteCodeSize(SCRIPT_FUNCTION_OBJECT_BYTECODE_SIZE_MAX)
-    , m_gcTimeLimit(0)
+    , m_isPruningCompiledByteCodes(false)
 #if defined(ENABLE_COMPRESSIBLE_STRING)
     , m_lastCompressibleStringsTestTime(0)
     , m_compressibleStringsUncomressedBufferSize(0)

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -219,11 +219,6 @@ public:
     bool waitEventFromAnotherThread(unsigned timeoutInMillisecond = 0); // zero means infinity
     void executePendingJobFromAnotherThread();
 
-    std::vector<ByteCodeBlock*>& compiledByteCodeBlocks()
-    {
-        return m_compiledByteCodeBlocks;
-    }
-
     size_t& compiledByteCodeSize()
     {
         return m_compiledByteCodeSize;
@@ -232,6 +227,11 @@ public:
     bool isPruningCompiledByteCodes() const
     {
         return m_isPruningCompiledByteCodes;
+    }
+
+    bool isFinalized() const
+    {
+        return m_isFinalized;
     }
 
     size_t maxCompiledByteCodeSize()
@@ -463,7 +463,8 @@ private:
 
     HashSet<ObjectStructure*, ObjectStructureHash, ObjectStructureEqualTo, GCUtil::gc_malloc_allocator<ObjectStructure*>> m_rootedObjectStructure;
 
-    std::vector<ByteCodeBlock*> m_compiledByteCodeBlocks;
+    // sum of the sizes registered by ByteCodeBlock::accountCompiledByteCodeSize();
+    // each block's registered amount is subtracted back in its disclaim callback
     size_t m_compiledByteCodeSize;
     size_t m_maxCompiledByteCodeSize;
     // true while a bytecode pruning GC cycle is in progress.

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -229,6 +229,11 @@ public:
         return m_compiledByteCodeSize;
     }
 
+    bool isPruningCompiledByteCodes() const
+    {
+        return m_isPruningCompiledByteCodes;
+    }
+
     size_t maxCompiledByteCodeSize()
     {
         return m_maxCompiledByteCodeSize;
@@ -461,7 +466,10 @@ private:
     std::vector<ByteCodeBlock*> m_compiledByteCodeBlocks;
     size_t m_compiledByteCodeSize;
     size_t m_maxCompiledByteCodeSize;
-    size_t m_gcTimeLimit;
+    // true while a bytecode pruning GC cycle is in progress.
+    // the InterpretedCodeBlock mark procedure skips tracing m_byteCodeBlock
+    // references of this VM while this flag is set
+    bool m_isPruningCompiledByteCodes;
 
 #if defined(ENABLE_COMPRESSIBLE_STRING)
     uint64_t m_lastCompressibleStringsTestTime;


### PR DESCRIPTION
Bytecode pruning used to disconnect CodeBlock->ByteCodeBlock references at MARK_START and extend the GC time limit to unlimited so that marking completes within a single stop-the-world pause. Under incremental GC this effectively disables incremental collection (the saved time limit gets clobbered on retried mark attempts and stays unlimited forever), and an abandoned mark cycle leaves the pruning state unrestored.

Instead of disconnecting references, the mark procedure of InterpretedCodeBlock now simply skips tracing m_byteCodeBlock while a pruning cycle is in progress, so ByteCodeBlocks reachable only through their CodeBlock die at the end of the cycle. The reference itself stays valid for the mutator the whole time: blocks in use survive via the conservative stack rescan of the final mark pause, and dying blocks disconnect themselves from their CodeBlock in the disclaim callback before their memory is reclaimed (safe since the kind is registered with mark-unconditionally and swept eagerly).

- InterpretedCodeBlock(WithRareData) always uses the custom GC kind (a static typed descriptor cannot skip a field conditionally)
- pruning state is a per-VMInstance flag; the SIZE_MAX sentinel, the relink loop and all GC time limit manipulation are removed
- the thread-local full-GC flag is no longer consumed by the first listener; the event dispatcher clears it once after RECLAIM_END, so every VMInstance on the thread observes the same cycle