### PR TITLE
Fix export name leak from nested function bodies

### DIFF
--- a/src/parser/esprima_cpp/esprima.cpp
+++ b/src/parser/esprima_cpp/esprima.cpp
@@ -3407,12 +3407,18 @@ public:
                 if (this->match(LeftBrace)) {
                     this->parseFunctionSourceElements(newBuilder);
                 } else {
+                    // names declared while parsing the arrow body belong to
+                    // the arrow's scope; they must not reach an outer
+                    // collector (e.g. `export const a = () => ...` collecting
+                    // exported names)
                     auto oldNameCallback = this->nameDeclaredCallback;
+                    this->nameDeclaredCallback = nullptr;
 #if defined(ESCARGOT_SMALL_CONFIG)
                     this->isolateCoverGrammar(newBuilder, &Parser::parseAssignmentExpression<ASTBuilder, false>);
 #else
                     this->isolateCoverGrammar(newBuilder, &Parser::parseAssignmentExpression<SyntaxChecker, false>);
 #endif
+                    this->nameDeclaredCallback = oldNameCallback;
 
                     this->currentScopeContext->m_bodyEndLOC.index = this->lastMarker.index;
 #if !(defined NDEBUG) || defined ESCARGOT_DEBUGGER
@@ -5224,6 +5230,11 @@ public:
 
         bool oldAllowLexicalDeclaration = this->context->allowLexicalDeclaration;
         auto oldNameCallback = this->nameDeclaredCallback;
+        // names declared inside a nested function body belong to that
+        // function; without this, `export const a = t => { const o = ...; }`
+        // reported the arrow-local `o` as an exported name ("duplicate
+        // export name" once a second arrow declared `o` too)
+        this->nameDeclaredCallback = nullptr;
         this->context->allowLexicalDeclaration = true;
 
         bool oldInCatchClause = this->context->inCatchClause;


### PR DESCRIPTION
`export const a = t => { const o = ...; }` registered the arrow-local `o` as an exported name: the nameDeclaredCallback installed while parsing an exported declaration stayed active while nested function bodies were parsed. A second exported arrow declaring `o` then failed the whole module with "duplicate export name 'o'" -- make-plural's cardinals module (which openstreetmap.org loads for localization) is exactly this shape.

A single occurrence did not collide, so the module parsed but still leaked the body-local into the namespace (Object.keys gained the extra name); the duplicate-name parse error was just the loud case.

Both nested-body parse paths saved the callback but never cleared it (the expression-body arrow path didn't even restore its dead saved copy); null it during the nested parse and restore afterwards.