### PR TITLE
RTOS CI: report FreeRTOS size/memory drift on PRs, add manual baselin…

### DIFF
--- a/.github/workflows/es-actions.yml
+++ b/.github/workflows/es-actions.yml
@@ -837,6 +837,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.freertos == 'true'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -873,6 +876,12 @@ jobs:
             printf "- RAM (data+bss): %d bytes (%.1f KiB)\n", $2 + $3, ($2 + $3) / 1024.0;
           }'
         } >> "$GITHUB_STEP_SUMMARY"
+        # Stash flash/RAM bytes for the baseline-diff + PR comment step below,
+        # which runs after the boot test (it also needs the GC heap figure
+        # out of qemu-output.log).
+        arm-none-eabi-size "$elf" | awk 'NR==2 {
+          printf "FLASH_BYTES=%d\nRAM_BYTES=%d\n", $1 + $2, $2 + $3;
+        }' >> "$GITHUB_ENV"
     - name: Boot-test under QEMU (mps3-an547 / Cortex-M55)
       run: |
         timeout 60 qemu-system-arm \
@@ -902,6 +911,84 @@ jobs:
         grep -q '\[js\] done' qemu-output.log
 
         echo "FreeRTOS/QEMU sample: boot + exception-suite + SunSpider 1.0.2 all passed ($marker_count marker lines)."
+
+    - name: Compare size/memory against recorded baseline
+      run: |
+        # "hello world" memory proxy: GC heap size right after
+        # Globals::initialize()+Context::create(), before any real script
+        # runs -- see print_gc_stats("init") in samples/rtos/freertos/src/main.cpp.
+        heap_init_kib=$(grep -m1 '^\[gc\] init' qemu-output.log | sed -E 's/.*h=([0-9]+)K.*/\1/')
+
+        base_flash=$(jq -r '.flash_bytes'    samples/rtos/freertos/ci-baseline.json)
+        base_ram=$(jq -r '.ram_bytes'        samples/rtos/freertos/ci-baseline.json)
+        base_heap=$(jq -r '.heap_init_kib'   samples/rtos/freertos/ci-baseline.json)
+        base_date=$(jq -r '.recorded_date'   samples/rtos/freertos/ci-baseline.json)
+
+        row() {
+          # args: label, current, current_unit, baseline, unit
+          local label="$1" cur="$2" unit="$3" base="$4"
+          awk -v label="$label" -v cur="$cur" -v base="$base" -v unit="$unit" 'BEGIN {
+            d = cur - base;
+            pct = (base != 0) ? (d / base * 100.0) : 0.0;
+            sign = (d >= 0) ? "+" : "";
+            printf "| %s | %d %s | %d %s | %s%d %s (%s%.2f%%) |\n", label, cur, unit, base, unit, sign, d, unit, sign, pct;
+          }'
+        }
+
+        {
+          echo "<!-- escargot-rtos-freertos-ci-metrics -->"
+          echo "### FreeRTOS (Cortex-M55) size & memory report"
+          echo ""
+          echo "| Metric | Current | Baseline ($base_date) | Delta |"
+          echo "|---|---|---|---|"
+          row "Flash (text+data)"              "$FLASH_BYTES" "B" "$base_flash"
+          row "RAM (data+bss)"                 "$RAM_BYTES"   "B" "$base_ram"
+          row "GC heap after init (hello world)" "$heap_init_kib" "KiB" "$base_heap"
+          echo ""
+          echo "_Baseline is only updated manually (\`samples/rtos/freertos/ci-baseline.json\`) when a size/memory increase is deliberately accepted -- CI never rewrites it._"
+        } | tee rtos-metrics-comment.md >> "$GITHUB_STEP_SUMMARY"
+    - name: Post/update PR comment with size & memory report
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const body = fs.readFileSync('rtos-metrics-comment.md', 'utf8');
+          const marker = '<!-- escargot-rtos-freertos-ci-metrics -->';
+
+          const sameRepo = context.payload.pull_request.head.repo &&
+            context.payload.pull_request.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+          if (!sameRepo) {
+            core.notice('Skipping PR comment: PR is from a fork, GITHUB_TOKEN is read-only there. See the job summary instead.');
+            return;
+          }
+
+          try {
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }
+          } catch (e) {
+            core.warning(`Could not post/update PR comment: ${e}`);
+          }
 
   build-boot-test-nuttx-qemu:
     needs: changes

--- a/.github/workflows/rtos-update-baseline.yml
+++ b/.github/workflows/rtos-update-baseline.yml
@@ -1,0 +1,93 @@
+name: RTOS - Update FreeRTOS CI Baseline
+
+# Manual-only "button": re-measures the FreeRTOS/QEMU sample's binary size
+# and init-time GC heap, and -- only if they actually differ from what's
+# recorded -- commits the new numbers to samples/rtos/freertos/ci-baseline.json.
+# es-actions.yml's build-boot-test-freertos-qemu job reads that file on every
+# push/PR to report drift, but never writes it; this is the only thing that
+# updates it, and only when a maintainer deliberately runs it (Actions tab ->
+# this workflow -> "Run workflow").
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: rtos-update-baseline
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  update-baseline:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install cross-compile toolchain and QEMU
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build python3 \
+          gcc-arm-none-eabi qemu-system-arm
+    - name: Cross-compile FreeRTOS sample for Cortex-M55
+      run: |
+        cmake -DCMAKE_TOOLCHAIN_FILE=toolchain-cm55.cmake \
+          -Hsamples/rtos/freertos -Bsamples/rtos/freertos/build -GNinja
+        ninja -Csamples/rtos/freertos/build
+    - name: Measure binary size
+      run: |
+        elf=samples/rtos/freertos/build/escargot-rtos.elf
+        arm-none-eabi-size "$elf"
+        arm-none-eabi-size "$elf" | awk 'NR==2 {
+          printf "FLASH_BYTES=%d\nRAM_BYTES=%d\n", $1 + $2, $2 + $3;
+        }' >> "$GITHUB_ENV"
+    - name: Boot-test under QEMU and capture GC heap at init
+      run: |
+        timeout 60 qemu-system-arm \
+          -machine mps3-an547 \
+          -cpu cortex-m55 \
+          -semihosting \
+          -semihosting-config enable=on,target=native \
+          -kernel samples/rtos/freertos/build/escargot-rtos.elf \
+          -nographic \
+          -serial null > qemu-output.log 2>&1 || true
+        cat qemu-output.log
+
+        # Same sanity checks as the regular CI job -- refuse to record a
+        # baseline from a build that doesn't actually boot cleanly.
+        grep -Eq '\[ok\][[:space:]]+1\+2[[:space:]]+=>[[:space:]]+3' qemu-output.log
+        marker_count=$(grep -c '\[ok\]\|\[THROW\]' qemu-output.log)
+        test "$marker_count" -ge $((1 + 15 + 26))
+        ! grep -q '\[PARSE_ERR\]\|\[ABORT\]\|\[TERMINATE\]\|\[KILL\]' qemu-output.log
+        grep -q '\[js\] done' qemu-output.log
+
+        heap_init_kib=$(grep -m1 '^\[gc\] init' qemu-output.log | sed -E 's/.*h=([0-9]+)K.*/\1/')
+        echo "HEAP_INIT_KIB=$heap_init_kib" >> "$GITHUB_ENV"
+    - name: Update ci-baseline.json (if changed) and commit
+      run: |
+        baseline=samples/rtos/freertos/ci-baseline.json
+        old_flash=$(jq -r '.flash_bytes'  "$baseline")
+        old_ram=$(jq -r '.ram_bytes'      "$baseline")
+        old_heap=$(jq -r '.heap_init_kib' "$baseline")
+
+        if [ "$old_flash" = "$FLASH_BYTES" ] && [ "$old_ram" = "$RAM_BYTES" ] && [ "$old_heap" = "$HEAP_INIT_KIB" ]; then
+          echo "No change: measured values match the recorded baseline. Nothing to commit."
+          exit 0
+        fi
+
+        tmp=$(mktemp)
+        jq --arg date "$(date -u +%F)" \
+           --argjson flash "$FLASH_BYTES" \
+           --argjson ram "$RAM_BYTES" \
+           --argjson heap "$HEAP_INIT_KIB" \
+           '.recorded_date = $date | .flash_bytes = $flash | .ram_bytes = $ram | .heap_init_kib = $heap' \
+           "$baseline" > "$tmp"
+        mv "$tmp" "$baseline"
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add "$baseline"
+        git commit -s -m "RTOS CI: update FreeRTOS size/memory baseline" -m "flash: ${old_flash} -> ${FLASH_BYTES} bytes
+        ram: ${old_ram} -> ${RAM_BYTES} bytes
+        heap_init: ${old_heap} -> ${HEAP_INIT_KIB} KiB"
+        git push origin HEAD:"${GITHUB_REF_NAME}"

--- a/samples/rtos/freertos/ci-baseline.json
+++ b/samples/rtos/freertos/ci-baseline.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Manually-maintained reference point for the FreeRTOS/QEMU CI job's size/memory report (see .github/workflows/es-actions.yml, build-boot-test-freertos-qemu). CI never writes this file automatically -- it only reads it to show how far the current build has drifted. When a size increase is intentional and accepted, update the numbers below in their own commit/PR so future drift is measured from the new, accepted point.",
+  "recorded_date": "2026-07-30",
+  "flash_bytes": 1102656,
+  "ram_bytes": 622404,
+  "heap_init_kib": 4096
+}


### PR DESCRIPTION
…e update

build-boot-test-freertos-qemu now compares the current build's flash/RAM size and init-time GC heap (hello-world memory proxy) against a manually-maintained baseline (samples/rtos/freertos/ci-baseline.json), and posts/updates a sticky PR comment with the delta. CI never writes that baseline file itself.

Add a companion workflow_dispatch-only workflow
(rtos-update-baseline.yml) that re-measures the sample and, if the numbers actually changed, commits the new baseline -- the only way that file is meant to be updated, and only when a maintainer deliberately triggers it.