### PR TITLE
Fix private access in class field arrows

### DIFF
--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -89,6 +89,49 @@ Script* ScriptParser::InitializeScriptResult::scriptThrowsExceptionIfParseError(
     return script.value();
 }
 
+static bool isPrivateClassContext(InterpretedCodeBlock* codeBlock)
+{
+    return codeBlock->isClassMethod() || codeBlock->isClassStaticMethod()
+        || codeBlock->isClassConstructor()
+        || codeBlock->isOneExpressionOnlyVirtualArrowFunctionExpression()
+        || codeBlock->isFunctionBodyOnlyVirtualArrowFunctionExpression();
+}
+
+static bool hasShadowedPrivateNameInClassChain(InterpretedCodeBlock* codeBlock)
+{
+    for (InterpretedCodeBlock* current = codeBlock; current; current = current->parent()) {
+        if (!isPrivateClassContext(current)) {
+            continue;
+        }
+
+        auto privateNames = current->classPrivateNames();
+        if (!privateNames) {
+            continue;
+        }
+
+        for (InterpretedCodeBlock* outer = current->parent(); outer; outer = outer->parent()) {
+            if (!isPrivateClassContext(outer)) {
+                continue;
+            }
+
+            auto outerPrivateNames = outer->classPrivateNames();
+            if (!outerPrivateNames) {
+                continue;
+            }
+
+            for (size_t i = 0; i < privateNames->size(); i++) {
+                for (size_t j = 0; j < outerPrivateNames->size(); j++) {
+                    if (privateNames->data()[i] == outerPrivateNames->data()[j]) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
 InterpretedCodeBlock* ScriptParser::generateCodeBlockTreeFromASTWalker(Context* ctx, StringView source, Script* script, ASTScopeContext* scopeCtx, InterpretedCodeBlock* parentCodeBlock, bool isEvalCode, bool isEvalCodeInFunction)
 {
     InterpretedCodeBlock* codeBlock;
@@ -126,16 +169,41 @@ InterpretedCodeBlock* ScriptParser::generateCodeBlockTreeFromASTWalker(Context* 
             }
         }
 
-        if (scopeCtx->m_hasThisExpression && scopeCtx->m_isArrowFunctionExpression) {
+        // private name access (e.g. `#f in o`) needs the upper env's homeObject
+        // at call time just like `this` does, so it forces the same walk.
+        if ((scopeCtx->m_hasThisExpression || scopeCtx->m_hasClassPrivateNameExpression)
+            && scopeCtx->m_isArrowFunctionExpression) {
             // every arrow function should save this value of upper env.
             // except arrow function is localed on class constructor(class constructor needs test of this binding is valid)
             InterpretedCodeBlock* c = codeBlock;
             while (c) {
                 if (c->isKindOfFunction()) {
                     if (c->isArrowFunctionExpression()) {
+                        if (c != codeBlock && c->isOneExpressionOnlyVirtualArrowFunctionExpression()
+                            && scopeCtx->m_hasClassPrivateNameExpression) {
+                            // A field initializer is a virtual arrow. Its
+                            // environment carries the class home object needed
+                            // by a nested arrow after initialization completes.
+                            // The initializer itself runs before its frame dies,
+                            // so it can stay on the stack.
+                            // Runtime lookup cannot stop at an intermediate
+                            // same-named declaration. Preserve the existing
+                            // allocation for that nested-class edge case.
+                            if (!hasShadowedPrivateNameInClassChain(c)) {
+                                c->m_canAllocateEnvironmentOnStack = false;
+                                break;
+                            }
+                            if (!scopeCtx->m_hasThisExpression) {
+                                // Private access alone entered this walk, so
+                                // leave the previous allocation unchanged.
+                                break;
+                            }
+                        }
                         // pass
                     } else if (c->isClassConstructor()) {
-                        c->m_canAllocateEnvironmentOnStack = false;
+                        if (scopeCtx->m_hasThisExpression || !hasShadowedPrivateNameInClassChain(c)) {
+                            c->m_canAllocateEnvironmentOnStack = false;
+                        }
                         break;
                     } else if ((c->isClassMethod() || c->isClassStaticMethod()) && scopeCtx->m_hasClassPrivateNameExpression) {
                         /*
@@ -152,7 +220,12 @@ InterpretedCodeBlock* ScriptParser::generateCodeBlockTreeFromASTWalker(Context* 
                           }
                         }
                         */
-                        c->m_canAllocateEnvironmentOnStack = false;
+                        // an arrow entered here only by a private name gets the
+                        // same shadow suppression as field initializers; a
+                        // `this` arrow keeps the historical allocation.
+                        if (scopeCtx->m_hasThisExpression || !hasShadowedPrivateNameInClassChain(c)) {
+                            c->m_canAllocateEnvironmentOnStack = false;
+                        }
                         break;
                     } else {
                         break;

--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -2905,6 +2905,9 @@ public:
                 *idToken = this->lookahead;
                 ASTNode property = this->parseClassPrivateIdentifierName(builder);
                 if (!this->isParsingSingleFunction) {
+                    // a brand check (`#x in o`) resolves the private member
+                    // context the same way `o.#x` does
+                    this->currentScopeContext->m_hasClassPrivateNameExpression = true;
                     if (!this->currentClassInfo) {
                         this->throwError(Messages::PrivateFieldMustBeDeclared, property->asIdentifier()->name().string());
                     }

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -2067,7 +2067,9 @@ Value Object::getPrivateMember(ExecutionState& state, Object* contextObject, Ato
                 return piece->m_privateMemberValues[r.value()];
             }
         }
-    } else if (shouldReferOuterClass && contextObject->asScriptClassConstructorFunctionObject()->outerClassConstructor()) {
+    } else if (shouldReferOuterClass && contextObject->isScriptClassConstructorFunctionObject() && contextObject->asScriptClassConstructorFunctionObject()->outerClassConstructor()) {
+        // the isScriptClassConstructorFunctionObject() check treats a non-class
+        // outer context as a miss instead of crashing on the cast
         return getPrivateMember(state, contextObject->asScriptClassConstructorFunctionObject()->outerClassConstructor().value(), propertyName);
     }
     ErrorObject::throwBuiltinError(state, ErrorCode::TypeError, ErrorObject::Messages::CanNotReadPrivateMember, propertyName.string());
@@ -2080,7 +2082,7 @@ bool Object::hasPrivateMember(ExecutionState& state, Object* contextObject, Atom
     auto piece = findPieceOnPrivateMemberChain(state, e, contextObject);
     if (piece) {
         return piece->m_privateMemberStructure->findProperty(propertyName);
-    } else if (shouldReferOuterClass && contextObject->asScriptClassConstructorFunctionObject()->outerClassConstructor()) {
+    } else if (shouldReferOuterClass && contextObject->isScriptClassConstructorFunctionObject() && contextObject->asScriptClassConstructorFunctionObject()->outerClassConstructor()) {
         return hasPrivateMember(state, contextObject->asScriptClassConstructorFunctionObject()->outerClassConstructor().value(), propertyName);
     }
     return false;
@@ -2110,7 +2112,7 @@ void Object::setPrivateMember(ExecutionState& state, Object* contextObject, Atom
                 return;
             }
         }
-    } else if (shouldReferOuterClass && contextObject->asScriptClassConstructorFunctionObject()->outerClassConstructor()) {
+    } else if (shouldReferOuterClass && contextObject->isScriptClassConstructorFunctionObject() && contextObject->asScriptClassConstructorFunctionObject()->outerClassConstructor()) {
         return setPrivateMember(state, contextObject->asScriptClassConstructorFunctionObject()->outerClassConstructor().value(), propertyName, value);
     }
     ErrorObject::throwBuiltinError(state, ErrorCode::TypeError, ErrorObject::Messages::CanNotWritePrivateMember, propertyName.string());


### PR DESCRIPTION
Arrows created by class field initializers can outlive the virtual initializer frame. Keep that initializer environment on the heap when a nested arrow accesses a private name; the initializer itself runs inside its frame and stays on the stack.

Mark private brand checks as private-name uses so arrows containing only #x in o take the same path.

Keep the old allocation path when nested classes shadow a private name, in field initializers, methods, and constructors alike. The current runtime lookup cannot safely cross that boundary.

Stop the outer-class lookup when a recorded outer context is not a class constructor, such as an object literal method's home object, so the lookup misses instead of crashing on an unchecked cast.