### PR TITLE
Fix stale hasEnumerableProperty flag

### DIFF
--- a/src/runtime/ObjectStructure.cpp
+++ b/src/runtime/ObjectStructure.cpp
@@ -219,7 +219,8 @@ ObjectStructure* ObjectStructureWithoutTransition::replacePropertyDescriptor(siz
         m_properties = nullptr;
     }
     newProperties->at(idx).m_descriptor = newDesc;
-    return new ObjectStructureWithoutTransition(newProperties, m_hasIndexPropertyName, m_hasSymbolPropertyName, m_hasNonAtomicPropertyName, m_hasEnumerableProperty);
+    bool hasEnumerableProperty = m_hasEnumerableProperty ? true : newDesc.isEnumerable();
+    return new ObjectStructureWithoutTransition(newProperties, m_hasIndexPropertyName, m_hasSymbolPropertyName, m_hasNonAtomicPropertyName, hasEnumerableProperty);
 }
 
 void* ObjectStructureWithTransition::operator new(size_t size)
@@ -386,7 +387,8 @@ ObjectStructure* ObjectStructureWithTransition::replacePropertyDescriptor(size_t
 {
     ObjectStructureItemVector* newProperties = new ObjectStructureItemVector(m_properties);
     newProperties->at(idx).m_descriptor = newDesc;
-    return new ObjectStructureWithoutTransition(newProperties, m_hasIndexPropertyName, m_hasSymbolPropertyName, m_hasNonAtomicPropertyName, m_hasEnumerableProperty);
+    bool hasEnumerableProperty = m_hasEnumerableProperty ? true : newDesc.isEnumerable();
+    return new ObjectStructureWithoutTransition(newProperties, m_hasIndexPropertyName, m_hasSymbolPropertyName, m_hasNonAtomicPropertyName, hasEnumerableProperty);
 }
 
 ObjectStructure* ObjectStructureWithTransition::convertToNonTransitionStructure()
@@ -513,6 +515,7 @@ ObjectStructure* ObjectStructureWithMap::replacePropertyDescriptor(size_t idx, c
     }
 
     newProperties->at(idx).m_descriptor = newDesc;
-    return new ObjectStructureWithMap(newProperties, newPropertyNameMap, m_hasIndexPropertyName, m_hasSymbolPropertyName, m_hasEnumerableProperty);
+    bool hasEnumerableProperty = m_hasEnumerableProperty ? true : newDesc.isEnumerable();
+    return new ObjectStructureWithMap(newProperties, newPropertyNameMap, m_hasIndexPropertyName, m_hasSymbolPropertyName, hasEnumerableProperty);
 }
 } // namespace Escargot


### PR DESCRIPTION
When an existing property's attributes are changed via defineProperty (e.g. Object.defineProperties(proto, { lat: { enumerable: true } })), Object::defineOwnPropertyMethod replaces the structure through replacePropertyDescriptor. All three implementations copied the old m_hasEnumerableProperty flag without considering the new descriptor, so a structure whose only enumerable property was created this way still reported hasEnumerableProperty() == false.

EnumerateObjectWithIteration::executeEnumeration relies on that flag to decide whether the prototype chain needs to be searched, so for-in silently skipped every inherited property in this case, while getOwnPropertyDescriptor correctly reported enumerable=true.

This broke google.maps.Circle() in web engines embedding Escargot: the Maps API re-defines the LatLngAltitude class getters (lat/lng/altitude) as enumerable with a partial descriptor, and its LatLng validator copies properties with for-in. The getters were never enumerated and every circle vertex became (NaN, NaN).

Update the flag from the new descriptor, matching the conservative pattern already used by the addProperty paths.