### PR TITLE
Fix Atomics wait/notify race conditions with per-waiter condition var…

### DIFF
--- a/src/builtins/BuiltinAtomics.cpp
+++ b/src/builtins/BuiltinAtomics.cpp
@@ -470,14 +470,12 @@ static Value doWait(ExecutionState& state, bool isAsync, const Value& typedArray
                 bool notified = true;
                 {
                     std::unique_lock<std::mutex> ul(WL->m_mutex);
-                    bool isExistOnWaiterList = std::find(WL->m_waiterList.begin(), WL->m_waiterList.end(), waiterItem) != WL->m_waiterList.end();
-                    if (isExistOnWaiterList) {
-                        if (t == std::numeric_limits<double>::infinity()) {
-                            WL->m_waiter.wait(ul);
-                        } else {
-                            notified = WL->m_waiter.wait_for(ul, std::chrono::milliseconds((int64_t)t)) == std::cv_status::no_timeout;
-                        }
+                    if (t == std::numeric_limits<double>::infinity()) {
+                        waiterItem->m_conditionVariable.wait(ul, [&] { return waiterItem->m_notified; });
+                    } else {
+                        notified = waiterItem->m_conditionVariable.wait_for(ul, std::chrono::milliseconds((int64_t)t), [&] { return waiterItem->m_notified; });
                     }
+                    WL->m_waiterList.erase(std::remove(WL->m_waiterList.begin(), WL->m_waiterList.end(), waiterItem), WL->m_waiterList.end());
                 }
 
                 {
@@ -493,10 +491,6 @@ static Value doWait(ExecutionState& state, bool isAsync, const Value& typedArray
                         }
                     }
                 }
-                {
-                    std::unique_lock<std::mutex> ul(WL->m_mutex);
-                    WL->m_waiterList.erase(std::remove(WL->m_waiterList.begin(), WL->m_waiterList.end(), waiterItem), WL->m_waiterList.end());
-                }
                 Global::platform()->markJSJobFromAnotherThreadExists(context);
             };
             std::unique_lock<std::mutex> ul(state.context()->vmInstance()->asyncWaiterDataMutex());
@@ -510,14 +504,13 @@ static Value doWait(ExecutionState& state, bool isAsync, const Value& typedArray
         return Value(resultObject.value());
     } else {
         bool notified = true;
-        WL->m_mutex.unlock();
-        std::unique_lock<std::mutex> ul(WL->m_mutex);
+        std::unique_lock<std::mutex> ul(WL->m_mutex, std::adopt_lock);
         auto waiterItem = std::shared_ptr<Global::WaiterItem>(new Global::WaiterItem(state.context(), WL));
         WL->m_waiterList.push_back(waiterItem);
         if (t == std::numeric_limits<double>::infinity()) {
-            WL->m_waiter.wait(ul);
+            waiterItem->m_conditionVariable.wait(ul, [&] { return waiterItem->m_notified; });
         } else {
-            notified = WL->m_waiter.wait_for(ul, std::chrono::milliseconds((int64_t)t)) == std::cv_status::no_timeout;
+            notified = waiterItem->m_conditionVariable.wait_for(ul, std::chrono::milliseconds((int64_t)t), [&] { return waiterItem->m_notified; });
         }
         WL->m_waiterList.erase(std::remove(WL->m_waiterList.begin(), WL->m_waiterList.end(), waiterItem), WL->m_waiterList.end());
         if (notified) {
@@ -578,9 +571,10 @@ static Value builtinAtomicsNotify(ExecutionState& state, Value thisValue, size_t
     //     c. Perform NotifyWaiter(WL, W).
     //     d. Set n to n + 1.
     for (n = 0; n < count; n++) {
-        const auto& f = WL->m_waiterList.front();
-        f->m_waiter->m_waiter.notify_one();
+        auto f = WL->m_waiterList.front();
         WL->m_waiterList.erase(WL->m_waiterList.begin());
+        f->m_notified = true;
+        f->m_conditionVariable.notify_one();
     }
     // 13. Perform LeaveCriticalSection(WL).
     WL->m_mutex.unlock();

--- a/src/runtime/Global.cpp
+++ b/src/runtime/Global.cpp
@@ -113,7 +113,10 @@ void Global::finalize()
 
 #if defined(ENABLE_THREADING)
     for (size_t i = 0; i < g_waiter.size(); i++) {
-        g_waiter[i]->m_waiter.notify_all();
+        for (auto& waiterItem : g_waiter[i]->m_waiterList) {
+            waiterItem->m_notified = true;
+            waiterItem->m_conditionVariable.notify_one();
+        }
         delete g_waiter[i];
     }
     std::vector<Waiter*>().swap(g_waiter);

--- a/src/runtime/Global.h
+++ b/src/runtime/Global.h
@@ -72,18 +72,20 @@ public:
             : m_context(context)
             , m_waiter(waiter)
             , m_promise(promise)
+            , m_notified(false)
         {
         }
 
         Context* m_context;
         Waiter* m_waiter;
         Optional<Object*> m_promise;
+        std::condition_variable m_conditionVariable;
+        bool m_notified;
     };
 
     struct Waiter {
         void* m_blockAddress;
         std::mutex m_mutex;
-        std::condition_variable m_waiter;
         std::vector<std::shared_ptr<WaiterItem>> m_waiterList;
     };
 


### PR DESCRIPTION
…iables

* Instead of sharing a single condition_variable per Waiter list (which led to potential thundering herds and spurious wakeup issues), assign a condition_variable and an explicit m_notified flag to each individual WaiterItem.