### PR TITLE
Fix ESCARGOT_TCO_DEBUG check on multi-config generators

### DIFF
--- a/.github/workflows/es-actions.yml
+++ b/.github/workflows/es-actions.yml
@@ -615,7 +615,17 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        arch: [x86, x64]
+        include:
+          - arch: x86
+            generator: Ninja
+          # Exercises the VS solution + msbuild config path documented in
+          # README.md (cmake -G "Visual Studio 17 2022" / msbuild
+          # ESCARGOT.sln) that the Ninja leg above never touches --
+          # multi-config-generator-specific CMake bugs (CMAKE_BUILD_TYPE is
+          # always empty at configure time there; see 392a015d0) only show
+          # up on this leg.
+          - arch: x64
+            generator: "Visual Studio 17 2022"
     steps:
     - name: Set git cllf config
       run: |
@@ -646,27 +656,55 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
         sdk: "10.0.26100.0"
-    - name: Build ${{ matrix.arch }} Release
+    - name: Build ${{ matrix.arch }} Release (Ninja)
+      if: matrix.generator == 'Ninja'
       run: |
         CMake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION:STRING="10.0" -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} -Bout/ -DENABLE_SHELL=ON -DESCARGOT_BUILD_SHARED_LIBS=ON -DESCARGOT_LIBICU_SUPPORT=ON -DESCARGOT_WASM=ON -DESCARGOT_THREADING=ON -DESCARGOT_TCO=ON -DESCARGOT_TEST=ON -DESCARGOT_SHADOWREALM=ON -G Ninja -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=release
         CMake --build out/ --config Release
       shell: cmd
-    - name: Upload build artifact
+    # VS generator is multi-config -- arch is fixed at configure time via
+    # CMAKE_GENERATOR_PLATFORM (there's no single-config "MSBuild"
+    # generator), config (Release) is picked at build time via --config,
+    # same as the Ninja leg. Deliberately no CMAKE_C/CXX_COMPILER override
+    # here: the VS generator manages its own MSVC toolset.
+    - name: Build ${{ matrix.arch }} Release (MSBuild)
+      if: matrix.generator != 'Ninja'
+      run: |
+        CMake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION:STRING="10.0" -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} -DCMAKE_GENERATOR_PLATFORM=${{ matrix.arch }} -Bout/ -DENABLE_SHELL=ON -DESCARGOT_BUILD_SHARED_LIBS=ON -DESCARGOT_LIBICU_SUPPORT=ON -DESCARGOT_WASM=ON -DESCARGOT_THREADING=ON -DESCARGOT_TCO=ON -DESCARGOT_TEST=ON -DESCARGOT_SHADOWREALM=ON -G "${{ matrix.generator }}"
+        CMake --build out/ --config Release
+      shell: cmd
+    # walrus.dll: -DESCARGOT_WASM=ON below unconditionally builds Walrus
+    # (the WASM engine) as WALRUS_OUTPUT="shared_lib" regardless of
+    # ESCARGOT_BUILD_SHARED_LIBS (see build/escargot.cmake) -- escargot.exe
+    # dynamically depends on it at runtime even in an otherwise-static
+    # build. The old single combined build+test job never surfaced this
+    # because build and run happened in the same working directory; once
+    # split across jobs via artifact upload/download, walrus.dll has to be
+    # carried across explicitly too, or escargot.exe fails to start.
+    #
+    # upload-artifact strips the common leading directory of the listed
+    # paths, so both legs land as escargot.exe/escargot.dll/walrus.dll at
+    # the artifact root regardless of which subdirectory the generator
+    # actually wrote them to -- test262/octane-on-windows below need no
+    # generator-specific handling.
+    - name: Upload build artifact (Ninja)
+      if: matrix.generator == 'Ninja'
       uses: actions/upload-artifact@v6
       with:
         name: build-artifact-win-${{ matrix.arch }}
-        # walrus.dll: -DESCARGOT_WASM=ON below unconditionally builds Walrus
-        # (the WASM engine) as WALRUS_OUTPUT="shared_lib" regardless of
-        # ESCARGOT_BUILD_SHARED_LIBS (see build/escargot.cmake) -- escargot.exe
-        # dynamically depends on it at runtime even in an otherwise-static
-        # build. The old single combined build+test job never surfaced this
-        # because build and run happened in the same working directory; once
-        # split across jobs via artifact upload/download, walrus.dll has to be
-        # carried across explicitly too, or escargot.exe fails to start.
         path: |
           out/escargot.exe
           out/escargot.dll
           out/walrus.dll
+    - name: Upload build artifact (MSBuild)
+      if: matrix.generator != 'Ninja'
+      uses: actions/upload-artifact@v6
+      with:
+        name: build-artifact-win-${{ matrix.arch }}
+        path: |
+          out/Release/escargot.exe
+          out/Release/escargot.dll
+          out/Release/walrus.dll
     - if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,15 @@ ENDIF()
 # ESCARGOT_TCO_DEBUG's debug-only check below). ESCARGOT_OUTPUT itself no
 # longer exists -- it was split into the independent ESCARGOT_ENABLE_SHELL /
 # ESCARGOT_BUILD_SHARED_LIBS / ESCARGOT_BUILD_CCTEST booleans below.
+#
+# On multi-config generators (Visual Studio, Xcode, Ninja Multi-Config),
+# CMAKE_BUILD_TYPE is always empty at configure time -- the config is only
+# selected at build time via --config -- so ESCARGOT_MODE always resolves to
+# "release" there regardless of what will actually be built. Record whether
+# we're on such a generator so configure-time-only consumers of ESCARGOT_MODE
+# (see ESCARGOT_TCO_DEBUG below) can skip checks they can't correctly perform.
+GET_PROPERTY (ESCARGOT_IS_MULTI_CONFIG_GENERATOR GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
 IF (NOT DEFINED ESCARGOT_MODE)
     STRING(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
     IF (CMAKE_BUILD_TYPE_LOWER MATCHES "debug")

--- a/build/config.cmake
+++ b/build/config.cmake
@@ -220,10 +220,17 @@ option(ESCARGOT_TCO_DEBUG "Enable extra tail-call-optimization debug checks (deb
 IF (ESCARGOT_TCO)
     SET (ESCARGOT_DEFINITIONS ${ESCARGOT_DEFINITIONS} -DENABLE_TCO)
     IF (ESCARGOT_TCO_DEBUG)
-        IF (NOT ESCARGOT_MODE STREQUAL "debug")
+        # ESCARGOT_MODE is resolved once at configure time from
+        # CMAKE_BUILD_TYPE, which is meaningless on multi-config generators
+        # (see CMakeLists.txt) -- this early-error check can only run where
+        # the config is actually known at configure time. Correctness for
+        # multi-config is instead handled below by gating the define itself
+        # on the Debug config via a generator expression, so a non-Debug
+        # build from the same tree just silently doesn't get it.
+        IF (NOT ESCARGOT_IS_MULTI_CONFIG_GENERATOR AND NOT ESCARGOT_MODE STREQUAL "debug")
             MESSAGE (FATAL_ERROR "ESCARGOT_TCO_DEBUG is enabled only for debug mode")
         ENDIF()
-        SET (ESCARGOT_DEFINITIONS ${ESCARGOT_DEFINITIONS} -DENABLE_TCO_DEBUG)
+        SET (ESCARGOT_DEFINITIONS ${ESCARGOT_DEFINITIONS} $<$<CONFIG:Debug>:ENABLE_TCO_DEBUG>)
     ENDIF()
 ENDIF()
 

--- a/build/escargot.cmake
+++ b/build/escargot.cmake
@@ -261,13 +261,18 @@ IF (ESCARGOT_WASM)
     SET (ESCARGOT_LIBRARIES ${ESCARGOT_LIBRARIES} walrus)
 ENDIF()
 
+IF (NOT PYTHON_EXECUTABLE)
+      FIND_PACKAGE (Python3 COMPONENTS Interpreter REQUIRED)
+      SET (PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+ENDIF()
+
 SET (UNICODE_PROPERTY_TABLES_HEADER ${CMAKE_BINARY_DIR}/escargot_generated/yarr/UnicodePatternTables.h)
 SET (SIMPLE_CASE_FOLDING_HEADER ${CMAKE_BINARY_DIR}/escargot_generated/yarr/SimpleCaseFoldingTable.h)
 
 ADD_CUSTOM_COMMAND(
     OUTPUT ${UNICODE_PROPERTY_TABLES_HEADER}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/escargot_generated/yarr/
-    COMMAND python3 ${PROJECT_SOURCE_DIR}/tools/code_generators/generateYarrUnicodePropertyTables.py ${PROJECT_SOURCE_DIR}/tools/unicode_data ${UNICODE_PROPERTY_TABLES_HEADER}
+    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/code_generators/generateYarrUnicodePropertyTables.py ${PROJECT_SOURCE_DIR}/tools/unicode_data ${UNICODE_PROPERTY_TABLES_HEADER}
     DEPENDS ${PROJECT_SOURCE_DIR}/tools/code_generators/generateYarrUnicodePropertyTables.py
     COMMENT "Generating UnicodePatternTables.h"
 )
@@ -275,8 +280,9 @@ ADD_CUSTOM_COMMAND(
 ADD_CUSTOM_COMMAND(
     OUTPUT ${SIMPLE_CASE_FOLDING_HEADER}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/escargot_generated/yarr/
-    COMMAND python3 ${PROJECT_SOURCE_DIR}/tools/code_generators/generateSimpleCaseFoldingTable.py ${PROJECT_SOURCE_DIR}/tools/unicode_data ${SIMPLE_CASE_FOLDING_HEADER}
+    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/code_generators/generateSimpleCaseFoldingTable.py ${PROJECT_SOURCE_DIR}/tools/unicode_data ${SIMPLE_CASE_FOLDING_HEADER}
     DEPENDS ${PROJECT_SOURCE_DIR}/tools/code_generators/generateSimpleCaseFoldingTable.py
+    ${UNICODE_PROPERTY_TABLES_HEADER}
     COMMENT "Generating SimpleCaseFoldingTable.h"
 )
 


### PR DESCRIPTION
ESCARGOT_MODE is resolved once at configure time from CMAKE_BUILD_TYPE, which is always empty on multi-config generators (Visual Studio, Xcode, Ninja Multi-Config) since the config is only chosen at build time via --config. That made ESCARGOT_MODE always resolve to "release" there, so setting ESCARGOT_TCO_DEBUG=ON on a multi-config generator always hit the "debug mode only" FATAL_ERROR, even for a legitimate Debug build.

Skip that configure-time check on multi-config generators (detected via GENERATOR_IS_MULTI_CONFIG), and instead gate the ENABLE_TCO_DEBUG define itself on the Debug config via a $<CONFIG:Debug> generator expression, so it only actually compiles in for a Debug build; other configs from the same build tree silently don't get it. Single-config behavior is unchanged.