### PR TITLE
ci: prevent stale performance host locks

### DIFF
--- a/.github/workflows/es-actions.yml
+++ b/.github/workflows/es-actions.yml
@@ -653,7 +653,9 @@ jobs:
           ready_file="$(mktemp "$RUNNER_TEMP/performance-host-lock.XXXXXX")"
           rm -f "$ready_file"
           install -d -m 700 "$lock_dir"
-          RUNNER_TRACKING_ID="" flock -s "$lock_file" bash -c 'printf acquired > "$1"; exec sleep infinity' bash "$ready_file" &
+          # Keep the lock FD in this process, then exec sleep so $! remains
+          # the lock holder's PID and the release step can reliably kill it.
+          RUNNER_TRACKING_ID="" bash -c 'exec 9>"$1"; flock -s 9; printf acquired > "$2"; exec sleep infinity' bash "$lock_file" "$ready_file" &
           lock_pid=$!
           for _ in $(seq 1 600); do
             test -s "$ready_file" && break
@@ -2061,7 +2063,9 @@ jobs:
         ready_file="$(mktemp "$RUNNER_TEMP/performance-host-lock.XXXXXX")"
         rm -f "$ready_file"
         install -d -m 700 "$lock_dir"
-        RUNNER_TRACKING_ID="" flock -s "$lock_file" bash -c 'printf acquired > "$1"; exec sleep infinity' bash "$ready_file" &
+        # Keep the lock FD in this process, then exec sleep so $! remains
+        # the lock holder's PID and the release step can reliably kill it.
+        RUNNER_TRACKING_ID="" bash -c 'exec 9>"$1"; flock -s 9; printf acquired > "$2"; exec sleep infinity' bash "$lock_file" "$ready_file" &
         lock_pid=$!
         for _ in $(seq 1 600); do
           test -s "$ready_file" && break

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -29,7 +29,8 @@ jobs:
         set -euo pipefail
         lock_dir="$HOME/.cache/escargot-locks"
         install -d -m 700 "$lock_dir"
-        flock -x "$lock_dir/performance-host.lock" bash -euo pipefail -s <<'LOCKED'
+        # Never wait forever if a runner is lost while holding the lock.
+        flock -x -w 3600 "$lock_dir/performance-host.lock" bash -euo pipefail -s <<'LOCKED'
           report="$GITHUB_WORKSPACE/performance-report"
           build="$GITHUB_WORKSPACE/out/performance-release"
           mkdir -p "$report/logs"

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -18,10 +18,16 @@ jobs:
     if: github.repository == 'Samsung/escargot'
     runs-on: [self-hosted, linux, arm64, test]
     timeout-minutes: 180
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
     - uses: actions/checkout@v5
       with:
         submodules: recursive
+
+    - uses: actions/configure-pages@v5
 
     - name: Build and measure with exclusive host access
       shell: bash
@@ -45,7 +51,7 @@ jobs:
           # Warm-up is intentionally excluded from the reported samples.
           measure octane-warmup "$GITHUB_WORKSPACE/test/octane" run.js
           measure web-tooling-warmup "$GITHUB_WORKSPACE/test/web-tooling-benchmark" dist/cli.js
-          for n in 1 2 3; do
+          for n in 1; do
             measure "octane-$n" "$GITHUB_WORKSPACE/test/octane" run.js
             measure "web-tooling-$n" "$GITHUB_WORKSPACE/test/web-tooling-benchmark" dist/cli.js
           done
@@ -54,7 +60,7 @@ jobs:
           report = pathlib.Path(sys.argv[1])
           def collect(prefix, pattern):
               score, rss, output = [], [], []
-              for n in range(1, 4):
+              for n in range(1, 2):
                   log = (report / "logs" / f"{prefix}-{n}.log").read_text(errors="replace")
                   match = re.search(pattern, log)
                   if not match: raise SystemExit(f"Could not parse {prefix} run {n}")
@@ -68,7 +74,7 @@ jobs:
             "web_tooling": collect("web-tooling", r"Geometric mean:\s*([0-9.]+)\s+runs/s")}
           (report / "measurements.json").write_text(json.dumps(data, indent=2) + "\n")
           rss = data["octane"]["rss_samples_kb"] + data["web_tooling"]["rss_samples_kb"]
-          (report / "summary.txt").write_text(f"Octane score (mean): {data['octane']['score']}\nWeb Tooling score (mean): {data['web_tooling']['score']} runs/s\nAverage RSS: {round(statistics.mean(rss))} KB\nMaximum RSS: {max(rss)} KB\n")
+          (report / "summary.txt").write_text(f"Octane score: {data['octane']['score']}\nWeb Tooling score: {data['web_tooling']['score']} runs/s\nAverage RSS: {round(statistics.mean(rss))} KB\nMaximum RSS: {max(rss)} KB\n")
           PY
         LOCKED
 
@@ -92,6 +98,9 @@ jobs:
           git worktree add --orphan "$site" gh-pages
         fi
         mkdir -p "$site/performance/data" "$site/performance/raw"
+        # This is a static dashboard. Do not let GitHub Pages process files
+        # from any checked-out documentation tree with Jekyll.
+        touch "$site/.nojekyll"
         cp performance-report/measurements.json "$site/performance/raw/$REVISION.json"
         python3 - "$site/performance/data/history.json" performance-report/measurements.json <<'PY'
         import json, os, pathlib, sys
@@ -110,12 +119,37 @@ jobs:
         cat > "$site/performance/index.html" <<'HTML'
         <!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Escargot performance</title>
         <style>body{margin:0;background:#0b1220;color:#e5edf8;font:15px system-ui}main{max-width:1100px;margin:auto;padding:32px}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px}.card{background:#17243a;border:1px solid #304664;border-radius:14px;padding:16px}canvas{width:100%;height:220px}table{width:100%;border-collapse:collapse;margin-top:28px}td,th{padding:9px;border-bottom:1px solid #304664;text-align:right}td:first-child,th:first-child{text-align:left}a{color:#7dd3fc}details{text-align:left;white-space:pre-wrap}code{font-size:11px}</style>
-        <main><h1>Escargot performance</h1><p>master only. Three measured runs per benchmark; warm-up is excluded. RSS is maximum resident set size.</p><div class="grid"><section class="card"><h2>Octane</h2><canvas id="octane"></canvas></section><section class="card"><h2>Web Tooling</h2><canvas id="web"></canvas></section><section class="card"><h2>Average RSS (MiB)</h2><canvas id="avg"></canvas></section><section class="card"><h2>Maximum RSS (MiB)</h2><canvas id="max"></canvas></section></div><table><thead><tr><th>Commit</th><th>Octane</th><th>Web Tooling</th><th>Avg RSS</th><th>Max RSS</th><th>Printed output</th></tr></thead><tbody id="rows"></tbody></table></main>
+        <main><h1>Escargot performance</h1><p>master only. One measured run per benchmark; warm-up is excluded. RSS is maximum resident set size.</p><div class="grid"><section class="card"><h2>Octane</h2><canvas id="octane"></canvas></section><section class="card"><h2>Web Tooling</h2><canvas id="web"></canvas></section><section class="card"><h2>Average RSS (MiB)</h2><canvas id="avg"></canvas></section><section class="card"><h2>Maximum RSS (MiB)</h2><canvas id="max"></canvas></section></div><table><thead><tr><th>Commit</th><th>Octane</th><th>Web Tooling</th><th>Avg RSS</th><th>Max RSS</th><th>Printed output</th></tr></thead><tbody id="rows"></tbody></table></main>
         <script>fetch("data/history.json").then(r=>r.json()).then(d=>{let m=x=>x/1024,v={octane:x=>x.octane.score,web:x=>x.web_tooling.score,avg:x=>m((x.octane.average_rss_kb+x.web_tooling.average_rss_kb)/2),max:x=>m(Math.max(x.octane.maximum_rss_kb,x.web_tooling.maximum_rss_kb))};Object.entries(v).forEach(([id,f])=>{let a=d.map(f),c=document.querySelector("#"+id),x=c.getContext("2d"),w=c.width=c.clientWidth*devicePixelRatio,h=c.height=c.clientHeight*devicePixelRatio,p=30,lo=Math.min(...a),hi=Math.max(...a),r=hi-lo||1;x.strokeStyle="#38bdf8";x.lineWidth=2;x.beginPath();a.forEach((n,i)=>{let X=p+i*(w-2*p)/Math.max(1,a.length-1),Y=h-p-(n-lo)*(h-2*p)/r;i?x.lineTo(X,Y):x.moveTo(X,Y)});x.stroke();x.fillStyle="#e5edf8";x.fillText(hi.toFixed(2),p,16);x.fillText(lo.toFixed(2),p,h-10)});rows.innerHTML=d.slice().reverse().map(x=>"<tr><td><a href='"+x.revision_url+"'>"+x.short_sha+"</a></td><td>"+x.octane.score+"</td><td>"+x.web_tooling.score+"</td><td>"+v.avg(x).toFixed(1)+" MiB</td><td>"+v.max(x).toFixed(1)+" MiB</td><td><details><summary>logs</summary><code>"+[...x.octane.output,...x.web_tooling.output].join("\n\n")+"</code></details></td></tr>").join("")})</script>
         HTML
         cd "$site"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add index.html performance/index.html performance/data/history.json "performance/raw/$REVISION.json"
+        git add .nojekyll index.html performance/index.html performance/data/history.json "performance/raw/$REVISION.json"
         git diff --cached --quiet || git commit -m "performance: $REVISION"
         git push origin gh-pages
+
+        # Deploy the generated static branch contents, without the worktree's
+        # .git directory, through the GitHub Pages artifact flow.
+        mkdir -p "$GITHUB_WORKSPACE/performance-pages"
+        git archive --format=tar gh-pages | tar -xf - -C "$GITHUB_WORKSPACE/performance-pages"
+
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: performance-pages
+
+  deploy-pages:
+    needs: benchmark-arm64
+    if: github.repository == 'Samsung/escargot'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fixes the shared performance-host lock holder so the PID recorded for cleanup is the actual process holding the lock FD. Also bounds benchmark exclusive-lock waits to 10 minutes, preventing silent multi-hour hangs if a runner is lost.