### PR TITLE
Implement stopping on exceptions in the Devtools Debugger

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -2035,6 +2035,7 @@ public:
     virtual void init(const char* options, Context* context) override {}
     virtual void parseCompleted(String* source, String* srcName, size_t originLineOffset, String* error = nullptr) override;
     virtual bool stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state) override;
+    virtual bool stopAtException(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state, const Value* exceptionValue) override;
     virtual void byteCodeReleaseNotification(ByteCodeBlock* byteCodeBlock) override;
     virtual void exceptionCaught(String* message, SavedStackTraceDataVector& exceptionTrace) override;
     virtual void consoleOut(String* output) override;
@@ -2141,6 +2142,17 @@ bool DebuggerC::stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, uint32_t offset, 
     }
     }
     return false;
+}
+
+bool DebuggerC::stopAtException(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state, const Value* exceptionValue)
+{
+    UNUSED_PARAMETER(exceptionValue);
+
+    if (!(m_pauseOnCaughtExceptions || m_pauseOnUnCaughtExceptions)) {
+        return false;
+    }
+
+    return DebuggerC::stopAtBreakpoint(byteCodeBlock, offset, state);
 }
 
 void DebuggerC::byteCodeReleaseNotification(ByteCodeBlock* byteCodeBlock)

--- a/src/debugger/Debugger.h
+++ b/src/debugger/Debugger.h
@@ -193,6 +193,7 @@ public:
     virtual void init(const char* options, Context* context) = 0;
     virtual void parseCompleted(String* source, String* srcName, size_t originLineOffset, String* error = nullptr) = 0;
     virtual bool stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state) = 0;
+    virtual bool stopAtException(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state, const Value* exceptionValue) = 0;
     virtual void byteCodeReleaseNotification(ByteCodeBlock* byteCodeBlock) = 0;
     virtual void exceptionCaught(String* message, SavedStackTraceDataVector& exceptionTrace) = 0;
     virtual void consoleOut(String* output) = 0;
@@ -223,10 +224,22 @@ public:
         m_restartDebugging = b;
     }
 
+    bool getPauseOnCaughtExceptions() const
+    {
+        return m_pauseOnCaughtExceptions;
+    }
+
+    bool getPauseOnUnCaughtExceptions() const
+    {
+        return m_pauseOnUnCaughtExceptions;
+    }
+
 protected:
     Debugger()
         : m_delay(ESCARGOT_DEBUGGER_MESSAGE_PROCESS_DELAY)
         , m_stopState(nullptr)
+        , m_pauseOnCaughtExceptions(false)
+        , m_pauseOnUnCaughtExceptions(false)
         , m_context(nullptr)
         , m_activeSavedStackTraceExecutionState(nullptr)
         , m_activeSavedStackTrace(nullptr)
@@ -248,6 +261,8 @@ protected:
     std::vector<BreakpointLocationsInfo*> m_breakpointLocationsVector;
     Vector<uintptr_t, GCUtil::gc_malloc_atomic_allocator<uintptr_t>> m_releasedFunctions;
     bool m_restartDebugging;
+    bool m_pauseOnCaughtExceptions;
+    bool m_pauseOnUnCaughtExceptions;
 
 private:
     Context* m_context;

--- a/src/debugger/DebuggerDevtools.cpp
+++ b/src/debugger/DebuggerDevtools.cpp
@@ -60,6 +60,134 @@ rapidjson::Value stringToRapidjsonValue(const std::string& value, rapidjson::Mem
     return rapidjsonStringValue;
 }
 
+std::string objectToStringTypeName(const Value object)
+{
+    std::string objectType;
+    if (object.isSymbol()) {
+        objectType = "symbol";
+    } else if (object.isFunction()) {
+        objectType = "function";
+    } else if (object.isUndefined()) {
+        objectType = "undefined";
+    } else if (object.isString()) {
+        objectType = "string";
+    } else if (object.isNumber()) {
+        objectType = "number";
+    } else if (object.isBoolean()) {
+        objectType = "boolean";
+    } else if (object.isBigInt()) {
+        objectType = "bigint";
+    } else if (object.isObject()) {
+        objectType = "object";
+    } else {
+        ASSERT_NOT_REACHED();
+    }
+    return objectType;
+}
+
+static void addObjectProperties(ExecutionState* state, PropertyNameValueMap* values, Object* object)
+{
+    Object::OwnPropertyKeyVector keys = object->ownPropertyKeys(*state);
+    for (const auto key : keys) {
+        ObjectPropertyName propertyName(*state, key);
+        AtomicString name(*state, key.toStringWithoutException(*state));
+
+        try {
+            ObjectGetResult result = object->getOwnProperty(*state, propertyName);
+            Value value = result.value(*state, value);
+
+            if (values->find(name) == values->end()) {
+                values->insert(std::make_pair(name, value));
+            }
+        } catch (const Value& val) {
+            if (values->find(name) == values->end()) {
+                values->insert(std::make_pair(name, Value()));
+            }
+        }
+    }
+}
+
+static void addRecordProperties(ExecutionState* state, PropertyNameValueMap* values, const IdentifierRecordVector& identifiers, EnvironmentRecord* record)
+{
+    for (const auto identifier : identifiers) {
+        try {
+            const EnvironmentRecord::GetBindingValueResult result = record->getBindingValue(*state, identifier.m_name);
+            ASSERT(result.m_hasBindingValue);
+            if (values->find(identifier.m_name) == values->end()) {
+                values->insert(std::make_pair(identifier.m_name, result.m_value));
+            }
+        } catch (const Value& val) {
+            if (values->find(identifier.m_name) == values->end()) {
+                values->insert(std::make_pair(identifier.m_name, Value()));
+            }
+        }
+    }
+}
+
+static void addRecordProperties(ExecutionState* state, PropertyNameValueMap* values, const ModuleEnvironmentRecord::ModuleBindingRecordVector& bindings, ModuleEnvironmentRecord* record)
+{
+    for (const auto binding : bindings) {
+        try {
+            EnvironmentRecord::GetBindingValueResult result = record->getBindingValue(*state, binding.m_localName);
+            ASSERT(result.m_hasBindingValue);
+            if (values->find(binding.m_localName) == values->end()) {
+                values->insert(std::make_pair(binding.m_localName, result.m_value));
+            }
+        } catch (const Value& val) {
+            if (values->find(binding.m_localName) == values->end()) {
+                values->insert(std::make_pair(binding.m_localName, Value()));
+            }
+        }
+    }
+}
+
+static bool isErrorObject(const Value& val)
+{
+    return val.isPointerValue() && val.asPointerValue()->isErrorObject();
+}
+
+rapidjson::Value DebuggerDevtools::jsValueToJsonValueObj(ExecutionState* state, const Value value, rapidjson::MemoryPoolAllocator<>& allocator, const std::string& name = "")
+{
+    auto result = rapidjson::Value(rapidjson::kObjectType);
+
+    std::string propertyValueString;
+    if (value.isSymbol()) {
+        propertyValueString = string_format("Symbol (%s)", name.c_str());
+    } else if (value.isObject()) {
+        propertyValueString = "Object";
+    } else {
+        propertyValueString = value.toStringWithoutException(*state)->toUTF8StringData().data();
+    }
+
+    result.AddMember("type", stringToRapidjsonValue(objectToStringTypeName(value), allocator), allocator);
+    if (value.isObject()) {
+        result.AddMember("className", stringToRapidjsonValue(value.asObject()->constructorName(*state)->toUTF8StringData().data(), allocator), allocator);
+    }
+    result.AddMember("value", stringToRapidjsonValue(propertyValueString, allocator), allocator);
+
+    std::string description;
+    if (isErrorObject(value)) {
+        const auto errorObject = value.asPointerValue()->asErrorObject();
+
+        const ObjectPropertyName propertyName(*state, Value(String::fromASCII("message")));
+        const Value message = errorObject->getOwnProperty(*state, propertyName).value(*state, value);
+
+        const std::string className = errorObject->constructorName(*state)->toUTF8StringData().data();
+        description = string_format("%s: %s", className.c_str(), message.toStringWithoutException(*state)->toUTF8StringData().data());
+    } else {
+        description = propertyValueString;
+    }
+    result.AddMember("description", stringToRapidjsonValue(description, allocator), allocator); // string representation of the object
+
+    if (value.isObject()) {
+        auto* values = new (GC) PropertyNameValueMap();
+        addObjectProperties(state, values, value.asObject());
+        result.AddMember("objectId", stringToRapidjsonValue(string_format("%d", registerValuesMap(values)), allocator), allocator);
+    }
+
+    return result;
+}
+
 bool DebuggerDevtools::sendMessage(const std::string& msg, const size_t length)
 {
     if (UNLIKELY(!m_networkEnabled || !m_debuggerEnabled || !m_runtimeEnabled)) {
@@ -206,64 +334,12 @@ void DebuggerDevtools::parseCompleted(String* source, String* srcName, const siz
     sendJSONDocument(reply);
 }
 
-static void addObjectProperties(ExecutionState* state, PropertyNameValueMap* values, Object* object)
+void DebuggerDevtools::sendPausedEvent(ByteCodeBlock* byteCodeBlock, const uint32_t offset, ExecutionState* state, StopReason stopReason, const Value* exceptionValue)
 {
-    Object::OwnPropertyKeyVector keys = object->ownPropertyKeys(*state);
-    for (const auto key : keys) {
-        ObjectPropertyName propertyName(*state, key);
-        AtomicString name(*state, key.toStringWithoutException(*state));
-
-        try {
-            ObjectGetResult result = object->getOwnProperty(*state, propertyName);
-            Value value = result.value(*state, value);
-
-            if (values->find(name) == values->end()) {
-                values->insert(std::make_pair(name, value));
-            }
-        } catch (const Value& val) {
-            if (values->find(name) == values->end()) {
-                values->insert(std::make_pair(name, Value()));
-            }
-        }
+    if (m_processingPauseEvent) {
+        return;
     }
-}
-
-static void addRecordProperties(ExecutionState* state, PropertyNameValueMap* values, const IdentifierRecordVector& identifiers, EnvironmentRecord* record)
-{
-    for (const auto identifier : identifiers) {
-        try {
-            const EnvironmentRecord::GetBindingValueResult result = record->getBindingValue(*state, identifier.m_name);
-            ASSERT(result.m_hasBindingValue);
-            if (values->find(identifier.m_name) == values->end()) {
-                values->insert(std::make_pair(identifier.m_name, result.m_value));
-            }
-        } catch (const Value& val) {
-            if (values->find(identifier.m_name) == values->end()) {
-                values->insert(std::make_pair(identifier.m_name, Value()));
-            }
-        }
-    }
-}
-
-static void addRecordProperties(ExecutionState* state, PropertyNameValueMap* values, const ModuleEnvironmentRecord::ModuleBindingRecordVector& bindings, ModuleEnvironmentRecord* record)
-{
-    for (const auto binding : bindings) {
-        try {
-            EnvironmentRecord::GetBindingValueResult result = record->getBindingValue(*state, binding.m_localName);
-            ASSERT(result.m_hasBindingValue);
-            if (values->find(binding.m_localName) == values->end()) {
-                values->insert(std::make_pair(binding.m_localName, result.m_value));
-            }
-        } catch (const Value& val) {
-            if (values->find(binding.m_localName) == values->end()) {
-                values->insert(std::make_pair(binding.m_localName, Value()));
-            }
-        }
-    }
-}
-
-void DebuggerDevtools::sendPausedEvent(ByteCodeBlock* byteCodeBlock, const uint32_t offset, ExecutionState* state, const bool breakpoint)
-{
+    m_processingPauseEvent = true;
     const auto* stopByteCode = reinterpret_cast<ByteCode*>(byteCodeBlock->m_code.data() + offset);
     const std::string stopFilename = byteCodeBlock->codeBlock()->script()->srcName()->toUTF8StringData().data();
     const uint64_t stopLine = stopByteCode->m_loc.line - 1; // chrome starts line indexes at 0
@@ -279,11 +355,45 @@ void DebuggerDevtools::sendPausedEvent(ByteCodeBlock* byteCodeBlock, const uint3
     reply.AddMember("params", rapidjson::Value(rapidjson::kObjectType), reply.GetAllocator());
     reply["params"].AddMember("callFrames", rapidjson::Value(rapidjson::kArrayType), reply.GetAllocator());
     reply["params"].AddMember("hitBreakpoints", rapidjson::Value(rapidjson::kArrayType), reply.GetAllocator());
-    reply["params"]["hitBreakpoints"].PushBack(stringToRapidjsonValue(string_format("%s:%lu:%lu", stopFilename.c_str(), stopLine, stopColumn), reply.GetAllocator()), reply.GetAllocator());
-    reply["params"].AddMember("reason", stringToRapidjsonValue(breakpoint ? "Breakpoint" : "Break on start", reply.GetAllocator()), reply.GetAllocator());
 
     StackTraceDataOnStackVector stackTraceDataVector;
     SandBox::createStackTrace(stackTraceDataVector, *state, true);
+
+
+    std::string reason;
+    switch (stopReason) {
+    case BREAK_ON_START:
+        reason = "Break on start";
+        break;
+    case BREAKPOINT:
+        reason = "Breakpoint";
+        break;
+    case EXCEPTION:
+        reason = "exception";
+        break;
+    }
+
+    if (stopReason == BREAK_ON_START || stopReason == BREAKPOINT) {
+        reply["params"]["hitBreakpoints"].PushBack(stringToRapidjsonValue(string_format("%s:%lu:%lu", stopFilename.c_str(), stopLine, stopColumn), reply.GetAllocator()), reply.GetAllocator());
+    }
+    reply["params"].AddMember("reason", stringToRapidjsonValue(reason, reply.GetAllocator()), reply.GetAllocator());
+
+    if (stopReason == EXCEPTION) {
+        ASSERT(exceptionValue != nullptr);
+        bool isError = isErrorObject(*exceptionValue);
+        Value exception;
+        if (isError) {
+            exception = exceptionValue->asPointerValue()->asErrorObject();
+        } else {
+            exception = *exceptionValue;
+        }
+        reply["params"].AddMember("data", jsValueToJsonValueObj(state, exception, reply.GetAllocator()), reply.GetAllocator());
+        reply["params"]["data"].AddMember("uncaught", false, reply.GetAllocator()); // we can't tell is a given error will be caught or not
+        if (isError) {
+            reply["params"]["data"].AddMember("subtype", "error", reply.GetAllocator());
+        }
+    }
+
     ByteCodeLOCDataMap locMap;
     bool first = true;
 
@@ -389,6 +499,7 @@ void DebuggerDevtools::sendPausedEvent(ByteCodeBlock* byteCodeBlock, const uint3
     }
 
     sendJSONDocument(reply);
+    m_processingPauseEvent = false;
 }
 
 bool DebuggerDevtools::stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, const uint32_t offset, ExecutionState* state)
@@ -402,7 +513,7 @@ bool DebuggerDevtools::stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, const uint
         return false;
     }
 
-    sendPausedEvent(byteCodeBlock, offset, state, !m_startBreakpoint);
+    sendPausedEvent(byteCodeBlock, offset, state, (m_startBreakpoint ? BREAK_ON_START : BREAKPOINT));
 
     if (m_startBreakpoint) {
         m_startBreakpoint = false;
@@ -420,6 +531,34 @@ bool DebuggerDevtools::stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, const uint
 
     m_activeObjects.clear();
     m_delay = ESCARGOT_DEBUGGER_MESSAGE_PROCESS_DELAY;
+
+    return false;
+}
+
+bool DebuggerDevtools::stopAtException(ByteCodeBlock* byteCodeBlock, const uint32_t offset, ExecutionState* state, const Value* exceptionValue)
+{
+    if (!(m_pauseOnCaughtExceptions || m_pauseOnUnCaughtExceptions)) {
+        return false;
+    }
+
+    if (m_processingPauseEvent) {
+        return false;
+    }
+
+    if (!enabled()) {
+        return false;
+    }
+
+    ASSERT(m_activeObjects.empty());
+    m_stopState = ESCARGOT_DEBUGGER_IN_WAIT_MODE;
+
+    m_activeObjects.clear();
+    m_delay = ESCARGOT_DEBUGGER_MESSAGE_PROCESS_DELAY;
+
+    sendPausedEvent(byteCodeBlock, offset, state, EXCEPTION, exceptionValue);
+
+    while (processEvents(state, byteCodeBlock))
+        ;
 
     return false;
 }
@@ -553,31 +692,6 @@ uint32_t DebuggerDevtools::registerValuesMap(PropertyNameValueMap* newPropertyMa
     return m_nextObjectId++;
 }
 
-std::string objectToStringTypeName(const Value object)
-{
-    std::string objectType;
-    if (object.isSymbol()) {
-        objectType = "symbol";
-    } else if (object.isFunction()) {
-        objectType = "function";
-    } else if (object.isUndefined()) {
-        objectType = "undefined";
-    } else if (object.isString()) {
-        objectType = "string";
-    } else if (object.isNumber()) {
-        objectType = "number";
-    } else if (object.isBoolean()) {
-        objectType = "boolean";
-    } else if (object.isBigInt()) {
-        objectType = "bigint";
-    } else if (object.isObject()) {
-        objectType = "object";
-    } else {
-        ASSERT_NOT_REACHED();
-    }
-    return objectType;
-}
-
 bool DebuggerDevtools::sendProperties(rapidjson::Document& jsonMessage, ExecutionState* state)
 {
     if (m_verboseLogging) {
@@ -630,27 +744,7 @@ bool DebuggerDevtools::sendProperties(rapidjson::Document& jsonMessage, Executio
         propertyObject.AddMember("enumerable", true, reply.GetAllocator());
         propertyObject.AddMember("symbol", propertyValue.isSymbol(), reply.GetAllocator());
 
-        propertyObject.AddMember("value", rapidjson::Value(rapidjson::kObjectType), reply.GetAllocator());
-
-        rapidjson::Value propertyValueString;
-        if (propertyValue.isSymbol()) {
-            propertyValueString = stringToRapidjsonValue(string_format("Symbol (%s)", propertyName.c_str()), reply.GetAllocator());
-        } else {
-            propertyValueString = stringToRapidjsonValue(propertyValue.toStringWithoutException(*state)->toUTF8StringData().data(), reply.GetAllocator());
-        }
-
-        propertyObject["value"].AddMember("type", stringToRapidjsonValue(objectToStringTypeName(propertyValue), reply.GetAllocator()), reply.GetAllocator());
-        if (propertyValue.isObject()) {
-            propertyObject["value"].AddMember("className", stringToRapidjsonValue(propertyValue.asObject()->constructorName(*state)->toUTF8StringData().data(), reply.GetAllocator()), reply.GetAllocator());
-        }
-        propertyObject["value"].AddMember("value", propertyValueString, reply.GetAllocator());
-        propertyObject["value"].AddMember("description", propertyValueString, reply.GetAllocator()); // string representation of the object
-
-        if (propertyValue.isObject()) {
-            auto* values = new (GC) PropertyNameValueMap();
-            addObjectProperties(state, values, propertyValue.asObject());
-            propertyObject["value"].AddMember("objectId", stringToRapidjsonValue(string_format("%d", registerValuesMap(values)), reply.GetAllocator()), reply.GetAllocator());
-        }
+        propertyObject.AddMember("value", jsValueToJsonValueObj(state, propertyValue, reply.GetAllocator(), propertyName), reply.GetAllocator());
 
         reply["result"]["result"].PushBack(propertyObject, reply.GetAllocator());
     }
@@ -727,8 +821,28 @@ bool DebuggerDevtools::enableProfiler(rapidjson::Document& jsonMessage)
 
 bool DebuggerDevtools::setPauseOnExceptions(rapidjson::Document& jsonMessage)
 {
-    // TODO: handdle other parameters: state: none (unset), uncaught, caught, all
-    this->m_pauseOnExceptions = true;
+    const std::string newState = jsonMessage["params"]["state"].GetString();
+
+    if (newState == "all") {
+        m_pauseOnCaughtExceptions = true;
+        m_pauseOnUnCaughtExceptions = true;
+    } else if (newState == "caught") {
+        m_pauseOnCaughtExceptions = true;
+        m_pauseOnUnCaughtExceptions = false;
+        if (m_verboseLogging) {
+            ESCARGOT_LOG_INFO("NOTE: We don't distinguish between caught and uncaught exceptions, both settings apply to all exceptions!\n");
+        }
+    } else if (newState == "uncaught") {
+        m_pauseOnCaughtExceptions = false;
+        m_pauseOnUnCaughtExceptions = true;
+        if (m_verboseLogging) {
+            ESCARGOT_LOG_INFO("NOTE: We don't distinguish between caught and uncaught exceptions, both settings apply to all exceptions!\n");
+        }
+    } else if (newState == "none") {
+        m_pauseOnCaughtExceptions = false;
+        m_pauseOnUnCaughtExceptions = false;
+    }
+
     return replyOK(jsonMessage);
 }
 

--- a/src/debugger/DebuggerDevtools.cpp
+++ b/src/debugger/DebuggerDevtools.cpp
@@ -198,7 +198,7 @@ bool DebuggerDevtools::sendMessage(const std::string& msg, const size_t length)
     const bool result = send(0, msg.c_str(), length == static_cast<size_t>(-1) ? msg.length() : length);
     if (result) {
         if (m_verboseLogging) {
-            ESCARGOT_LOG_INFO("Escargot -> Devtools: %s\n", msg.c_str());
+            ESCARGOT_LOG_INFO("Escargot -> Devtools: %s", msg.c_str());
         }
     } else {
         ESCARGOT_LOG_ERROR("Error sending message!");
@@ -233,7 +233,7 @@ void DebuggerDevtools::init(const char* options, Context* context)
 bool DebuggerDevtools::skipSourceCode(String* srcName) const
 {
     if (m_verboseLogging) {
-        ESCARGOT_LOG_INFO("Implement this: DebuggerDevtools::skipSourceCode\n");
+        ESCARGOT_LOG_INFO("Implement this: DebuggerDevtools::skipSourceCode");
     }
     return false;
 }
@@ -696,16 +696,16 @@ bool DebuggerDevtools::sendProperties(rapidjson::Document& jsonMessage, Executio
 {
     if (m_verboseLogging) {
         if (jsonMessage["params"]["ownProperties"].GetBool()) {
-            ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'ownProperties' is not supported!\n");
+            ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'ownProperties' is not supported!");
         }
         if (jsonMessage["params"]["accessorPropertiesOnly"].GetBool()) {
-            ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'accessorPropertiesOnly' is not supported!\n");
+            ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'accessorPropertiesOnly' is not supported!");
         }
         if (!jsonMessage["params"]["nonIndexedPropertiesOnly"].GetBool()) {
-            ESCARGOT_LOG_ERROR("Warning: getProperties: sending indexed properties is not supported!\n");
+            ESCARGOT_LOG_ERROR("Warning: getProperties: sending indexed properties is not supported!");
         }
         if (jsonMessage["params"]["generatePreview"].GetBool()) {
-            ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'generatePreview' is not supported!\n");
+            ESCARGOT_LOG_ERROR("Warning: getProperties: parameter 'generatePreview' is not supported!");
         }
     }
 
@@ -830,13 +830,13 @@ bool DebuggerDevtools::setPauseOnExceptions(rapidjson::Document& jsonMessage)
         m_pauseOnCaughtExceptions = true;
         m_pauseOnUnCaughtExceptions = false;
         if (m_verboseLogging) {
-            ESCARGOT_LOG_INFO("NOTE: We don't distinguish between caught and uncaught exceptions, both settings apply to all exceptions!\n");
+            ESCARGOT_LOG_INFO("NOTE: We don't distinguish between caught and uncaught exceptions, both settings apply to all exceptions!");
         }
     } else if (newState == "uncaught") {
         m_pauseOnCaughtExceptions = false;
         m_pauseOnUnCaughtExceptions = true;
         if (m_verboseLogging) {
-            ESCARGOT_LOG_INFO("NOTE: We don't distinguish between caught and uncaught exceptions, both settings apply to all exceptions!\n");
+            ESCARGOT_LOG_INFO("NOTE: We don't distinguish between caught and uncaught exceptions, both settings apply to all exceptions!");
         }
     } else if (newState == "none") {
         m_pauseOnCaughtExceptions = false;
@@ -968,7 +968,7 @@ bool DebuggerDevtools::removeBreakpoint(rapidjson::Document& jsonMessage)
 bool DebuggerDevtools::sendPossibleBreakpoints(rapidjson::Document& jsonMessage)
 {
     if (jsonMessage["params"]["restrictToFunction"].GetBool() && m_verboseLogging) {
-        ESCARGOT_LOG_ERROR("Warning: restrictToFunction is not supported\n");
+        ESCARGOT_LOG_ERROR("Warning: restrictToFunction is not supported");
     }
 
     std::string scriptIdString = jsonMessage["params"]["start"]["scriptId"].GetString();
@@ -980,7 +980,7 @@ bool DebuggerDevtools::sendPossibleBreakpoints(rapidjson::Document& jsonMessage)
     }
 
     if (scriptId != std::stoi(jsonMessage["params"]["end"]["scriptId"].GetString()) && m_verboseLogging) {
-        ESCARGOT_LOG_ERROR("Error: Script ranges across multiple scripts not supported!\n");
+        ESCARGOT_LOG_ERROR("Error: Script ranges across multiple scripts not supported!");
         return replyMethodNotFound(jsonMessage);
     }
 
@@ -1021,7 +1021,7 @@ bool DebuggerDevtools::takeHeapSnapshot(rapidjson::Document& jsonMessage, Execut
     std::string fileName = snapshot.takeHeapSnapshot(state);
 
     if (fileName.empty()) {
-        ESCARGOT_LOG_ERROR("Error: Error happened during heap snapshot creation. Aborting now.\n");
+        ESCARGOT_LOG_ERROR("Error: Error happened during heap snapshot creation. Aborting now.");
         abort();
     }
     // DevTools just sends done and total messages, then adds "finished" before sending the snapshot
@@ -1039,7 +1039,7 @@ bool DebuggerDevtools::takeHeapSnapshot(rapidjson::Document& jsonMessage, Execut
 
     std::ifstream file(fileName, std::ios::in);
     if (!file.is_open()) {
-        ESCARGOT_LOG_ERROR("ERROR: Could not open snapshot file. Aborting now.\n");
+        ESCARGOT_LOG_ERROR("ERROR: Could not open snapshot file. Aborting now.");
         abort();
     }
 
@@ -1101,7 +1101,7 @@ bool DebuggerDevtools::evaluate(rapidjson::Document& jsonMessage, ExecutionState
     } catch (const Value& val) {
         result = val;
         if (m_verboseLogging) {
-            ESCARGOT_LOG_ERROR("Eval failed: %s\n", result.toStringWithoutException(*state)->toUTF8StringData().data());
+            ESCARGOT_LOG_ERROR("Eval failed: %s", result.toStringWithoutException(*state)->toUTF8StringData().data());
         }
     }
     m_stopState = ESCARGOT_DEBUGGER_IN_WAIT_MODE;
@@ -1245,7 +1245,7 @@ bool DebuggerDevtools::processEvents(ExecutionState* state, Optional<ByteCodeBlo
         }
 
         if (m_verboseLogging) {
-            ESCARGOT_LOG_INFO("Devtools -> Escargot: %.*s\n", static_cast<int>(length), reinterpret_cast<const char*>(buffer));
+            ESCARGOT_LOG_INFO("Devtools -> Escargot: %.*s", static_cast<int>(length), reinterpret_cast<const char*>(buffer));
         }
 
         rapidjson::Document document;
@@ -1253,12 +1253,12 @@ bool DebuggerDevtools::processEvents(ExecutionState* state, Optional<ByteCodeBlo
 
         rapidjson::Document jsonMessage;
         if (UNLIKELY(jsonMessage.Parse(reinterpret_cast<const char*>(buffer)).HasParseError())) {
-            ESCARGOT_LOG_ERROR("Json Message parsing error: %s at offset: %d\n", GetParseError_En(jsonMessage.GetParseError()), static_cast<int32_t>(jsonMessage.GetErrorOffset()));
+            ESCARGOT_LOG_ERROR("Json Message parsing error: %s at offset: %d", GetParseError_En(jsonMessage.GetParseError()), static_cast<int32_t>(jsonMessage.GetErrorOffset()));
             return false;
         }
         const char* methodName = jsonMessage["method"].GetString();
         if (UNLIKELY(methodName == nullptr) && m_verboseLogging) {
-            ESCARGOT_LOG_ERROR("Debugger method not provided: %s\n", reinterpret_cast<const char*>(buffer));
+            ESCARGOT_LOG_ERROR("Debugger method not provided: %s", reinterpret_cast<const char*>(buffer));
             return false;
         }
 #define FOR_EACH_MESSAGE_TYPE(messageTypesList, ...)                                                                                                                       \
@@ -1273,7 +1273,7 @@ bool DebuggerDevtools::processEvents(ExecutionState* state, Optional<ByteCodeBlo
         FOR_EACH_MESSAGE_TYPE(messageTypesArg2, jsonMessage, state);
         FOR_EACH_MESSAGE_TYPE(messageTypesArg3, jsonMessage, state, byteCodeBlock);
 
-        ESCARGOT_LOG_ERROR("Debugger function not supported: %s\n", reinterpret_cast<const char*>(buffer));
+        ESCARGOT_LOG_ERROR("Debugger function not supported: %s", reinterpret_cast<const char*>(buffer));
         this->replyMethodNotFound(jsonMessage); // maybe reply with not supported instead? if there is such a reply in the spec
     }
 

--- a/src/debugger/DebuggerDevtools.h
+++ b/src/debugger/DebuggerDevtools.h
@@ -42,6 +42,12 @@ struct ScriptInfo {
     String* source;
 };
 
+typedef enum StopReason {
+    BREAK_ON_START,
+    BREAKPOINT,
+    EXCEPTION,
+} StopReason;
+
 typedef HashMap<AtomicString, Value, std::hash<AtomicString>, std::equal_to<AtomicString>, GCUtil::gc_malloc_allocator<std::pair<AtomicString const, Value>>> PropertyNameValueMap;
 typedef Vector<PropertyNameValueMap*, GCUtil::gc_malloc_allocator<PropertyNameValueMap*>> PropertyNameValueMapVector;
 
@@ -60,14 +66,13 @@ public:
 
     void parseCompleted(String* source, String* srcName, size_t originLineOffset, String* error = nullptr) override;
     bool stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state) override;
+    bool stopAtException(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state, const Value* exceptionValue) override;
     void byteCodeReleaseNotification(ByteCodeBlock* byteCodeBlock) override;
     void exceptionCaught(String* message, SavedStackTraceDataVector& exceptionTrace) override;
     void consoleOut(String* output) override;
     String* getClientSource(String** sourceName) override;
     bool getWaitBeforeExitClient() override;
 
-
-    void sendPausedEvent(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state, bool breakpoint = false);
 
 protected:
     bool processEvents(ExecutionState* state, Optional<ByteCodeBlock*> byteCodeBlock, bool isBlockingRequest = true) override;
@@ -94,8 +99,11 @@ private:
     bool sendPossibleBreakpoints(rapidjson::Document& jsonMessage);
     bool takeHeapSnapshot(rapidjson::Document& jsonMessage, ExecutionState* state = nullptr);
     bool replyMethodNotFound(rapidjson::Document& jsonMessage);
+    void sendPausedEvent(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state, StopReason stopReason = BREAKPOINT, const Value* exceptionValue = nullptr);
+
 
     uint32_t registerValuesMap(PropertyNameValueMap* newPropertyMap);
+    rapidjson::Value jsValueToJsonValueObj(ExecutionState* state, Value value, rapidjson::MemoryPoolAllocator<>& allocator, const std::string& name);
 
     static bool compareBreakpointLocations(const BreakpointByteCodeLocation& a, const BreakpointByteCodeLocation& b)
     {
@@ -112,9 +120,9 @@ private:
     bool m_debuggerEnabled = false;
     bool m_runtimeEnabled = false;
     bool m_profilerEnabled = false;
-    bool m_pauseOnExceptions = false;
     bool m_breakpointsActive = false;
     bool m_startBreakpoint = true;
+    bool m_processingPauseEvent = false;
 
     std::unordered_map<uint8_t, ScriptInfo> m_scriptsById;
     std::unordered_map<std::string, uint8_t> m_scriptIdByUrl;

--- a/src/debugger/DebuggerEscargot.cpp
+++ b/src/debugger/DebuggerEscargot.cpp
@@ -431,7 +431,7 @@ bool DebuggerEscargot::doEval(ExecutionState* state, Optional<ByteCodeBlock*> by
     return true;
 
 error:
-    ESCARGOT_LOG_ERROR("Invalid eval message received. Closing connection.\n");
+    ESCARGOT_LOG_ERROR("Invalid eval message received. Closing connection.");
     close(CloseProtocolError);
     return false;
 }
@@ -1003,13 +1003,13 @@ bool DebuggerEscargot::processEvents(ExecutionState* state, Optional<ByteCodeBlo
             std::string fileName = snapshot.takeHeapSnapshot(state);
 
             if (fileName.empty()) {
-                ESCARGOT_LOG_ERROR("Error happened during heap snapshot creation. Aborting now.\n");
+                ESCARGOT_LOG_ERROR("Error happened during heap snapshot creation. Aborting now.");
                 abort();
             } else if (enabled()) {
                 String* data = String::fromUTF8(fileName.c_str(), fileName.length());
 
                 if (data == nullptr) {
-                    ESCARGOT_LOG_ERROR("Error happened during heap snapshot creation. Aborting now.\n");
+                    ESCARGOT_LOG_ERROR("Error happened during heap snapshot creation. Aborting now.");
                     abort();
                 }
 
@@ -1021,7 +1021,7 @@ bool DebuggerEscargot::processEvents(ExecutionState* state, Optional<ByteCodeBlo
         }
         }
 
-        ESCARGOT_LOG_ERROR("Invalid message received. Closing connection.\n");
+        ESCARGOT_LOG_ERROR("Invalid message received. Closing connection.");
         close(CloseProtocolError);
         return false;
     }

--- a/src/debugger/DebuggerEscargot.cpp
+++ b/src/debugger/DebuggerEscargot.cpp
@@ -253,6 +253,15 @@ bool DebuggerEscargot::stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, uint32_t o
     return m_restartDebugging;
 }
 
+bool DebuggerEscargot::stopAtException(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state, const Value* exceptionValue)
+{
+    if (!(m_pauseOnCaughtExceptions || m_pauseOnUnCaughtExceptions)) {
+        return false;
+    }
+
+    return stopAtBreakpoint(byteCodeBlock, offset, state);
+}
+
 void DebuggerEscargot::byteCodeReleaseNotification(ByteCodeBlock* byteCodeBlock)
 {
     // All messages which involves this pointer should be ignored until the confirmation arrives.

--- a/src/debugger/DebuggerEscargot.h
+++ b/src/debugger/DebuggerEscargot.h
@@ -192,6 +192,7 @@ public:
     void init(const char* options, Context* context) override;
     void parseCompleted(String* source, String* srcName, size_t originLineOffset, String* error = nullptr) override;
     bool stopAtBreakpoint(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state) override;
+    bool stopAtException(ByteCodeBlock* byteCodeBlock, uint32_t offset, ExecutionState* state, const Value* exceptionValue) override;
     void byteCodeReleaseNotification(ByteCodeBlock* byteCodeBlock) override;
     void exceptionCaught(String* message, SavedStackTraceDataVector& exceptionTrace) override;
     void consoleOut(String* output) override;

--- a/src/debugger/DebuggerTcp.cpp
+++ b/src/debugger/DebuggerTcp.cpp
@@ -76,10 +76,10 @@ static void tcpLogError(int errorNumber)
                   (LPTSTR)&errorMessage,
                   0,
                   NULL);
-    ESCARGOT_LOG_ERROR("TCP Error: %s\n", errorMessage);
+    ESCARGOT_LOG_ERROR("TCP Error: %s", errorMessage);
     LocalFree(errorMessage);
 #else /* !WIN32 */
-    ESCARGOT_LOG_ERROR("TCP Error: %s\n", strerror(errorNumber));
+    ESCARGOT_LOG_ERROR("TCP Error: %s", strerror(errorNumber));
 #endif /* WIN32 */
 }
 
@@ -172,7 +172,7 @@ bool DebuggerTcp::send(const uint8_t type, const void* buffer, const size_t leng
            || (m_websocketMessageType == ESCARGOT_DEBUGGER_WEBSOCKET_BINARY_FRAME && length <= ESCARGOT_DEBUGGER_MAX_MESSAGE_LENGTH));
 
     if (length > ESCARGOT_WS_MAX_MESSAGE_LENGTH) {
-        ESCARGOT_LOG_ERROR("Cannot send WebSocket payload: 64-bit payload length is not supported.\n");
+        ESCARGOT_LOG_ERROR("Cannot send WebSocket payload: 64-bit payload length is not supported.");
         close(CloseAbortConnection);
         return false;
     }
@@ -202,7 +202,7 @@ bool DebuggerTcp::send(const uint8_t type, const void* buffer, const size_t leng
     memcpy(message + headerLength, buffer, length);
 
     if (!tcpSend(m_socket, message, headerLength + length)) {
-        ESCARGOT_LOG_ERROR("Failed to send data via WebSocket connection.\n");
+        ESCARGOT_LOG_ERROR("Failed to send data via WebSocket connection.");
         close(CloseAbortConnection);
         return false;
     }
@@ -220,13 +220,13 @@ bool DebuggerTcp::receive(uint8_t* buffer, size_t& length)
                         m_receiveBuffer + m_receiveBufferFill,
                         m_bufferSize - m_receiveBufferFill,
                         &receivedLength)) {
-            ESCARGOT_LOG_ERROR("Failed to receive data from WebSocket connection.\n");
+            ESCARGOT_LOG_ERROR("Failed to receive data from WebSocket connection.");
             close(CloseAbortConnection);
             return false;
         }
 
         if (receivedLength == 0 && m_receiveBufferFill < m_headerLength) {
-            // ESCARGOT_LOG_INFO("Incomplete WebSocket frame header, waiting for more data.\n");
+            // ESCARGOT_LOG_INFO("Incomplete WebSocket frame header, waiting for more data.");
             return false;
         }
 
@@ -244,14 +244,14 @@ bool DebuggerTcp::receive(uint8_t* buffer, size_t& length)
                 return false;
             }
 
-            ESCARGOT_LOG_ERROR("Unsupported Websocket opcode.\n");
+            ESCARGOT_LOG_ERROR("Unsupported Websocket opcode.");
             close(CloseProtocolUnsupported);
             return false;
         }
 
         if ((m_receiveBuffer[0] & ~ESCARGOT_DEBUGGER_WEBSOCKET_OPCODE_MASK) != ESCARGOT_DEBUGGER_WEBSOCKET_FIN_BIT
             || !(m_receiveBuffer[1] & ESCARGOT_DEBUGGER_WEBSOCKET_MASK_BIT)) {
-            ESCARGOT_LOG_ERROR("Unsupported Websocket message.\n");
+            ESCARGOT_LOG_ERROR("Unsupported Websocket message.");
             close(CloseProtocolUnsupported);
             return false;
         }
@@ -259,7 +259,7 @@ bool DebuggerTcp::receive(uint8_t* buffer, size_t& length)
         uint8_t payloadLengthField = m_receiveBuffer[1] & ESCARGOT_DEBUGGER_WEBSOCKET_LENGTH_MASK;
 
         if (payloadLengthField > ESCARGOT_WS_MESSAGE_16BIT_LENGTH_MARKER) {
-            ESCARGOT_LOG_ERROR("64-bit WebSocket payload length is not supported.\n");
+            ESCARGOT_LOG_ERROR("64-bit WebSocket payload length is not supported.");
             close(CloseProtocolUnsupported);
             return false;
         }
@@ -279,7 +279,7 @@ bool DebuggerTcp::receive(uint8_t* buffer, size_t& length)
         }
 
         if (m_payloadLength == 0) {
-            ESCARGOT_LOG_ERROR("Invalid WebSocket payload length: zero-length messages are not supported.\n");
+            ESCARGOT_LOG_ERROR("Invalid WebSocket payload length: zero-length messages are not supported.");
             close(CloseProtocolUnsupported);
             return false;
         }
@@ -373,7 +373,7 @@ Debugger* DebuggerTcp::createDebugger(const char* options, Context* context)
         return nullptr;
     }
 
-    ESCARGOT_LOG_INFO("Waiting for client connection 0.0.0.0:%hd\n", port);
+    ESCARGOT_LOG_INFO("Waiting for client connection 0.0.0.0:%hd", port);
 
     struct pollfd fd[1];
     fd[0].fd = serverSocket;
@@ -391,7 +391,7 @@ Debugger* DebuggerTcp::createDebugger(const char* options, Context* context)
         }
         timeout -= 10;
         if (timeout < 0) {
-            ESCARGOT_LOG_ERROR("Waiting for client connection error: timeout reached\n");
+            ESCARGOT_LOG_ERROR("Waiting for client connection error: timeout reached");
             tcpCloseSocket(serverSocket);
             return nullptr;
         }
@@ -432,7 +432,7 @@ Debugger* DebuggerTcp::createDebugger(const char* options, Context* context)
         }
 #endif /* WIN32 */
 
-        ESCARGOT_LOG_INFO("Connected from: %s\n", inet_ntoa(addr.sin_addr));
+        ESCARGOT_LOG_INFO("Connected from: %s", inet_ntoa(addr.sin_addr));
 
         if (!httpRouter.handleHttpRequest(clientSocket)) {
             tcpCloseSocket(clientSocket);

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -253,7 +253,11 @@ ALWAYS_INLINE bool InterpreterSlowPath::typedArrayLengthPropertyIsIntrinsic(Exec
 Value Interpreter::interpret(ExecutionState* state, ByteCodeBlock* byteCodeBlock, size_t programCounter, Value* registerFile)
 {
     state->m_programCounter = &programCounter;
+#ifdef ESCARGOT_DEBUGGER
+    try {
+#else /* ESCARGOT_DEBUGGER */
     {
+#endif /* ESCARGOT_DEBUGGER */
 #if defined(ESCARGOT_COMPUTED_GOTO_INTERPRETER)
 #if defined(ESCARGOT_COMPUTED_GOTO_INTERPRETER_INIT_WITH_NULL)
         if (UNLIKELY((((ByteCode*)programCounter)->m_opcodeInAddress) == NULL)) {
@@ -2119,6 +2123,16 @@ Value Interpreter::interpret(ExecutionState* state, ByteCodeBlock* byteCodeBlock
         }
 
         DEFINE_DEFAULT
+
+#ifdef ESCARGOT_DEBUGGER
+    } catch (const Value& err) {
+        if (state->context()->debuggerEnabled() && !state->context()->isStoppingOnExceptionInProgress()) {
+            state->context()->setStoppingOnExceptionInProgress(true);
+            const auto offset = static_cast<uint32_t>(programCounter - reinterpret_cast<size_t>(byteCodeBlock->m_code.data()));
+            state->context()->debugger()->stopAtException(byteCodeBlock, offset, state, &err);
+        }
+        throw;
+#endif /* ESCARGOT_DEBUGGER */
     }
 
     ASSERT_NOT_REACHED();
@@ -3907,6 +3921,9 @@ NEVER_INLINE Value InterpreterSlowPath::tryOperation(ExecutionState*& state, siz
                         state.m_onCatch = in;
                     });
 #endif
+#ifdef ESCARGOT_DEBUGGER
+                    newState->context()->setStoppingOnExceptionInProgress(false);
+#endif /* ESCARGOT_DEBUGGER */
                     Interpreter::interpret(newState, byteCodeBlock, (size_t)codeBuffer + code->m_catchPosition, registerFile);
                     if (newState->inExecutionStopState()) {
                         return Value();

--- a/src/runtime/Context.cpp
+++ b/src/runtime/Context.cpp
@@ -87,6 +87,7 @@ Context::Context(VMInstance* instance)
     , m_securityPolicyCheckCallbackPublic(nullptr)
 #ifdef ESCARGOT_DEBUGGER
     , m_debugger(nullptr)
+    , m_stoppingOnExceptionInProgress(false)
 #endif /* ESCARGOT_DEBUGGER */
 {
     ExecutionState stateForInit(this);
@@ -232,6 +233,16 @@ void Context::pumpDebuggerEvents()
         return Value();
     },
            m_debugger);
+}
+
+bool Context::isStoppingOnExceptionInProgress() const
+{
+    return m_stoppingOnExceptionInProgress;
+}
+
+void Context::setStoppingOnExceptionInProgress(const bool isInProgress)
+{
+    m_stoppingOnExceptionInProgress = isInProgress;
 }
 
 #endif /* ESCARGOT_DEBUGGER */

--- a/src/runtime/Context.h
+++ b/src/runtime/Context.h
@@ -336,6 +336,9 @@ public:
     void setAsAlwaysStopState();
     bool inDebuggingCodeMode() const;
     String* getClientSource(String** sourceName);
+
+    bool isStoppingOnExceptionInProgress() const;
+    void setStoppingOnExceptionInProgress(bool isInProgress);
 #endif /* ESCARGOT_DEBUGGER */
 
 private:
@@ -392,6 +395,7 @@ private:
 #ifdef ESCARGOT_DEBUGGER
     // debugger support
     Debugger* m_debugger;
+    bool m_stoppingOnExceptionInProgress;
 #endif /* ESCARGOT_DEBUGGER */
 };
 

--- a/src/runtime/SandBox.cpp
+++ b/src/runtime/SandBox.cpp
@@ -100,6 +100,8 @@ void SandBox::processCatch(const Value& error, SandBoxResult& result)
 
         debugger->exceptionCaught(message, exceptionTrace);
     }
+
+    m_context->setStoppingOnExceptionInProgress(false);
 #endif /* ESCARGOT_DEBUGGER */
 }
 


### PR DESCRIPTION
Currently I don't make a distinction between caught and uncaught exceptions in the Devtools UI, both options apply to all exceptions. I did not find a way of telling at the time an exception is thrown if it is going to be caught or not; If you have suggestions please let me know.

Remove newlines from error and info macro calls in the debuggers; They are now redundant because of 004b8c2dd2d2bbfd1072ff27b9cd1965b6aaa85b